### PR TITLE
fix(app): re-introduce double and triple tap for messages on mobile

### DIFF
--- a/app/lib/features/message_list/message_text_selection.dart
+++ b/app/lib/features/message_list/message_text_selection.dart
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async' show scheduleMicrotask;
+
+import 'package:air/features/message_list/swipe_to_reply.dart';
+import 'package:flutter/cupertino.dart'
+    show cupertinoTextSelectionHandleControls;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// The devices the region hands its touch gestures to, and so the ones the
+/// gestures taken from it have to cover.
+const Set<PointerDeviceKind> _touchDevices = {
+  PointerDeviceKind.touch,
+  PointerDeviceKind.stylus,
+  PointerDeviceKind.invertedStylus,
+};
+
+/// How the text inside a message bubble can be selected.
+enum MessageSelection {
+  /// Not selectable: the copy of a bubble shown inside an overlay, and the
+  /// placeholders that stand in for a message rather than carry its text.
+  off,
+
+  /// Mouse selection: click and drag, double-click a word, triple-click the
+  /// message. The toolbar and handles stay off, the right-click menu offers
+  /// the copy.
+  pointer,
+
+  /// Touch selection: double-tap a word, triple-tap the message, then the
+  /// platform's own handles and toolbar. See [TouchSelectableText].
+  touch,
+}
+
+/// Message text a finger can select, without taking the gestures the bubble
+/// already carries.
+///
+/// [SelectableRegion] alone doesn't do on touch what the bubble needs:
+///
+///  * it claims a long press for its own word selection, where the message
+///    actions have to open instead, and
+///  * it caps a touch series below the third tap (Flutter only selects a
+///    paragraph on a triple tap from a precise pointer), leaving no way to take
+///    the whole message.
+///
+/// So the long press is taken here, ahead of the region, and the third tap
+/// selects everything the region holds -- which is exactly one message. The
+/// horizontal drag the region claims for its own selection (and then drops,
+/// since it only drags a selection under a precise pointer) goes back to
+/// swipe-to-reply the same way.
+class TouchSelectableText extends StatefulWidget {
+  const TouchSelectableText({
+    super.key,
+    required this.onLongPress,
+    required this.child,
+  });
+
+  /// Opens the message actions, in place of the region's word selection.
+  ///
+  /// Registering no callback hands the long press back to the region.
+  final VoidCallback? onLongPress;
+
+  final Widget child;
+
+  @override
+  State<TouchSelectableText> createState() => _TouchSelectableTextState();
+}
+
+class _TouchSelectableTextState extends State<TouchSelectableText> {
+  final GlobalKey<SelectableRegionState> _regionKey = GlobalKey();
+
+  /// Taps of the series in progress, and the down that started the last one.
+  /// Taken from the raw pointer stream rather than from a recognizer, so the
+  /// region keeps seeing the first two taps and selects the word itself.
+  int _tapCount = 0;
+  PointerDownEvent? _lastTapDown;
+
+  void _handlePointerDown(PointerDownEvent event) {
+    final last = _lastTapDown;
+    final continues =
+        last != null &&
+        event.timeStamp - last.timeStamp <= kDoubleTapTimeout &&
+        (event.position - last.position).distance <= kDoubleTapSlop;
+    _tapCount = continues ? _tapCount + 1 : 1;
+    _lastTapDown = event;
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    final down = _lastTapDown;
+    // A drag ends the series rather than continuing it.
+    if (down != null &&
+        (event.position - down.position).distance > kTouchSlop) {
+      _tapCount = 0;
+      _lastTapDown = null;
+      return;
+    }
+    if (_tapCount != 3) return;
+    // The region handles this tap first -- on Android its series has already
+    // wrapped around to a single tap, which collapses what the double tap
+    // selected -- so the message-wide selection only holds once the event is
+    // through.
+    scheduleMicrotask(_selectMessage);
+  }
+
+  void _handlePointerCancel(PointerCancelEvent event) {
+    _tapCount = 0;
+    _lastTapDown = null;
+  }
+
+  void _selectMessage() {
+    // The cause the region takes as "raise the handles and the toolbar".
+    _regionKey.currentState?.selectAll(SelectionChangedCause.toolbar);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final swipe = SwipeToReplyScope.maybeOf(context);
+    return SelectableRegion(
+      key: _regionKey,
+      selectionControls: switch (Theme.of(context).platform) {
+        TargetPlatform.iOS => cupertinoTextSelectionHandleControls,
+        _ => materialTextSelectionHandleControls,
+      },
+      contextMenuBuilder: (context, state) =>
+          AdaptiveTextSelectionToolbar.selectableRegion(
+            selectableRegionState: state,
+          ),
+      magnifierConfiguration: TextMagnifier.adaptiveMagnifierConfiguration,
+      child: Listener(
+        onPointerDown: _handlePointerDown,
+        onPointerUp: _handlePointerUp,
+        onPointerCancel: _handlePointerCancel,
+        // Sits under the region's own detector, so it enters the gesture arena
+        // first and its long press resolves ahead of the region's.
+        child: RawGestureDetector(
+          behavior: HitTestBehavior.translucent,
+          excludeFromSemantics: true,
+          gestures: {
+            LongPressGestureRecognizer:
+                GestureRecognizerFactoryWithHandlers<
+                  LongPressGestureRecognizer
+                >(
+                  () => LongPressGestureRecognizer(
+                    debugOwner: this,
+                    supportedDevices: _touchDevices,
+                  ),
+                  (instance) => instance.onLongPress = widget.onLongPress,
+                ),
+            if (swipe != null)
+              HorizontalDragGestureRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                    HorizontalDragGestureRecognizer
+                  >(
+                    () => HorizontalDragGestureRecognizer(
+                      debugOwner: this,
+                      supportedDevices: _touchDevices,
+                    ),
+                    (instance) => instance
+                      ..onStart = swipe.dragStart
+                      ..onUpdate = swipe.dragUpdate
+                      ..onEnd = swipe.dragEnd
+                      ..onCancel = swipe.dragCancel,
+                  ),
+          },
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/message_list/swipe_to_reply.dart
+++ b/app/lib/features/message_list/swipe_to_reply.dart
@@ -27,6 +27,19 @@ const double _iconPadding = 12.0;
 const double _springStiffness = 400.0;
 const double _springDamping = 28.0;
 
+/// Drives the swipe from a gesture recognized somewhere below the scope.
+///
+/// A drag that starts on selectable message text never reaches the scope's own
+/// detector -- the [SelectableRegion] around the text claims horizontal drags
+/// from inside the bubble -- so the text recognizes the drag itself and hands
+/// it over here.
+abstract class SwipeToReplyDrag {
+  void dragStart(DragStartDetails details);
+  void dragUpdate(DragUpdateDetails details);
+  void dragEnd(DragEndDetails details);
+  void dragCancel();
+}
+
 /// Gesture area for swipe-to-reply.
 ///
 /// Place this high in the widget tree to define the hit-test area for the
@@ -51,6 +64,10 @@ class SwipeToReplyScope extends StatefulWidget {
 
   final Widget child;
 
+  /// The scope a descendant can hand a drag of its own to, if there is one.
+  static SwipeToReplyDrag? maybeOf(BuildContext context) =>
+      context.getInheritedWidgetOfExactType<_SwipeToReplyInherited>()?.state;
+
   @override
   State<SwipeToReplyScope> createState() => _SwipeToReplyScopeState();
 }
@@ -59,7 +76,8 @@ class SwipeToReplyScope extends StatefulWidget {
 enum _DragIntent { undecided, reply, revealTime }
 
 class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin
+    implements SwipeToReplyDrag {
   late final AnimationController _controller;
 
   /// Raw accumulated drag distance (before damping).
@@ -103,7 +121,8 @@ class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
     return min(_triggerThreshold + overshoot * _rubberBandFactor, _maxOffset);
   }
 
-  void _onDragStart(DragStartDetails details) {
+  @override
+  void dragStart(DragStartDetails details) {
     // Ignore new drags while the spring-back animation is running to
     // prevent double-firing onReply on rapid re-swipes.
     if (_controller.isAnimating) return;
@@ -114,7 +133,8 @@ class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
     _controller.stop();
   }
 
-  void _onDragUpdate(DragUpdateDetails details) {
+  @override
+  void dragUpdate(DragUpdateDetails details) {
     if (!isDragging) return;
     final reveal = _timeReveal;
     if (_intent == _DragIntent.undecided && details.delta.dx != 0) {
@@ -142,7 +162,8 @@ class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
     }
   }
 
-  void _onDragEnd(DragEndDetails details) {
+  @override
+  void dragEnd(DragEndDetails details) {
     if (!isDragging) return;
     isDragging = false;
     if (_release()) return;
@@ -152,7 +173,8 @@ class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
     _springBack();
   }
 
-  void _onDragCancel() {
+  @override
+  void dragCancel() {
     if (!isDragging) return;
     isDragging = false;
     if (_release()) return;
@@ -189,10 +211,10 @@ class _SwipeToReplyScopeState extends State<SwipeToReplyScope>
       state: this,
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onHorizontalDragStart: _onDragStart,
-        onHorizontalDragUpdate: _onDragUpdate,
-        onHorizontalDragEnd: _onDragEnd,
-        onHorizontalDragCancel: _onDragCancel,
+        onHorizontalDragStart: dragStart,
+        onHorizontalDragUpdate: dragUpdate,
+        onHorizontalDragEnd: dragEnd,
+        onHorizontalDragCancel: dragCancel,
         child: widget.child,
       ),
     );

--- a/app/lib/features/message_list/text_message_tile.dart
+++ b/app/lib/features/message_list/text_message_tile.dart
@@ -34,6 +34,7 @@ import 'package:air/features/message_list/message_list_cubit.dart';
 import 'package:air/features/message_list/message_reactions.dart';
 import 'package:air/features/message_list/message_renderer.dart';
 import 'package:air/features/message_list/message_hover_time.dart';
+import 'package:air/features/message_list/message_text_selection.dart';
 import 'package:air/features/message_list/mobile_message_actions.dart';
 import 'package:air/features/message_list/swipe_to_reply.dart';
 import 'package:air/features/message_list/time_reveal.dart';
@@ -459,11 +460,12 @@ class _MessageShell extends StatelessWidget {
                 actions: actions,
                 overlayContent: _content(
                   bubbleMaxWidth: bubbleMaxWidth,
-                  enableSelection: false,
+                  selection: MessageSelection.off,
                 ),
               ),
         onSecondaryTapDown: null,
-        enableSelection: false,
+        selection: MessageSelection.touch,
+        swipeToReply: isReplyable,
         detached: isDetached.value,
       ),
     );
@@ -488,7 +490,10 @@ class _MessageShell extends StatelessWidget {
           onSecondaryTapDown: actions.isEmpty
               ? null
               : (details) => _openContextMenu(context, details, actions),
-          enableSelection: isDesktopPlatform,
+          selection: isDesktopPlatform
+              ? MessageSelection.pointer
+              : MessageSelection.off,
+          swipeToReply: false,
           detached: false,
           affordance: _withHoverActions ? _hoverActions(context) : null,
         ),
@@ -523,7 +528,8 @@ class _MessageShell extends StatelessWidget {
 
   Widget _content({
     required double bubbleMaxWidth,
-    required bool enableSelection,
+    required MessageSelection selection,
+    VoidCallback? onLongPress,
   }) => _MessageContent(
     messageId: commands.messageId,
     content: contentMessage.content,
@@ -531,7 +537,8 @@ class _MessageShell extends StatelessWidget {
     isSender: isSender,
     senderId: contentMessage.sender,
     isHidden: isHidden,
-    enableSelection: enableSelection,
+    selection: selection,
+    onLongPress: onLongPress,
     maxWidth: bubbleMaxWidth,
   );
 
@@ -542,7 +549,8 @@ class _MessageShell extends StatelessWidget {
     required double bubbleMaxWidth,
     required VoidCallback? onLongPress,
     required GestureTapDownCallback? onSecondaryTapDown,
-    required bool enableSelection,
+    required MessageSelection selection,
+    required bool swipeToReply,
     required bool detached,
     Widget? affordance,
   }) {
@@ -550,10 +558,13 @@ class _MessageShell extends StatelessWidget {
       key: commands.bubbleKey,
       child: _content(
         bubbleMaxWidth: bubbleMaxWidth,
-        enableSelection: enableSelection,
+        selection: selection,
+        // A touch selection region takes the long press for itself unless the
+        // message actions claim it from inside. See [TouchSelectableText].
+        onLongPress: onLongPress,
       ),
     );
-    if (!enableSelection && isReplyable) {
+    if (swipeToReply) {
       bubble = SwipeToReplyBubble(
         icon: AppIcon.cornerLeft(
           size: S.s16,
@@ -595,15 +606,9 @@ class _MessageShell extends StatelessWidget {
             child: GestureDetector(
               behavior: HitTestBehavior.deferToChild,
               onTap: isHidden ? () => isRevealed.value = true : null,
-              // Mobile: double-tap a message to react. On desktop, the
-              // recognizer must not be registered at all, otherwise it wins the
-              // gesture arena and blocks double-click text selection.
-              onDoubleTap: isMobilePlatform && isReplyable
-                  ? () {
-                      AppHaptics.confirm();
-                      commands.openReactionMenu();
-                    }
-                  : null,
+              // No double-tap recognizer on either platform: it wins the
+              // gesture arena and blocks selecting a word by double
+              // click/tap. Reacting goes through the long press instead.
               onLongPress: onLongPress,
               child: bubble,
             ),
@@ -798,7 +803,7 @@ class _MessageCommands {
 
   /// Anchors the bar to whatever raised it so it opens centered above it: the
   /// hover react button, else the right-click point, else the bubble as a last
-  /// resort (a mobile double-tap raises no anchor of its own).
+  /// resort.
   void openReactionMenu({GlobalKey? anchor}) {
     final cursor = cursorPosition.value;
     final anchorRect =
@@ -947,7 +952,8 @@ class _MessageContent extends StatelessWidget {
     required this.isSender,
     required this.senderId,
     required this.isHidden,
-    required this.enableSelection,
+    required this.selection,
+    required this.onLongPress,
     required this.maxWidth,
   });
 
@@ -957,7 +963,11 @@ class _MessageContent extends StatelessWidget {
   final bool isSender;
   final UiUserId senderId;
   final bool isHidden;
-  final bool enableSelection;
+  final MessageSelection selection;
+
+  /// Opens the message actions. Only [MessageSelection.touch] takes it, where
+  /// the selection region would otherwise claim the long press.
+  final VoidCallback? onLongPress;
 
   /// Widest the bubble may get. Applied to the content rather than to the
   /// bubble, so the bubble hugs what it carries and the reaction chips and
@@ -1089,9 +1099,13 @@ class _MessageContent extends StatelessWidget {
         child: Text(text, style: MessageText.placeholderStyleOf(context)),
       );
 
-  Widget _selectable(Widget child) {
-    if (!enableSelection) return SelectionContainer.disabled(child: child);
-    return RawGestureDetector(
+  Widget _selectable(Widget child) => switch (selection) {
+    MessageSelection.off => SelectionContainer.disabled(child: child),
+    MessageSelection.touch => TouchSelectableText(
+      onLongPress: onLongPress,
+      child: child,
+    ),
+    MessageSelection.pointer => RawGestureDetector(
       // Prevents SelectableRegion from selecting words on right-click.
       gestures: {
         _EagerSecondaryClickRecognizer:
@@ -1104,8 +1118,8 @@ class _MessageContent extends StatelessWidget {
         contextMenuBuilder: (context, _) => const SizedBox.shrink(),
         child: child,
       ),
-    );
-  }
+    ),
+  };
 
   String _deletedBy(BuildContext context, AppLocalizations loc) {
     if (isSender) return loc.textMessage_deletedBySelf;

--- a/app/test/features/message_list/message_text_selection_test.dart
+++ b/app/test/features/message_list/message_text_selection_test.dart
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:air/core/core.dart';
+import 'package:air/ds/patterns/reaction_bar/reaction_bar.dart';
+import 'package:air/features/chat/chat_details_cubit.dart';
+import 'package:air/features/message_list/message_cubit.dart';
+import 'package:air/features/message_list/message_list_cubit.dart';
+import 'package:air/features/message_list/message_list_view.dart';
+import 'package:air/features/user/user_cubit.dart';
+import 'package:air/features/user/user_settings_cubit.dart';
+import 'package:air/features/user/users_cubit.dart';
+import 'package:air/l10n/l10n.dart';
+import 'package:flutter/gestures.dart' show kDoubleTapMinTime;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../chat_list/chat_list_content_test.dart';
+import '../../helpers.dart';
+import '../../mocks.dart';
+
+const Size _testSize = Size(1080, 2800);
+
+const String _messageText = 'Hello Alice';
+
+final _chatId = 1.chatId();
+
+final _messages = [
+  UiChatMessage(
+    id: 1.messageId(),
+    chatId: _chatId,
+    timestamp: DateTime.parse('2023-01-01T00:00:00.000Z'),
+    message: UiMessage_Content(
+      UiContentMessage(
+        sender: 2.userId(),
+        sent: true,
+        edited: false,
+        content: UiMimiContent(
+          plainBody: _messageText,
+          topicId: Uint8List(0),
+          content: simpleMessage(_messageText),
+          attachments: [],
+        ),
+      ),
+    ),
+    status: UiMessageStatus.sent,
+    reactions: [],
+  ),
+];
+
+MessageCubit _createMockMessageCubit({
+  required UserCubit userCubit,
+  required MessageState initialState,
+}) => MockMessageCubit(initialState: initialState);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(0.messageId());
+    registerFallbackValue(0.userId());
+  });
+
+  group('Message text selection on touch', () {
+    late MockUserCubit userCubit;
+    late MockUsersCubit contactsCubit;
+    late MockChatDetailsCubit chatDetailsCubit;
+    late MockMessageListCubit messageListCubit;
+    late MockAttachmentsRepository attachmentsRepository;
+    late MockUserSettingsCubit userSettingsCubit;
+    late List<String> copied;
+
+    setUp(() {
+      userCubit = MockUserCubit();
+      contactsCubit = MockUsersCubit();
+      chatDetailsCubit = MockChatDetailsCubit();
+      messageListCubit = MockMessageListCubit();
+      attachmentsRepository = MockAttachmentsRepository();
+      userSettingsCubit = MockUserSettingsCubit();
+      copied = [];
+
+      when(() => userCubit.state).thenReturn(MockUiUser(id: 1));
+      when(
+        () => contactsCubit.state,
+      ).thenReturn(MockUsersState(profiles: userProfiles));
+      when(
+        () => chatDetailsCubit.markAsRead(
+          untilMessageId: any(named: 'untilMessageId'),
+          untilTimestamp: any(named: 'untilTimestamp'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () =>
+            chatDetailsCubit.replyToMessage(messageId: any(named: 'messageId')),
+      ).thenAnswer((_) async {});
+      when(() => userSettingsCubit.state).thenReturn(const UserSettings());
+      messageListCubit.setState(_messages);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              copied.add((call.arguments as Map)['text'] as String);
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    Widget buildSubject() => RepositoryProvider<AttachmentsRepository>.value(
+      value: attachmentsRepository,
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider<UserCubit>.value(value: userCubit),
+          BlocProvider<UsersCubit>.value(value: contactsCubit),
+          BlocProvider<ChatDetailsCubit>.value(value: chatDetailsCubit),
+          BlocProvider<MessageListCubit>.value(value: messageListCubit),
+          BlocProvider<UserSettingsCubit>.value(value: userSettingsCubit),
+        ],
+        child: Builder(
+          builder: (context) {
+            final theme = testThemeData(
+              MediaQuery.platformBrightnessOf(context),
+            ).copyWith(platform: TargetPlatform.android);
+            return MaterialApp(
+              debugShowCheckedModeBanner: false,
+              theme: theme,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              home: const Scaffold(
+                body: MessageListView(
+                  createMessageCubit: _createMockMessageCubit,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    Future<void> pumpList(WidgetTester tester) async {
+      tester.view.physicalSize = _testSize;
+      addTearDown(tester.view.resetPhysicalSize);
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+    }
+
+    /// Taps [count] times in a row on [position], close enough in time to form
+    /// one series.
+    Future<void> tapSeries(
+      WidgetTester tester,
+      Offset position, {
+      required int count,
+    }) async {
+      for (var i = 0; i < count; i++) {
+        if (i > 0) await tester.pump(kDoubleTapMinTime);
+        await tester.tapAt(position);
+      }
+      await tester.pumpAndSettle();
+    }
+
+    /// What the selection holds, taken through the toolbar's own copy.
+    Future<String?> copySelection(WidgetTester tester) async {
+      final copy = find.descendant(
+        of: find.byType(AdaptiveTextSelectionToolbar),
+        matching: find.text('Copy'),
+      );
+      if (copy.evaluate().isEmpty) return null;
+      await tester.tap(copy);
+      await tester.pumpAndSettle();
+      return copied.isEmpty ? null : copied.last;
+    }
+
+    /// Left of the first word, past the bubble's own padding.
+    Offset firstWord(WidgetTester tester) {
+      final text = tester.getRect(find.text(_messageText));
+      return Offset(text.left + 4, text.center.dy);
+    }
+
+    testWidgets('double tap selects the word under the finger', (tester) async {
+      await pumpList(tester);
+
+      await tapSeries(tester, firstWord(tester), count: 2);
+
+      expect(await copySelection(tester), 'Hello');
+      // The quick reactions used to sit on the double tap, where they took the
+      // gesture away from the word selection.
+      expect(find.byType(ReactionBar), findsNothing);
+    });
+
+    testWidgets('triple tap selects the whole message', (tester) async {
+      await pumpList(tester);
+
+      await tapSeries(tester, firstWord(tester), count: 3);
+
+      expect(await copySelection(tester), _messageText);
+    });
+
+    testWidgets('long press opens the message actions, not a selection', (
+      tester,
+    ) async {
+      await pumpList(tester);
+
+      await tester.longPressAt(firstWord(tester));
+      await tester.pumpAndSettle();
+
+      final loc = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(loc.messageContextMenu_reply), findsOneWidget);
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+    });
+
+    testWidgets('a swipe on the text still replies', (tester) async {
+      await pumpList(tester);
+
+      await tester.drag(find.text(_messageText), const Offset(80, 0));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => chatDetailsCubit.replyToMessage(messageId: 1.messageId()),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION
- The PR #801 introduced a better `SelectionArea` that was only enabled on desktop
- The reaction menu from PR #1324 then claims all taps on message bubbles

Unfortunately, removing `onDoubleTap` and flipping `enableSelection` to true on mobile is not enough on its own. We need a new widget that handles: long press and third tap (on Android, this is capped at two with the stock widgets).