### PR TITLE
fix(server): notify all emulator clients of own messages/commits

### DIFF
--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -14,7 +14,7 @@ use aircommon::{
         },
         errors::{DecryptionError, EncryptionError},
     },
-    identifiers::{QsReference, SealedClientReference, UserId},
+    identifiers::{QsReference, SealedClientReference},
     messages::client_ds::WelcomeInfoParams,
     mls_group_config::leaf_node_is_virtual_client,
     time::TimeStamp,
@@ -308,33 +308,6 @@ impl DsGroupState {
     ) -> impl Iterator<Item = QsReference> {
         self.other_member_profiles(sender_index)
             .map(|(_, client_profile)| client_profile.client_queue_config.clone())
-    }
-
-    /// The same as [`Self::other_destination_clients`], but each destination is
-    /// paired with whether it is another client of the sending user. It
-    /// unfortunately requires parsing of the client's leaf credential.
-    pub(crate) fn other_destinations(
-        &self,
-        sender_index: LeafNodeIndex,
-    ) -> impl Iterator<Item = (QsReference, bool)> {
-        let is_self_group = self.is_self_group();
-        let sender_user_id = self.leaf_user_id(sender_index);
-        self.other_member_profiles(sender_index)
-            .map(move |(client_index, client_profile)| {
-                let is_sibling = is_self_group
-                    || sender_user_id.as_ref().is_some_and(|sender_user_id| {
-                        self.leaf_user_id(*client_index).as_ref() == Some(sender_user_id)
-                    });
-                (client_profile.client_queue_config.clone(), is_sibling)
-            })
-    }
-
-    /// The user owning `leaf_index`, if the leaf carries a user credential.
-    fn leaf_user_id(&self, leaf_index: LeafNodeIndex) -> Option<UserId> {
-        match self.leaf_credential(leaf_index)? {
-            LeafCredential::User(credential) => Some(credential.user_id().clone()),
-            LeafCredential::SelfGroup(_) => None,
-        }
     }
 
     /// Returns `true` if the group context's [`AirComponent`] marks this group as a

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -213,22 +213,20 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
 
     /// Fans out a message to the given clients (concurrently).
     ///
-    /// Each destination carries its own notification-suppression flag, so that
-    /// a message can reach the sender's other clients without waking them.
-    ///
     /// The parallelism is limited by a constant. Logs failures but does not
     /// fail the whole operation.
     async fn fan_out_message(
         &self,
         fan_out_payload: impl Into<DsFanOutPayload>,
-        destination_clients: impl IntoIterator<Item = (identifiers::QsReference, bool)>,
+        destination_clients: impl IntoIterator<Item = identifiers::QsReference>,
+        suppress_notifications: bool,
         broadcast_to_all_client_queues: bool,
     ) -> TimeStamp {
         let fan_out_payload = fan_out_payload.into();
         let timestamp = fan_out_payload.timestamp();
 
         let mut join_set: JoinSet<Result<(), <Qep as QsConnector>::EnqueueError>> = JoinSet::new();
-        for (client_reference, suppress_notifications) in destination_clients {
+        for client_reference in destination_clients {
             while MAX_CONCURRENT_FANOUTS <= join_set.len() {
                 join_set
                     .join_next()
@@ -272,9 +270,8 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
     ) -> TimeStamp {
         self.fan_out_message(
             fan_out_payload,
-            destination_clients
-                .into_iter()
-                .map(|client_reference| (client_reference, true)),
+            destination_clients,
+            true,
             broadcast_to_all_client_queues,
         )
         .await
@@ -1507,26 +1504,17 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
             .await?;
         }
 
+        let destination_clients = group_state.other_destination_clients(sender_index);
         let broadcast_to_all_client_queues = group_state.broadcast_to_all_client_queues();
 
         // Messages from legacy clients won't have this field set. Default to false.
         let suppress_notifications = payload.suppress_notifications.unwrap_or(false);
 
-        // The sender's own clients need the message, but a push notification for
-        // it would wake them for something their user just did themselves.
-        let destination_clients = group_state.other_destinations(sender_index).map(
-            |(client_reference, is_sender_sibling)| {
-                (
-                    client_reference,
-                    suppress_notifications || is_sender_sibling,
-                )
-            },
-        );
-
         let timestamp = self
             .fan_out_message(
                 message.into_serialized_mls_message(),
                 destination_clients,
+                suppress_notifications,
                 broadcast_to_all_client_queues,
             )
             .await;


### PR DESCRIPTION
In #1410 we assumed it would be a good idea to not server-side push-notify and wake other clients for our own changes (sent messages, our own commit in the self-group, etc.) but this turned out to be a mistake, because it's not our current strategy. We want to try and wake clients as often as we can to ensure they have a fresh state.

The desired optimisation is also dubious, since you end up doing _more_ work on every catch up, instead of catching up more often with _less_ work. On Android, for example, since `JobManager` only runs your instance when the radio (+ internet) is available, it doesn't change anything to ask to run more often, if you run faster.

This is a partial revert of 675e6bc5b847c328bdae83ad09437c98c87c1526.