### PR TITLE
feat(app): use RestorationMixin to restore the last home/chat route

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:air/core/core.dart';
 import 'package:air/l10n/l10n.dart';
 import 'package:air/l10n/supported_locales.dart';
 import 'package:air/features/navigation/navigation_cubit.dart';
+import 'package:air/features/navigation/navigation_restoration.dart';
 import 'package:air/features/navigation/app_router.dart';
 import 'package:air/features/onboarding/registration_cubit.dart';
 import 'package:air/ds/foundations/foundations.dart';
@@ -225,6 +226,7 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                     : appLocale;
 
                 return MaterialApp.router(
+                  restorationScopeId: 'root',
                   scrollBehavior: const AppScrollBehavior(),
                   scaffoldMessengerKey: scaffoldMessengerKey,
                   onGenerateTitle: (context) =>
@@ -240,25 +242,29 @@ class _AppState extends State<App> with WidgetsBindingObserver {
                   theme: lightTheme,
                   darkTheme: darkTheme,
                   routerConfig: _appRouter,
-                  builder: (context, router) => LoadableUserCubitProvider(
-                    appStateController: _appStateController,
-                    child: BlocListener<NavigationCubit, NavigationState>(
-                      // Drop the keyboard focus whenever we navigate, e.g. leaving
-                      // a chat's message composer to open the contact/chat
-                      // details. Otherwise the composer's FocusNode keeps focus
-                      // while sitting under the pushed screens, and on iOS the
-                      // keyboard reappears when a pageless route on top (like the
-                      // safety code screen) is popped, because Flutter restores
-                      // focus to it.
-                      //
-                      // Only touch devices have a software keyboard, and on
-                      // desktop we want the composer to keep its focus, so this
-                      // is scoped to non-desktop. The listener already only fires
-                      // when the navigation state actually changes.
-                      listenWhen: (previous, current) => !DeviceType.isDesktop,
-                      listener: (context, state) =>
-                          FocusManager.instance.primaryFocus?.unfocus(),
-                      child: router!,
+                  builder: (context, router) => NavigationRestorationScope(
+                    navigationCubit: _navigationCubit,
+                    child: LoadableUserCubitProvider(
+                      appStateController: _appStateController,
+                      child: BlocListener<NavigationCubit, NavigationState>(
+                        // Drop the keyboard focus whenever we navigate, e.g. leaving
+                        // a chat's message composer to open the contact/chat
+                        // details. Otherwise the composer's FocusNode keeps focus
+                        // while sitting under the pushed screens, and on iOS the
+                        // keyboard reappears when a pageless route on top (like the
+                        // safety code screen) is popped, because Flutter restores
+                        // focus to it.
+                        //
+                        // Only touch devices have a software keyboard, and on
+                        // desktop we want the composer to keep its focus, so this
+                        // is scoped to non-desktop. The listener already only fires
+                        // when the navigation state actually changes.
+                        listenWhen: (previous, current) =>
+                            !DeviceType.isDesktop,
+                        listener: (context, state) =>
+                            FocusManager.instance.primaryFocus?.unfocus(),
+                        child: router!,
+                      ),
                     ),
                   ),
                 );
@@ -313,7 +319,12 @@ class LoadableUserCubitProvider extends StatelessWidget {
             final navigationState = navigationCubit.state;
             if (navigationState is! HomeState &&
                 !navigationState.isCreatingAccount) {
-              navigationCubit.openHome();
+              final restoredHome = navigationCubit.takeRestoredHome();
+              if (restoredHome != null) {
+                await navigationCubit.applyRestoredHome(restoredHome);
+              } else {
+                navigationCubit.openHome();
+              }
             }
             final userLocaleCode = userSettingsCubit.state.locale;
             final appLocale = appLocaleCubit.state;

--- a/app/lib/features/navigation/navigation_cubit.dart
+++ b/app/lib/features/navigation/navigation_cubit.dart
@@ -28,6 +28,30 @@ class NavigationCubit extends Cubit<NavigationState> {
     notificationContext.setPolicy(policy: change.nextState.notificationPolicy);
   }
 
+  /// A home state restored from the platform's state-restoration bundle,
+  /// waiting for a user to load before it can be applied.
+  HomeNavigationState? _restoredHome;
+
+  void setRestoredHome(HomeNavigationState home) => _restoredHome = home;
+
+  /// Returns and clears the restored home state, so a later re-login doesn't
+  /// reapply a stale restore.
+  HomeNavigationState? takeRestoredHome() {
+    final home = _restoredHome;
+    _restoredHome = null;
+    return home;
+  }
+
+  /// Applies a restored home state, mirroring [openChat]'s side effect when
+  /// it restores an open chat.
+  Future<void> applyRestoredHome(HomeNavigationState home) async {
+    emit(NavigationState.home(home: home));
+    final chatId = home.chatId;
+    if (home.chatOpen && chatId != null) {
+      await notificationContext.chatOpened(chatId: chatId);
+    }
+  }
+
   // Navigation actions
 
   void openIntro() => emit(const NavigationState.intro());

--- a/app/lib/features/navigation/navigation_restoration.dart
+++ b/app/lib/features/navigation/navigation_restoration.dart
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:air/core/core.dart';
+import 'package:air/features/navigation/navigation_cubit.dart';
+import 'package:flutter/widgets.dart';
+import 'package:uuid/uuid.dart';
+
+/// Persists a reduced [HomeNavigationState] (tab and open chat) through
+/// Flutter's platform state-restoration channel, so an Android process
+/// killed for memory (task still in Recents) reopens on the same screen.
+///
+/// Must sit under a [MaterialApp]/[WidgetsApp] with `restorationScopeId`
+/// set, so a [RestorationScope] exists to attach to.
+class NavigationRestorationScope extends StatefulWidget {
+  const NavigationRestorationScope({
+    required this.navigationCubit,
+    required this.child,
+    super.key,
+  });
+
+  final NavigationCubit navigationCubit;
+  final Widget child;
+
+  @override
+  State<NavigationRestorationScope> createState() =>
+      _NavigationRestorationScopeState();
+}
+
+class _NavigationRestorationScopeState extends State<NavigationRestorationScope>
+    with RestorationMixin {
+  final RestorableStringN _lastHome = RestorableStringN(null);
+  StreamSubscription<NavigationState>? _subscription;
+
+  @override
+  String? get restorationId => 'navigation';
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = widget.navigationCubit.stream.listen(_onNavigationChange);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _lastHome.dispose();
+    super.dispose();
+  }
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_lastHome, 'lastHome');
+    if (initialRestore) {
+      final restored = _decode(_lastHome.value);
+      if (restored != null) {
+        widget.navigationCubit.setRestoredHome(restored);
+      }
+    }
+  }
+
+  // Only persisted while logged in: an Intro transition (logout, account
+  // switch) clears it so a later restore never leaks a chat across accounts.
+  void _onNavigationChange(NavigationState state) {
+    switch (state) {
+      case HomeState(:final home):
+        _lastHome.value = _encode(home);
+      case IntroState():
+        _lastHome.value = null;
+    }
+  }
+
+  static String _encode(HomeNavigationState home) => jsonEncode({
+    'tab': home.activeTab.name,
+    'chatId': home.chatId?.uuid.toString(),
+    'chatOpen': home.chatOpen,
+  });
+
+  static HomeNavigationState? _decode(String? value) {
+    if (value == null) return null;
+    try {
+      final json = jsonDecode(value) as Map<String, dynamic>;
+      final tab = HomeTab.values.firstWhere(
+        (t) => t.name == json['tab'],
+        orElse: () => HomeTab.chats,
+      );
+      final chatIdString = json['chatId'] as String?;
+      return HomeNavigationState(
+        activeTab: tab,
+        chatId: chatIdString != null
+            ? ChatId(uuid: UuidValue.fromString(chatIdString))
+            : null,
+        chatOpen: json['chatOpen'] as bool? ?? false,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}


### PR DESCRIPTION
On Android, under memory pressure or other condition, the OS can decide to gracefully kill the app (as long as it's possible). Flutter exposes a way to correctly persist values based on the app's lifecycle.

In this PR, we persist and restore the selected tab on the home screen, or the open chat (we consider any other route transient).

Tested on a Pixel 8 with Android 16.