### PR TITLE
feat(app): sort groups before onboarding a new client

### DIFF
--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -540,6 +540,7 @@ impl CoreUser {
                 let key_material = Group::load_all_key_material(&mut *txn).await?;
                 let mut groups = Vec::new();
 
+                let mut chats = Vec::new();
                 for group in key_material {
                     let Ok(chat_id) = ChatId::try_from(&group.group_id) else {
                         warn!(group_id = ?group.group_id, "group id is not a chat id; skipping group");
@@ -552,6 +553,14 @@ impl CoreUser {
                         debug!(group_id = ?group.group_id, "skipping non-active chat");
                         continue;
                     }
+                    chats.push((group, chat));
+                }
+
+                // Sort chats in descending order by last message date, to try  to onboard them 
+                // in the same order they were presented on the original client at link time.
+                chats.sort_unstable_by(|(_, a), (_, b)| b.last_message_at.cmp(&a.last_message_at));
+
+                for (group, chat) in chats {
                     let connection = match chat.chat_type() {
                         ChatType::Group(_) => None,
                         ChatType::Connection(user_id) => {

--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -556,9 +556,12 @@ impl CoreUser {
                     chats.push((group, chat));
                 }
 
-                // Sort chats in descending order by last message date, to try  to onboard them 
-                // in the same order they were presented on the original client at link time.
-                chats.sort_unstable_by(|(_, a), (_, b)| b.last_message_at.cmp(&a.last_message_at));
+                // Sort chats in ascending order by last message date: this determines onboarding
+                // order by the resync queue.
+                //
+                // Since a system message is inserted after each onboarding, the presented list
+                // should look similar to the one in the original device.
+                chats.sort_unstable_by_key(|(_, chat)| chat.last_message_at);
 
                 for (group, chat) in chats {
                     let connection = match chat.chat_type() {


### PR DESCRIPTION
This will make the order of chats in the new client similar to the one on the original one.