### PR TITLE
perf(CI): filter runs of Android, iOS, macOS and Windows CI jobs in PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,6 +11,17 @@ concurrency:
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "app/android/**"
+      - "app/fastlane/android.rb"
+      - "app/rust_builder/android/**"
+      - "app/.fvmrc"
+      - "app/pubspec.yaml"
+      - "app/pubspec.lock"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/android.yml"
+      - ".github/actions/setup-buildenv/**"
   push:
     branches:
       - main

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,15 +11,31 @@ concurrency:
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "app/ios/**"
+      - "app/fastlane/apple.rb"
+      - "app/fastlane/ios.rb"
+      - "app/rust_builder/ios/**"
+      - "app/.fvmrc"
+      - "app/pubspec.yaml"
+      - "app/pubspec.lock"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/ios.yml"
+      - ".github/actions/setup-buildenv/**"
   push:
     branches:
       - main
     paths:
-      - "coreclient/**"
       - "apiclient/**"
-      - "applogic/**"
-      - "common/**"
       - "app/**"
+      - "applogic/**"
+      - "apqmls/**"
+      - "common/**"
+      - "coreclient/**"
+      - "macros/**"
+      - "mls-assist/**"
+      - "protos/**"
       - "Cargo.toml"
       - "Cargo.lock"
   merge_group:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-name: Build macOS app
+name: Build app
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,15 +11,31 @@ concurrency:
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "app/macos/**"
+      - "app/fastlane/apple.rb"
+      - "app/fastlane/macos.rb"
+      - "app/rust_builder/macos/**"
+      - "app/.fvmrc"
+      - "app/pubspec.yaml"
+      - "app/pubspec.lock"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/macos.yml"
+      - ".github/actions/setup-buildenv/**"
   push:
     branches:
       - main
     paths:
-      - "coreclient/**"
       - "apiclient/**"
-      - "applogic/**"
-      - "common/**"
       - "app/**"
+      - "applogic/**"
+      - "apqmls/**"
+      - "common/**"
+      - "coreclient/**"
+      - "macros/**"
+      - "mls-assist/**"
+      - "protos/**"
       - "Cargo.toml"
       - "Cargo.lock"
   merge_group:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,14 +11,28 @@ concurrency:
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "app/windows/**"
+      - "app/rust_builder/windows/**"
+      - "app/.fvmrc"
+      - "app/pubspec.yaml"
+      - "app/pubspec.lock"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/windows.yml"
+      - ".github/actions/setup-buildenv/**"
   push:
     branches: ["main"]
     paths:
-      - "coreclient/**"
       - "apiclient/**"
-      - "applogic/**"
-      - "common/**"
       - "app/**"
+      - "applogic/**"
+      - "apqmls/**"
+      - "common/**"
+      - "coreclient/**"
+      - "macros/**"
+      - "mls-assist/**"
+      - "protos/**"
       - "Cargo.toml"
       - "Cargo.lock"
   merge_group:


### PR DESCRIPTION
The core idea is to only run the heavier CI build-only jobs when attempting to merge a PR as well as when platform-specific files are changed.

This should massively accelerate the initial feedback on pull requests (as well as save CI minutes). 🚀 

Also add missing path globs for the `push` trigger.