### PR TITLE
fix(ci): pin goldens to UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
         uses: ./.github/actions/setup-buildenv
 
       - name: Flutter tests
+        # TZ is pinned because goldens depict clock labels in the host's zone.
+        env:
+          TZ: UTC
         run: cd app && flutter test --file-reporter=json:test-results.json
 
       - name: Test report

--- a/app/test/flutter_test_config.dart
+++ b/app/test/flutter_test_config.dart
@@ -26,6 +26,7 @@ const pixel8DevicePixelRatio = 2.625;
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   setUpAll(() async {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    _checkTimeZoneIsUtc();
     _mockSystemDateTimeFormatChannel(binding);
     await _loadFonts();
     _setGoldenFileComparatorWithThreshold(goldenThreshold);
@@ -115,6 +116,21 @@ List<String> get _systemUiFontPaths => <String>[
     '/System/Library/Fonts/SFNSDisplay.ttf',
   ],
 ];
+
+/// Fails unless the host runs in UTC.
+///
+/// This makes sure that the goldens are recorded in UTC (this what CI does).
+/// Otherwise, goldens recorded locally and in CI differ (most of the time only
+/// slightly).
+void _checkTimeZoneIsUtc() {
+  if (DateTime.now().timeZoneOffset == Duration.zero) return;
+
+  throw StateError(
+    'Golden tests need the host in UTC, but it reports an offset of '
+    '${DateTime.now().timeZoneOffset}. Run the tests through '
+    '`just test-flutter` / `just update-goldens`, or set TZ=UTC yourself.',
+  );
+}
 
 void _setGoldenFileComparatorWithThreshold(double threshold) {
   assert(goldenFileComparator is LocalFileComparator);

--- a/justfile
+++ b/justfile
@@ -164,8 +164,9 @@ _generate-db-certs:
 # Use the current test results as new reference images.
 [working-directory: 'app']
 update-goldens:
-    # Delete existing goldens
-    rm -f **/goldens/*.{{ os() }}.png
+    # Delete existing goldens, so that the ones whose test is gone do not
+    # linger.
+    git ls-files -z 'test/**/goldens/*.{{ os() }}.png' | xargs -0 rm -f
     # Update golden snapshots
     TZ=UTC just flutter test --update-goldens
 

--- a/justfile
+++ b/justfile
@@ -134,8 +134,12 @@ regenerate-icons:
     just dart run tool/compile_svg_icons.dart
 
 # Run flutter test.
+#
+# TZ is pinned because goldens depict clock labels in the host's zone, so an
+# offset host rewrites every golden that shows a timestamp.
 [working-directory: 'app']
-test-flutter: (flutter "test")
+test-flutter:
+    TZ=UTC just flutter test
 
 docker-is-podman := if `command -v podman || true` =~ ".*podman$" { "true" } else { "false" }
 skip_docker := env_var_or_default("SKIP_DOCKER_COMPOSE", "false")
@@ -163,7 +167,7 @@ update-goldens:
     # Delete existing goldens
     rm -f **/goldens/*.{{ os() }}.png
     # Update golden snapshots
-    just flutter test --update-goldens
+    TZ=UTC just flutter test --update-goldens
 
 # Trigger the "Update Goldens" workflow on the current branch, or a given PR.
 [script]

--- a/justfile
+++ b/justfile
@@ -134,9 +134,6 @@ regenerate-icons:
     just dart run tool/compile_svg_icons.dart
 
 # Run flutter test.
-#
-# TZ is pinned because goldens depict clock labels in the host's zone, so an
-# offset host rewrites every golden that shows a timestamp.
 [working-directory: 'app']
 test-flutter:
     TZ=UTC just flutter test


### PR DESCRIPTION
Most likely this is what was responsible for the jitter in the goldens.

Also fix deletion of goldens before re-generation: sh does not expand * properly.