### PR TITLE
fix(app): fix drafts disappearing in chat list view

### DIFF
--- a/app/lib/features/chat_list/chat_list_content.dart
+++ b/app/lib/features/chat_list/chat_list_content.dart
@@ -425,10 +425,6 @@ class _LastMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isCurrentChat = context.select(
-      (NavigationCubit cubit) => cubit.state.chatId == chat.id,
-    );
-
     final palette = SemanticPalette.of(context);
     final loc = AppLocalizations.of(context);
 
@@ -464,7 +460,7 @@ class _LastMessage extends StatelessWidget {
       return Text(loc.textMessage_deleted, style: italicStyle);
     }
 
-    final showDraft = !isCurrentChat && draftMessage?.isNotEmpty == true;
+    final showDraft = draftMessage?.isNotEmpty == true;
 
     final prefixStyle = showDraft
         ? italicStyle

--- a/app/test/features/chat_list/chat_list_content_test.dart
+++ b/app/test/features/chat_list/chat_list_content_test.dart
@@ -383,5 +383,40 @@ void main() {
         matchesGoldenFile('goldens/chat_list_content_muted.png'),
       );
     });
+
+    // The draft chat, whose preview is the draft whatever navigation does.
+    final draftChat = chats[3];
+
+    Future<void> pumpDraftChat(
+      WidgetTester tester, {
+      required HomeNavigationState home,
+    }) async {
+      when(
+        () => navigationCubit.state,
+      ).thenReturn(NavigationState.home(home: home));
+      when(
+        () => chatListCubit.state,
+      ).thenReturn(ChatListState(chatIds: [draftChat.id]));
+
+      await tester.pumpWidget(buildSubject(chats: [draftChat]));
+    }
+
+    testWidgets('shows the draft of a closed chat', (tester) async {
+      await pumpDraftChat(
+        tester,
+        home: HomeNavigationState(chatOpen: false, chatId: draftChat.id),
+      );
+
+      expect(find.textContaining('Some draft message'), findsOne);
+    });
+
+    testWidgets('keeps the draft of the open chat', (tester) async {
+      await pumpDraftChat(
+        tester,
+        home: HomeNavigationState(chatOpen: true, chatId: draftChat.id),
+      );
+
+      expect(find.textContaining('Some draft message'), findsOne);
+    });
   });
 }

--- a/applogic/src/api/chat_details_cubit.rs
+++ b/applogic/src/api/chat_details_cubit.rs
@@ -466,8 +466,8 @@ impl ChatDetailsCubitBase {
                     draft.is_committed = is_committed;
                     true
                 }
-                Some(draft) if draft.is_committed != is_committed => {
-                    draft.is_committed = is_committed;
+                Some(draft) if is_committed && !draft.is_committed => {
+                    draft.is_committed = true;
                     true
                 }
                 Some(_) => false,

--- a/coreclient/src/chats/draft.rs
+++ b/coreclient/src/chats/draft.rs
@@ -154,7 +154,7 @@ mod persistence {
             )
             .execute(connection.as_mut())
             .await?;
-            if self.is_committed && result.rows_affected() > 0 {
+            if result.rows_affected() > 0 {
                 connection.notifier().update(chat_id);
             }
             Ok(())


### PR DESCRIPTION
Changes some conditions to always propagate updates to the UI when a draft is updated, as well as make sure it doesn't go away when it's being restored in the message composer.