### PR TITLE
perf(app): reduce jank and microstutter when scrolling the chat list

### DIFF
--- a/app/lib/ds/components/avatar/avatar.dart
+++ b/app/lib/ds/components/avatar/avatar.dart
@@ -62,7 +62,9 @@ class Avatar extends StatelessWidget {
         // Only the letter, and only where it can be seen. Under a picture it is
         // a grapheme break, a paragraph layout and a MediaQuery dependency for
         // something never painted.
-        child: image != null ? null : _Letter(displayName: displayName, size: size),
+        child: image != null
+            ? null
+            : _Letter(displayName: displayName, size: size),
       ),
     );
 

--- a/app/lib/ds/components/avatar/avatar.dart
+++ b/app/lib/ds/components/avatar/avatar.dart
@@ -42,34 +42,27 @@ class Avatar extends StatelessWidget {
     final palette = SemanticPalette.of(context);
     final image = this.image;
 
-    // A picture covers the circle, so the fill under it only shows while it
-    // decodes: a flat tint reads as a placeholder, where the gradient would
-    // read as a fallback that then swaps out.
-    final circle = Container(
-      width: size,
-      height: size,
+    // One decoration, not a background plus a foreground. A BoxDecoration
+    // paints its color and then its image, which is the same result as laying
+    // the picture over a tinted circle, for one render object instead of two.
+    // The tint only shows while the picture decodes: a flat one reads as a
+    // placeholder, where the gradient would read as a fallback that then swaps
+    // out.
+    final circle = DecoratedBox(
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         gradient: image == null ? AvatarTokens.gradientFor(gradientSeed) : null,
         color: image == null ? null : palette.text.quaternary,
+        image: image == null
+            ? null
+            : DecorationImage(image: image, fit: BoxFit.cover),
       ),
-      foregroundDecoration: image == null
-          ? null
-          : BoxDecoration(
-              shape: BoxShape.circle,
-              image: DecorationImage(image: image, fit: BoxFit.cover),
-            ),
-      child: Center(
-        // We size the letter off the circle, so text scaling would spill it
-        // over the edge instead of enlarging it.
-        child: MediaQuery.withNoTextScaling(
-          child: Text(
-            displayName.characters.firstOrNull?.toUpperCase() ?? "",
-            style: typeScale.body.regular
-                .style(color: palette.function.neutral.white)
-                .copyWith(fontSize: AvatarTokens.letterSize(size)),
-          ),
-        ),
+      child: SizedBox.square(
+        dimension: size,
+        // Only the letter, and only where it can be seen. Under a picture it is
+        // a grapheme break, a paragraph layout and a MediaQuery dependency for
+        // something never painted.
+        child: image != null ? null : _Letter(displayName: displayName, size: size),
       ),
     );
 
@@ -80,6 +73,38 @@ class Avatar extends StatelessWidget {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(onTap: onTap, child: circle),
+    );
+  }
+}
+
+/// The fallback initial, drawn only when no picture covers it.
+class _Letter extends StatelessWidget {
+  const _Letter({required this.displayName, required this.size});
+
+  final String displayName;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    // Grapheme clusters rather than code units, so an emoji or a combining
+    // mark yields one character instead of half of one.
+    final initial = displayName.characters.firstOrNull?.toUpperCase();
+    if (initial == null || initial.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Center(
+      child: Text(
+        initial,
+        // We size the letter off the circle, so text scaling would spill it
+        // over the edge instead of enlarging it. Set on the Text rather than
+        // through MediaQuery.withNoTextScaling, which costs a Builder, a
+        // dependency on the whole MediaQueryData and a copy of it.
+        textScaler: TextScaler.noScaling,
+        style: typeScale.body.regular
+            .style(color: SemanticPalette.of(context).function.neutral.white)
+            .copyWith(fontSize: AvatarTokens.letterSize(size)),
+      ),
     );
   }
 }

--- a/app/lib/ds/components/scroll/app_scrollbar.dart
+++ b/app/lib/ds/components/scroll/app_scrollbar.dart
@@ -100,14 +100,20 @@ class _AppScrollbarState extends State<AppScrollbar> with FrameSafeState {
             widget.child,
             Positioned.fill(
               child: IgnorePointer(
-                child: ValueListenableBuilder<_ThumbState>(
-                  valueListenable: _thumb,
-                  builder: (context, thumb, _) => _Thumb(
-                    thumb: thumb,
-                    tokens: tokens,
-                    color: color,
-                    trackTop: widget.trackTop,
-                    trackBottom: widget.trackBottom,
+                // The boundary keeps the thumb's every-frame movement from
+                // re-recording the layer it shares with the host's chrome:
+                // without it, each scroll frame repaints the whole Scaffold
+                // above the viewport.
+                child: RepaintBoundary(
+                  child: ValueListenableBuilder<_ThumbState>(
+                    valueListenable: _thumb,
+                    builder: (context, thumb, _) => _Thumb(
+                      thumb: thumb,
+                      tokens: tokens,
+                      color: color,
+                      trackTop: widget.trackTop,
+                      trackBottom: widget.trackBottom,
+                    ),
                   ),
                 ),
               ),

--- a/app/lib/ds/patterns/chat_list/chat_list.dart
+++ b/app/lib/ds/patterns/chat_list/chat_list.dart
@@ -5,6 +5,7 @@
 import 'package:air/ds/components/scroll/faded_scroll_frame.dart';
 import 'package:air/ds/components/scroll/scroll_edges.dart';
 import 'package:air/ds/patterns/chat_list/chat_list_tokens.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 /// The scrolling chat list: a floating header, the rows beneath it, and a fade
@@ -22,6 +23,7 @@ class ChatList extends StatefulWidget {
     required this.headerHeight,
     required this.itemCount,
     required this.itemBuilder,
+    this.cacheExtent,
     this.controller,
     this.onScrollOffset,
   });
@@ -40,6 +42,8 @@ class ChatList extends StatefulWidget {
 
   final int itemCount;
   final NullableIndexedWidgetBuilder itemBuilder;
+
+  final ScrollCacheExtent? cacheExtent;
 
   /// Supply one to drive a scrollbar or to scroll the list from outside.
   /// Without one the list keeps its own.
@@ -132,6 +136,7 @@ class _ChatListState extends State<ChatList> {
             padding: EdgeInsets.only(top: topPadding, bottom: bottomPadding),
             itemCount: widget.itemCount,
             itemBuilder: widget.itemBuilder,
+            scrollCacheExtent: widget.cacheExtent,
           ),
         ),
       ),

--- a/app/lib/ds/patterns/list_header/list_header.dart
+++ b/app/lib/ds/patterns/list_header/list_header.dart
@@ -8,7 +8,9 @@ import 'package:air/ds/components/button_icon/button_icon.dart';
 import 'package:air/ds/components/button_icon/button_icon_tokens.dart';
 import 'package:air/ds/foundations/foundations.dart';
 import 'package:air/ds/patterns/list_header/list_header_tokens.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 /// The header of a list-depth screen: a centered title in a pill, with a
 /// leading and a trailing slot. Transparent, so the list scrolls full-bleed
@@ -16,14 +18,14 @@ import 'package:flutter/widgets.dart';
 ///
 /// The pill only materializes once content slides under the bar, driven by
 /// [scrollOffset]. The host owns the scroll, so this stays a pure renderer.
-class ListHeader extends StatelessWidget {
+class ListHeader extends HookWidget {
   const ListHeader({
     super.key,
     required this.tokens,
     this.title,
     this.leading,
     this.trailing,
-    this.scrollOffset = 0,
+    this.scrollOffset,
   });
 
   final ListHeaderTokens tokens;
@@ -37,10 +39,29 @@ class ListHeader extends StatelessWidget {
   final Widget? trailing;
 
   /// How far the content beneath the bar has scrolled, in pixels.
-  final double scrollOffset;
+  final ValueListenable<double>? scrollOffset;
 
   @override
   Widget build(BuildContext context) {
+    final offset = scrollOffset;
+
+    final reveal = useValueNotifier(0.0);
+
+    useEffect(() {
+      if (offset == null) return null;
+      void update() {
+        final t = (offset.value / ListHeaderTokens.pillRevealDistance).clamp(
+          0.0,
+          1.0,
+        );
+        reveal.value = Effect.easeOutQuart.transform(t);
+      }
+
+      update();
+      offset.addListener(update);
+      return () => offset.removeListener(update);
+    }, [offset, reveal]);
+
     final hasSlot = leading != null || trailing != null;
 
     // The slot width is a floor, not a cap: we don't squash an action larger
@@ -72,11 +93,7 @@ class ListHeader extends StatelessWidget {
                 ),
                 child: Center(
                   child: (title != null && tokens.showTitle)
-                      ? _Title(
-                          title: title!,
-                          tokens: tokens,
-                          scrollOffset: scrollOffset,
-                        )
+                      ? _Title(title: title!, tokens: tokens, reveal: reveal)
                       : null,
                 ),
               ),
@@ -134,72 +151,72 @@ class _Title extends StatelessWidget {
   const _Title({
     required this.title,
     required this.tokens,
-    required this.scrollOffset,
+    required this.reveal,
   });
 
   final String title;
   final ListHeaderTokens tokens;
-  final double scrollOffset;
+  final ValueListenable<double> reveal;
 
   @override
   Widget build(BuildContext context) {
     final palette = SemanticPalette.of(context);
-
-    // Scroll-linked reveal, mirroring the frame's top fade: ramp 0 to 1 over
-    // the reveal distance, eased. It tracks the finger, so it needs no
-    // duration.
-    final t = (scrollOffset / ListHeaderTokens.pillRevealDistance).clamp(
-      0.0,
-      1.0,
-    );
-    final reveal = Effect.easeOutQuart.transform(t);
     final fill = palette.backgroundElevated.primary;
     final border = palette.separator.primary;
 
-    return Container(
+    return ConstrainedBox(
       constraints: BoxConstraints(minHeight: tokens.pillMinHeight),
-      padding: tokens.pillPadding,
-      decoration: BoxDecoration(
-        color: fill.withValues(alpha: fill.a * reveal),
-        borderRadius: BorderRadius.circular(ListHeaderTokens.pillRadius),
-        // Outside-aligned so the stroke grows outward from the pill's edge
-        // rather than inward: the label and its padding never shift as the
-        // border comes in.
-        border: ListHeaderTokens.pillBorderWidth > 0
-            ? Border.all(
-                color: border.withValues(alpha: border.a * reveal),
-                width: ListHeaderTokens.pillBorderWidth,
-                strokeAlign: BorderSide.strokeAlignOutside,
-              )
-            : null,
-        boxShadow: [
-          for (final shadow in ListHeaderTokens.pillShadow)
-            shadow.copyWith(
-              color: shadow.color.withValues(alpha: shadow.color.a * reveal),
-            ),
-        ],
-      ),
-      // No alignment here: a Container with one expands to its parent's
-      // bounded width instead of hugging its label.
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              // Emphasized, like the modal header's: this label names the
-              // screen, where the chat header's pill carries a person's name
-              // and stays plain.
-              style: typeScale.body.regular.style(
-                color: palette.text.primary,
-                weight: Weight.emphasized,
-                tight: true,
+      // The builder will only rebuild the builder and reuse the child.
+      child: ValueListenableBuilder<double>(
+        valueListenable: reveal,
+        child: Padding(
+          padding: tokens.pillPadding,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  // Emphasized, like the modal header's: this label names the
+                  // screen, where the chat header's pill carries a person's name
+                  // and stays plain.
+                  style: typeScale.body.regular.style(
+                    color: palette.text.primary,
+                    weight: Weight.emphasized,
+                    tight: true,
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ],
+        ),
+        builder: (context, reveal, child) => DecoratedBox(
+          decoration: BoxDecoration(
+            color: fill.withValues(alpha: fill.a * reveal),
+            borderRadius: BorderRadius.circular(ListHeaderTokens.pillRadius),
+            // Outside-aligned so the stroke grows outward from the pill's edge
+            // rather than inward: the label and its padding never shift as the
+            // border comes in.
+            border: ListHeaderTokens.pillBorderWidth > 0
+                ? Border.all(
+                    color: border.withValues(alpha: border.a * reveal),
+                    width: ListHeaderTokens.pillBorderWidth,
+                    strokeAlign: BorderSide.strokeAlignOutside,
+                  )
+                : null,
+            boxShadow: [
+              for (final shadow in ListHeaderTokens.pillShadow)
+                shadow.copyWith(
+                  color: shadow.color.withValues(
+                    alpha: shadow.color.a * reveal,
+                  ),
+                ),
+            ],
+          ),
+          child: child,
+        ),
       ),
     );
   }

--- a/app/lib/features/chat_list/chat_list_content.dart
+++ b/app/lib/features/chat_list/chat_list_content.dart
@@ -30,6 +30,7 @@ import 'package:air/features/user/avatar.dart';
 import 'package:air/util/time/app_clock.dart';
 import 'package:air/util/time/time_labels.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:air/features/chat_list/chat_list_cubit.dart';
@@ -107,6 +108,7 @@ class ChatListContent extends StatelessWidget {
           ),
         );
       },
+      cacheExtent: const ScrollCacheExtent.viewport(3),
       onScrollOffset: onScrollOffset,
     );
 
@@ -538,13 +540,22 @@ class _LastUpdated extends StatelessWidget {
   final UiChatDetails chat;
 
   @override
-  Widget build(BuildContext context) => LiveTime(
-    format: (context, now) => chatListStampLabel(
-      chat.lastUsed,
-      now: now,
-      formats: TimeFormats.of(context),
-      loc: AppLocalizations.of(context),
-    ),
-    builder: (context, label) => ChatListTimestamp(label: label),
-  );
+  Widget build(BuildContext context) {
+    // Resolved here rather than inside [format], which runs on every clock tick
+    // for every live row. TimeFormats.of walks the element tree looking for an
+    // SDTFScope, which is not for free. Both of these change only with the locale
+    // or the platform's patterns, and either rebuilds this widget.
+    final formats = TimeFormats.of(context);
+    final loc = AppLocalizations.of(context);
+
+    return LiveTime(
+      format: (context, now) => chatListStampLabel(
+        chat.lastUsed,
+        now: now,
+        formats: formats,
+        loc: loc,
+      ),
+      builder: (context, label) => ChatListTimestamp(label: label),
+    );
+  }
 }

--- a/app/lib/features/chat_list/chat_list_header.dart
+++ b/app/lib/features/chat_list/chat_list_header.dart
@@ -17,10 +17,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ChatListHeader extends StatelessWidget {
-  const ChatListHeader({super.key, this.scrollOffset = 0});
+  const ChatListHeader({super.key, this.scrollOffset});
 
   /// The list's scroll offset, which reveals the title pill.
-  final double scrollOffset;
+  final ValueNotifier<double>? scrollOffset;
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/features/chat_list/chat_list_view.dart
+++ b/app/lib/features/chat_list/chat_list_view.dart
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import 'package:air/features/chat/chat_details_cubit.dart';
 import 'package:air/ds/foundations/foundations.dart';
-import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:air/features/user/user_cubit.dart';
@@ -106,7 +105,7 @@ class _ChatListViewState extends State<ChatListView> {
 class _Header extends StatelessWidget {
   const _Header({required this.scrollOffset, required this.topInset});
 
-  final ValueListenable<double> scrollOffset;
+  final ValueNotifier<double>? scrollOffset;
 
   /// Status-bar inset. The header floats over a full-bleed list, so it cannot
   /// rely on a SafeArea to clear the notch.
@@ -116,10 +115,7 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(top: topInset),
-      child: ValueListenableBuilder<double>(
-        valueListenable: scrollOffset,
-        builder: (context, offset, _) => ChatListHeader(scrollOffset: offset),
-      ),
+      child: ChatListHeader(scrollOffset: scrollOffset),
     );
   }
 }

--- a/app/lib/features/home/home_screen.dart
+++ b/app/lib/features/home/home_screen.dart
@@ -64,7 +64,15 @@ class _HomeScreenMobileLayout extends StatelessWidget {
             },
           ),
         ),
-        const Positioned(left: 0, right: 0, bottom: 0, child: AppTabBar()),
+        const Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          // The boundary keeps the bar out of the route's layer, which is
+          // re-recorded during scrolling; without it the whole pill repaints
+          // on every scroll frame.
+          child: RepaintBoundary(child: AppTabBar()),
+        ),
       ],
     );
   }

--- a/app/lib/util/time/time_labels.dart
+++ b/app/lib/util/time/time_labels.dart
@@ -37,9 +37,11 @@ class TimeFormats {
         : null;
     return TimeFormats(
       locale: locale,
-      timePattern: patterns?.timePattern ??
+      timePattern:
+          patterns?.timePattern ??
           _cached('jm|$locale', () => DateFormat.jm(locale)).pattern!,
-      datePattern: patterns?.datePattern ??
+      datePattern:
+          patterns?.datePattern ??
           _cached('yMd|$locale', () => DateFormat.yMd(locale)).pattern!,
     );
   }
@@ -70,9 +72,9 @@ class TimeFormats {
 
   /// Numeric date with the year dropped, e.g. `5/20`.
   String dateWithoutYear(DateTime at) => _cached(
-        'dy|$datePattern',
-        () => DateFormat(_withoutYear(datePattern)),
-      ).format(at);
+    'dy|$datePattern',
+    () => DateFormat(_withoutYear(datePattern)),
+  ).format(at);
 
   /// Weekday, month and day, e.g. `Wed, May 20`.
   String weekdayMonthDay(DateTime at) =>

--- a/app/lib/util/time/time_labels.dart
+++ b/app/lib/util/time/time_labels.dart
@@ -37,8 +37,10 @@ class TimeFormats {
         : null;
     return TimeFormats(
       locale: locale,
-      timePattern: patterns?.timePattern ?? DateFormat.jm(locale).pattern!,
-      datePattern: patterns?.datePattern ?? DateFormat.yMd(locale).pattern!,
+      timePattern: patterns?.timePattern ??
+          _cached('jm|$locale', () => DateFormat.jm(locale)).pattern!,
+      datePattern: patterns?.datePattern ??
+          _cached('yMd|$locale', () => DateFormat.yMd(locale)).pattern!,
     );
   }
 
@@ -51,26 +53,34 @@ class TimeFormats {
   final String datePattern;
 
   /// The clock alone: `14:32`, or `2:32 PM` on a 12-hour device.
-  String clock(DateTime at) => DateFormat(timePattern).format(at);
+  String clock(DateTime at) =>
+      _cached('c|$timePattern', () => DateFormat(timePattern)).format(at);
 
   /// Abbreviated weekday, e.g. `Mon`.
-  String weekdayShort(DateTime at) => DateFormat.E(locale).format(at);
+  String weekdayShort(DateTime at) =>
+      _cached('E|$locale', () => DateFormat.E(locale)).format(at);
 
   /// Full weekday, e.g. `Monday`.
-  String weekdayLong(DateTime at) => DateFormat.EEEE(locale).format(at);
+  String weekdayLong(DateTime at) =>
+      _cached('EEEE|$locale', () => DateFormat.EEEE(locale)).format(at);
 
   /// Numeric date, e.g. `5/20/26`.
-  String date(DateTime at) => DateFormat(datePattern).format(at);
+  String date(DateTime at) =>
+      _cached('d|$datePattern', () => DateFormat(datePattern)).format(at);
 
   /// Numeric date with the year dropped, e.g. `5/20`.
-  String dateWithoutYear(DateTime at) =>
-      DateFormat(_withoutYear(datePattern)).format(at);
+  String dateWithoutYear(DateTime at) => _cached(
+        'dy|$datePattern',
+        () => DateFormat(_withoutYear(datePattern)),
+      ).format(at);
 
   /// Weekday, month and day, e.g. `Wed, May 20`.
-  String weekdayMonthDay(DateTime at) => DateFormat.MMMEd(locale).format(at);
+  String weekdayMonthDay(DateTime at) =>
+      _cached('MMMEd|$locale', () => DateFormat.MMMEd(locale)).format(at);
 
   /// Month, day and year, e.g. `May 20, 2026`.
-  String monthDayYear(DateTime at) => DateFormat.yMMMd(locale).format(at);
+  String monthDayYear(DateTime at) =>
+      _cached('yMMMd|$locale', () => DateFormat.yMMMd(locale)).format(at);
 
   @override
   bool operator ==(Object other) =>
@@ -83,10 +93,21 @@ class TimeFormats {
   int get hashCode => Object.hash(locale, timePattern, datePattern);
 }
 
+/// [DateFormat] re-parses its pattern on every fresh instance, and these are
+/// asked for once per visible row on every clock tick, so instances are kept.
+/// Keyed by pattern and locale; the ambient default locale is appended for
+/// the pattern-only constructors, which resolve their symbols through it.
+final _dateFormats = <String, DateFormat>{};
+
+DateFormat _cached(String key, DateFormat Function() create) =>
+    _dateFormats['$key|${Intl.getCurrentLocale()}'] ??= create();
+
+final _yearInPattern = RegExp(r"[/.\-,\s]*[yY]+[/.\-,\s]*");
+
 /// Strips the year and any separator left stranded beside it, so `M/d/yy`
 /// reads `M/d` and `dd.MM.yyyy` reads `dd.MM`.
 String _withoutYear(String pattern) =>
-    pattern.replaceAll(RegExp(r"[/.\-,\s]*[yY]+[/.\-,\s]*"), '').trim();
+    pattern.replaceAll(_yearInPattern, '').trim();
 
 /// A moment's distance from [now], in the terms the labels below distinguish.
 /// Calendar days, not 24-hour windows: a message sent late yesterday reads

--- a/app/test/ds/patterns/list_header_test.dart
+++ b/app/test/ds/patterns/list_header_test.dart
@@ -22,7 +22,7 @@ void main() {
         body: ListHeader(
           tokens: tokens,
           title: 'Chats',
-          scrollOffset: scrollOffset,
+          scrollOffset: ValueNotifier<double>(scrollOffset),
           leading: ListHeaderAction(
             tokens: tokens,
             onAction: onAction == null ? null : (_) => onAction(),
@@ -33,12 +33,15 @@ void main() {
 
     /// The pill is the only decorated box inside the header carrying a fill.
     BoxDecoration pillDecoration(WidgetTester tester) {
-      final container = tester.widget<Container>(
+      final box = tester.widget<DecoratedBox>(
         find
-            .ancestor(of: find.text('Chats'), matching: find.byType(Container))
+            .ancestor(
+              of: find.text('Chats'),
+              matching: find.byType(DecoratedBox),
+            )
             .first,
       );
-      return container.decoration! as BoxDecoration;
+      return box.decoration as BoxDecoration;
     }
 
     testWidgets('hides the title pill while the list rests at the top', (


### PR DESCRIPTION
- Don't rebuild the chat list header on scrolling all the time: hand the scroll offset down as a ValueNotifier, so only the title pill listens to it instead of the whole header rebuilding on every frame.
- Add repaint boundaries around the scrollbar thumb and the tab bar, which otherwise repaint the whole scaffold above the viewport on every scroll frame.
- Render the avatar with one decoration instead of a background plus a foreground (one render object instead of two), and lay out the fallback letter only when no picture covers it.
- Resolve time formats and localizations in build instead of in the LiveTime format callback, which runs on every clock tick for every live row. TimeFormats.of walks the element tree looking for an SDTFScope, which is not for free.
- Cache DateFormat instances and regexes in time label resolving.
- Configure 3x viewport scroll cache extent for the chat list.

This results in less dropped frames and more smooth scrolling.