### PR TITLE
fix(app): self-heal self-group chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5224,7 +5224,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5268,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "aes",
  "fpe",
@@ -5291,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "hex",
  "log",
@@ -5304,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "openmls_serialization_helpers"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5343,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=17a17446f03715e61759febdca3792fc936df428#17a17446f03715e61759febdca3792fc936df428"
+source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5224,7 +5224,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5268,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "aes",
  "fpe",
@@ -5291,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "hex",
  "log",
@@ -5304,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "openmls_serialization_helpers"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5343,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/gferon/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,12 @@ minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 num_enum = "0.7"
-openmls = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["clonable"] }
-openmls_memory_storage = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_rust_crypto = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_sqlite_storage = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["clonable"] }
+openmls_memory_storage = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_rust_crypto = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_sqlite_storage = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,12 @@ minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 num_enum = "0.7"
-openmls = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["clonable"] }
-openmls_memory_storage = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_sqlite_storage = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { git = "https://github.com/openmls/openmls", rev = "17a17446f03715e61759febdca3792fc936df428", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["clonable"] }
+openmls_memory_storage = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_rust_crypto = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_sqlite_storage = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/gferon/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"

--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -472,7 +472,7 @@ impl CoreUser {
         let api_client = self.api_client()?;
         let qs_user_id = self.inner.qs_user_id;
 
-        let self_group = self.ensure_self_group().await?;
+        let self_group = Box::pin(self.ensure_self_group()).await?;
         let self_group_id = self_group.group_id().clone();
         let identity_link_wrapper_key = self_group.identity_link_wrapper_key().clone();
 

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -36,7 +36,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
-    Chat,
+    Chat, ChatId,
     chats::{ChatAttributes, GroupDataExt},
     clients::{CoreUser, own_client_info::OwnClientInfo},
     db::access::{ReadConnection, WriteConnection, WriteDbTransaction},
@@ -236,12 +236,42 @@ impl SelfGroup {
 
 impl CoreUser {
     pub async fn ensure_self_group(&self) -> anyhow::Result<SelfGroup> {
-        if let Some(group) = SelfGroup::load(self.db().read().await?).await? {
-            return Ok(group);
+        let self_group = match SelfGroup::load(self.db().read().await?).await? {
+            Some(self_group) => self_group,
+            None => SelfGroup {
+                group: self.create_self_group().await?,
+            },
+        };
+        self.ensure_self_chat(self_group.group_id()).await?;
+        Ok(self_group)
+    }
+
+    /// Creates the "Notes to self" chat of the self group if it is missing, so
+    /// the group shows in the UI.
+    ///
+    /// Clients whose self group predates that chat only have the group, so
+    /// their self chat has to be backfilled here.
+    async fn ensure_self_chat(&self, group_id: &GroupId) -> anyhow::Result<()> {
+        if ChatId::load_from_group_id(self.db().read().await?, group_id)
+            .await?
+            .is_some()
+        {
+            return Ok(());
         }
 
-        let group = self.create_self_group().await?;
-        Ok(SelfGroup { group })
+        let chat = Chat::new_group_chat(
+            group_id.clone(),
+            ChatAttributes {
+                title: SELF_CHAT_TITLE.to_owned(),
+                picture: None,
+            },
+        );
+        self.db()
+            .with_write_transaction(async |txn| chat.store(&mut *txn).await)
+            .await?;
+        debug!("Created the missing self chat");
+
+        Ok(())
     }
 
     async fn create_self_group(&self) -> anyhow::Result<Group> {
@@ -256,12 +286,8 @@ impl CoreUser {
         let pq_group_id = pq_group_id.context("Missing PQ group ID")?;
 
         let identity_link_wrapper_key = IdentityLinkWrapperKey::random()?;
-        let chat_attributes = ChatAttributes {
-            title: SELF_CHAT_TITLE.to_owned(),
-            picture: None,
-        };
         let encrypted_title =
-            EncryptedGroupTitle::encrypt(&chat_attributes.title, &identity_link_wrapper_key)
+            EncryptedGroupTitle::encrypt(SELF_CHAT_TITLE, &identity_link_wrapper_key)
                 .context("Failed to encrypt self-group title")?;
         let group_data_bytes = GroupData {
             legacy_title: None,
@@ -302,10 +328,6 @@ impl CoreUser {
 
                 group.store(&mut *txn).await?;
 
-                // Create the "Notes to self" chat so the self group shows in the UI.
-                let chat = Chat::new_group_chat(group.group_id().clone(), chat_attributes);
-                chat.store(&mut *txn).await?;
-
                 Ok((group, partial_params, user_profile_key))
             })
             .await?;
@@ -326,9 +348,6 @@ impl CoreUser {
             self.db()
                 .with_write_transaction(async |txn| -> anyhow::Result<()> {
                     Group::delete_from_db(&mut *txn, group.group_id()).await?;
-                    if let Ok(chat_id) = crate::ChatId::try_from(group.group_id()) {
-                        Chat::delete(txn, chat_id).await?;
-                    }
                     Ok(())
                 })
                 .await?;

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -252,24 +252,28 @@ impl CoreUser {
     /// Clients whose self group predates that chat only have the group, so
     /// their self chat has to be backfilled here.
     async fn ensure_self_chat(&self, group_id: &GroupId) -> anyhow::Result<()> {
-        if ChatId::load_from_group_id(self.db().read().await?, group_id)
-            .await?
-            .is_some()
-        {
-            return Ok(());
-        }
-
-        let chat = Chat::new_group_chat(
-            group_id.clone(),
-            ChatAttributes {
-                title: SELF_CHAT_TITLE.to_owned(),
-                picture: None,
-            },
-        );
         self.db()
-            .with_write_transaction(async |txn| chat.store(&mut *txn).await)
+            .with_write_transaction(async |txn| -> sqlx::Result<()> {
+                if ChatId::load_from_group_id(&mut *txn, group_id)
+                    .await?
+                    .is_some()
+                {
+                    return Ok(());
+                }
+
+                let chat = Chat::new_group_chat(
+                    group_id.clone(),
+                    ChatAttributes {
+                        title: SELF_CHAT_TITLE.to_owned(),
+                        picture: None,
+                    },
+                );
+                chat.store(&mut *txn).await?;
+                debug!("Created the missing self chat");
+
+                Ok(())
+            })
             .await?;
-        debug!("Created the missing self chat");
 
         Ok(())
     }

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,8 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     # unreleased post-quantum and virtual-clients features of openmls after the 0.8.1 release
     "https://github.com/openmls/openmls",
+    # temporary fork of openmls
+    "https://github.com/gferon/openmls",
     "https://github.com/RustCrypto/RSA",
     # includes an unreleased patch of ml-dsa
     "https://github.com/RustCrypto/signatures",


### PR DESCRIPTION
There are many testers whose self group was created before the APQ ciphersuite was renamed, so we need to apply an alias from `AIR_128_MLKEM768_AES256GCM_SHA384_Ed25519` to `MLS_128_MLKEM768_AES256GCM_SHA384_Ed25519`.

Another issue is that on some device, the self-group only exists as an MLS group, but not as a visible chat in the chat list. This is also done here and will be surfaced as "Notes to self".