### PR TITLE
fix(backend): set timeout_client of load-balancer to 120s

### DIFF
--- a/deployment/ingress-nginx-values.yaml
+++ b/deployment/ingress-nginx-values.yaml
@@ -25,7 +25,7 @@ controller:
                       ],
                       "properties": {
                         "http2_enabled": true,
-                        "timeout_client": 3600
+                        "timeout_client": 120
                       }
                     },
                     {
@@ -46,7 +46,7 @@ controller:
                       ],
                       "properties": {
                         "http2_enabled": true,
-                        "timeout_client": 3600
+                        "timeout_client": 120
                       }
                     }
                   ],


### PR DESCRIPTION
The QS skips the sentinel push notification whenever the client still has a listen stream open (so far, so good).

However, mobile connections die silently all the time (I experienced this first hand). The
server side of such a connection stays open until something tears it down.

Timeline of a failure:

- Phone opens the app: listen stream established, QS tracks a listener
- Phone leaves WiFi / loses radio / gets frozen by Android: the phone-to-LB connection dies silently, no FIN or RST is sent
- Client HTTP/2 keepalive pings stop. Nobody notices: the server's pings are answered by nginx, and the LB treats client silence as "idle", tolerated for timeout_client = 3600s
- Somebody sends a message: QS sees the listener, skips the push, writes the message into the dead stream (bytes sit in TCP retransmit at the LB)
- More messages arrive: same thing, no push for any of them
- Phone shows nothing. It only wakes if a message arrives after the listener is cleaned up, or the user opens the app
- After 1 h of inactivity (or ~15-30 min of failed retransmits) the LB finally resets the connection, the reset cascades to the backend, the stale listener is dropped, pushes resume

Proposed fix: 120s tolerates three consecutively lost client keepalive pings before cutting a live connection, while keeping the push lost-window after a silent connection death to about two minutes.

Caveat: this bounds the lost push notifications to ~2 minutes, but does not eliminate it. To be able to recover from such situation, a change to QS will be needed.