### PR TITLE
fix(build): don't rebuild all the time in release mode

### DIFF
--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -77,6 +77,12 @@ runs:
       shell: bash
       run: echo "value=$(bash scripts/build-name.sh)" >> $GITHUB_OUTPUT
 
+    # Forces apiclient's build script to collect fresh git metadata for this
+    # commit (see apiclient/build.rs)
+    - name: Refresh client build metadata
+      shell: bash
+      run: echo "AIR_REFRESH_BUILD_METADATA=${{ github.sha }}" >> $GITHUB_ENV
+
     ## cargo-binstall (as a side-effect: setup Rust toolchain using rust-toolchain.toml)
 
     - name: Setup cargo binstall

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "mimi-room-policy",
  "mls-assist",
  "semver",
- "shadow-rs",
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
@@ -2025,27 +2024,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const_format"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
-dependencies = [
- "const_format_proc_macros",
- "konst",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -4023,12 +4001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
-name = "is_debug"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,21 +4148,6 @@ dependencies = [
  "crypto-common 0.2.2",
  "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "konst"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -5115,15 +5072,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -6935,18 +6883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shadow-rs"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c798acfc78a69c7b038adde44084d8df875555b091da42c90ae46257cdcc41a"
-dependencies = [
- "const_format",
- "is_debug",
- "time",
- "tzdb",
-]
-
-[[package]]
 name = "shake"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7532,9 +7468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8067,32 +8001,6 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "tz-rs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6c929ffa10fb34f4a3c7e9a73620a83ef2e85e47f9ec3381b8289e6762f42"
-
-[[package]]
-name = "tzdb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d4e985b6dda743ae7fd4140c28105316ffd75bc58258ee6cc12934e3eb7a0c"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
- "tzdb_data",
-]
-
-[[package]]
-name = "tzdb_data"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febaa995f6852367564e16c3369988b99d471d43ed12b1255b8d294661797f1c"
-dependencies = [
- "tz-rs",
-]
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,6 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_bytes = "0.11.17"
 serde_json = "1.0.140"
 sha2 = "0.11.0"
-shadow-rs = { version = "1.4.0", default-features = false }
 sqlx = { version = "0.9.0", default-features = false, features = ["macros", "uuid", "chrono", "migrate", "bigdecimal", "runtime-tokio", "sqlx-toml"] }
 strum = { version = "0.28", features = ["derive"] }
 tap = "1.0.1"

--- a/apiclient/Cargo.toml
+++ b/apiclient/Cargo.toml
@@ -18,7 +18,6 @@ futures-util.workspace = true
 mimi-room-policy.workspace = true
 mls-assist.workspace = true
 semver.workspace = true
-shadow-rs.workspace = true
 thiserror.workspace = true
 tls_codec.workspace = true
 tokio = { workspace = true, features = ["time"] }
@@ -32,6 +31,3 @@ uuid.workspace = true
 [dev-dependencies]
 tokio.workspace = true
 uuid.workspace = true
-
-[build-dependencies]
-shadow-rs = { workspace = true, features = ["build"] }

--- a/apiclient/build.rs
+++ b/apiclient/build.rs
@@ -2,8 +2,49 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use shadow_rs::ShadowBuilder;
+//! Collects the git metadata that `src/metadata.rs` reports to the server.
+
+use std::process::Command;
+
+/// Changing this variable forces the metadata to be collected again.
+const REFRESH_ENV: &str = "AIR_REFRESH_BUILD_METADATA";
+
+/// Used when the git state cannot be determined, e.g. when building from a
+/// source archive.
+const UNKNOWN_COMMIT_HASH: &str = "0000000000000000000000000000000000000000";
 
 fn main() {
-    ShadowBuilder::builder().build().unwrap();
+    // Deliberately no `rerun-if-changed` on the sources or on the git state:
+    // keeping the metadata in sync with every commit would recompile this
+    // crate -- and everything depending on it -- on every build. Set
+    // `AIR_REFRESH_BUILD_METADATA` to a value that changes (a commit hash, a
+    // build number) to collect it again.
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-env-changed={REFRESH_ENV}");
+
+    let commit_hash = git(&["rev-parse", "HEAD"]).unwrap_or_else(|| UNKNOWN_COMMIT_HASH.to_owned());
+    let dirty = git(&["status", "--porcelain"]).is_some_and(|status| !status.is_empty());
+    let commits_since_tag = git(&["describe", "--tags", "--abbrev=0", "HEAD"])
+        .and_then(|tag| git(&["rev-list", "--count", &format!("{tag}..HEAD")]))
+        .and_then(|count| count.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    println!("cargo::rustc-env=AIR_COMMIT_HASH={commit_hash}");
+    println!("cargo::rustc-env=AIR_GIT_DIRTY={dirty}");
+    println!("cargo::rustc-env=AIR_COMMITS_SINCE_TAG={commits_since_tag}");
+}
+
+/// Runs `git` with `args` and returns its trimmed stdout, or `None` if git is
+/// unavailable or the command fails.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    Some(stdout.trim().to_owned())
 }

--- a/apiclient/src/metadata.rs
+++ b/apiclient/src/metadata.rs
@@ -6,14 +6,16 @@ use std::sync::LazyLock;
 
 use airprotos::common::{self, v1::ClientMetadata};
 
-shadow_rs::shadow!(build);
-
+// Collected by `build.rs`. Note that these are only refreshed when the build
+// script reruns, see the comment there.
 pub(super) static METADATA: LazyLock<ClientMetadata> = LazyLock::new(|| {
     new_metadata(
-        build::PKG_VERSION,
-        !build::GIT_CLEAN,
-        build::COMMIT_HASH,
-        build::COMMITS_SINCE_TAG,
+        env!("CARGO_PKG_VERSION"),
+        env!("AIR_GIT_DIRTY") == "true",
+        env!("AIR_COMMIT_HASH"),
+        env!("AIR_COMMITS_SINCE_TAG")
+            .parse()
+            .expect("invalid commit count"),
     )
 });
 


### PR DESCRIPTION
shadow-rs tracks the git state and reruns its build script on every build, which recompiles apiclient and everything depending on it. Replace it with a small build.rs collecting the same metadata (commit hash, dirty flag, commits since tag). The metadata is only refreshed when AIR_REFRESH_BUILD_METADATA changes, e.g. in CI.