### PR TITLE
fix(app): move the message widget one level lower

### DIFF
--- a/app/lib/features/message_list/message_row_container.dart
+++ b/app/lib/features/message_list/message_row_container.dart
@@ -27,10 +27,7 @@ class MessageRowContainer extends StatelessWidget {
 
   final bool isConnectionChat;
 
-  /// Wraps the tile in [_AnimatedMessage] to play the entrance animation on
-  /// mount. Rebuilds within the same mount preserve the controller's progress;
-  /// flipping back to `false` (or never entering `true`) renders the tile
-  /// directly.
+  /// Whether the tile plays the entrance animation. Read once, on mount.
   final bool animated;
 
   /// The newest message in the chat.
@@ -124,22 +121,25 @@ class MessageRowContainer extends StatelessWidget {
       selected: false,
     );
 
-    return animated
-        ? _AnimatedMessage(
-            endsMessageGroup: endsMessageGroup,
-            isSender: isSender,
-            child: tile,
-          )
-        : tile;
+    return _AnimatedMessage(
+      animate: animated,
+      endsMessageGroup: endsMessageGroup,
+      isSender: isSender,
+      child: tile,
+    );
   }
 }
 
 class _AnimatedMessage extends StatefulWidget {
   const _AnimatedMessage({
+    required this.animate,
     required this.endsMessageGroup,
     required this.isSender,
     required this.child,
   });
+
+  /// Honored on mount only. See [MessageRowContainer.animated].
+  final bool animate;
 
   final bool endsMessageGroup;
   final bool isSender;
@@ -151,32 +151,35 @@ class _AnimatedMessage extends StatefulWidget {
 
 class _AnimatedMessageState extends State<_AnimatedMessage>
     with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
+  AnimationController? _controller;
 
   @override
   void initState() {
     super.initState();
+    if (!widget.animate) return;
     _controller = AnimationController(
       vsync: this,
       duration: Effect.duration(MotionPreset.short),
-    );
-    _controller.forward();
+    )..forward();
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller?.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final controller = _controller;
+    if (controller == null) return widget.child;
+
     final reserve = widget.endsMessageGroup
         ? MessageMetaTokens.heightOf(context)
         : S.s0;
 
     final animation = CurvedAnimation(
-      parent: _controller,
+      parent: controller,
       curve: Effect.easeOutQuart,
     );
 

--- a/app/test/features/message_list/mobile_message_actions_test.dart
+++ b/app/test/features/message_list/mobile_message_actions_test.dart
@@ -289,5 +289,74 @@ void main() {
         ),
       ).called(1);
     });
+
+    testWidgets('delivers a reaction picked on the message that just arrived', (
+      tester,
+    ) async {
+      tester.view.physicalSize = _testSize;
+      addTearDown(tester.view.resetPhysicalSize);
+
+      when(
+        () => chatDetailsCubit.sendReaction(
+          messageId: any(named: 'messageId'),
+          emoji: any(named: 'emoji'),
+        ),
+      ).thenAnswer((_) async {});
+
+      messageListCubit.setState(_mobileMessages, isAtBottom: true);
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final arrived = UiChatMessage(
+        id: 7.messageId(),
+        chatId: _chatId,
+        timestamp: DateTime.parse('2023-01-01T00:05:00.000Z'),
+        message: UiMessage_Content(
+          UiContentMessage(
+            sender: 2.userId(),
+            sent: true,
+            edited: false,
+            content: UiMimiContent(
+              plainBody: 'One more thing',
+              topicId: Uint8List(0),
+              content: simpleMessage('One more thing'),
+              attachments: [],
+            ),
+          ),
+        ),
+        status: UiMessageStatus.sent,
+        reactions: [],
+      );
+      messageListCubit.appendNewer([arrived], isIncoming: true);
+      await tester.pumpAndSettle();
+
+      // Past the window in which the view keeps the message eligible for the
+      // entrance animation.
+      await tester.pump(const Duration(seconds: 1));
+
+      await tester.longPress(find.text('One more thing'));
+      await tester.pumpAndSettle();
+
+      // Anything that rebuilds the list under the open overlay: a delivery
+      // state landing, the read marker moving, a message being edited.
+      messageListCubit.setState(
+        [..._mobileMessages, arrived],
+        isAtBottom: true,
+        revision: 7,
+      );
+      await tester.pump();
+
+      final semantics = tester.ensureSemantics();
+      await tester.tap(find.bySemanticsLabel(RegExp('👍')));
+      semantics.dispose();
+      await tester.pumpAndSettle();
+
+      verify(
+        () => chatDetailsCubit.sendReaction(
+          messageId: 7.messageId(),
+          emoji: '👍',
+        ),
+      ).called(1);
+    });
   });
 }

--- a/app/test/mocks.dart
+++ b/app/test/mocks.dart
@@ -184,8 +184,15 @@ class MockMessageListCubit implements MessageListCubit {
   /// window (index 0), mirroring a `NewerPageLoaded` pagination transition,
   /// then emits an updated state. Unlike [setState] this does not reload, so
   /// the AnchoredList sees an insert diff rather than a full reset.
-  void appendNewer(List<UiChatMessage> newer, {bool hasNewer = false}) {
+  void appendNewer(
+    List<UiChatMessage> newer, {
+    bool hasNewer = false,
+    bool isIncoming = false,
+  }) {
     messageData.insertAll(0, newer.reversed.toList());
+    if (isIncoming && !_incomingMessages.isClosed) {
+      _incomingMessages.add(newer.map((m) => m.id).toSet());
+    }
     final prev = _state.state;
     final rustState = MessageListState(
       isConnectionChat: prev.isConnectionChat ?? false,


### PR DESCRIPTION
Actions raised on a freshly arrived message didn't work the first time (reacting, editing, replying, etc.) but worked on a second attempt.

Because of the way the `MessageRowContainer` would pick between an animated message (for incoming) and the "permanent" one, the callbacks for the context menu and reaction bar would have a defunct `BuildContext` (= not mounted anymore) and the `onTap()` closures would immediately return.

Here's a timeline of what happened, as I understood it:
- Incoming message: `_animatedMessages.add(id)` -> we wrap the message bubble in `_AnimatedMessage`
- Animation plays -> message widget still wrapped
- 600 ms after start -> `_animatedMessages[id]` gets evicted, `animated: false`
- Long-press on message bubble + select action
- Meanwhile, the list rebuilds (i.e. delivery receipt, anything really) -> the widget gets flipped to non-wrapped under us
- `context.mounted: false` on the `onTap` closures 💣
- Try again, works, because we're on the non-wrapped widget which is "permanent".