### PR TITLE
perf(server): extract welcome info data from DsGroupState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ name = "airbackend"
 version = "0.21.0"
 dependencies = [
  "aircommon",
+ "airmacros",
  "airprotos",
  "anyhow",
  "apqmls",

--- a/backend/.sqlx/query-32067bb92550af36ec714c4b2d13307e1542fdf7f7d322f2646d6b24acda77b7.json
+++ b/backend/.sqlx/query-32067bb92550af36ec714c4b2d13307e1542fdf7f7d322f2646d6b24acda77b7.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n            ds_welcome_info\n            (group_id, epoch, ciphertext, created_at)\n        VALUES\n            ($1, $2, $3, $4)\n        ON CONFLICT (group_id, epoch) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Bytea",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "32067bb92550af36ec714c4b2d13307e1542fdf7f7d322f2646d6b24acda77b7"
+}

--- a/backend/.sqlx/query-9d008208726fcbb55c0d45aa73a4995faeb403b29ab936d896d93952fd897059.json
+++ b/backend/.sqlx/query-9d008208726fcbb55c0d45aa73a4995faeb403b29ab936d896d93952fd897059.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            ciphertext AS \"ciphertext: BlobDecoded<EncryptedWelcomeInfo>\"\n        FROM\n            ds_welcome_info\n        WHERE\n            group_id = $1 AND epoch = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "ciphertext: BlobDecoded<EncryptedWelcomeInfo>",
+        "type_info": "Bytea",
+        "origin": {
+          "Table": {
+            "table": "ds_welcome_info",
+            "name": "ciphertext"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9d008208726fcbb55c0d45aa73a4995faeb403b29ab936d896d93952fd897059"
+}

--- a/backend/.sqlx/query-f5daa40128746cc5d3d69888c23b1b459194c271daed4e09a59c14c63cb01949.json
+++ b/backend/.sqlx/query-f5daa40128746cc5d3d69888c23b1b459194c271daed4e09a59c14c63cb01949.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM\n            ds_welcome_info\n        WHERE\n            group_id = $1 AND created_at < $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f5daa40128746cc5d3d69888c23b1b459194c271daed4e09a59c14c63cb01949"
+}

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,6 +14,7 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 aircommon.workspace = true
+airmacros.workspace = true
 airprotos.workspace = true
 apqmls.workspace = true
 async-trait.workspace = true

--- a/backend/migrations/20260820120000_ds_welcome_info.down.sql
+++ b/backend/migrations/20260820120000_ds_welcome_info.down.sql
@@ -1,0 +1,5 @@
+-- SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+DROP TABLE IF EXISTS ds_welcome_info;

--- a/backend/migrations/20260820120000_ds_welcome_info.up.sql
+++ b/backend/migrations/20260820120000_ds_welcome_info.up.sql
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+CREATE TABLE ds_welcome_info (
+    group_id   UUID        NOT NULL REFERENCES encrypted_group (group_id) ON DELETE CASCADE,
+    epoch      BIGINT      NOT NULL,
+    ciphertext BYTEA       NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (group_id, epoch)
+);
+
+CREATE INDEX ds_welcome_info_created_at ON ds_welcome_info (group_id, created_at);

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -37,7 +37,7 @@ use aircommon::{
         welcome_attribution_info::EncryptedWelcomeAttributionInfo,
     },
     mls_group_config::QS_CLIENT_REFERENCE_EXTENSION_TYPE,
-    time::{Duration, TimeStamp},
+    time::TimeStamp,
     utils::removed_clients,
 };
 use tls_codec::DeserializeBytes;
@@ -48,10 +48,7 @@ use crate::{
     messages::intra_backend::{DsFanOutMessage, DsFanOutPayload, QsVirtualClientHint},
 };
 
-use super::{
-    group_state::{MemberProfile, leaf_credential_matches_flag},
-    process::USER_EXPIRATION_DAYS,
-};
+use super::group_state::{MemberProfile, leaf_credential_matches_flag};
 
 use super::group_state::DsGroupState;
 
@@ -329,7 +326,7 @@ impl DsGroupState {
     }
 
     // TODO: Make into a sans-io-style state machine
-    pub(crate) async fn process_group_operation(
+    pub(super) async fn process_group_operation(
         &mut self,
         params: GroupOperationParams,
     ) -> Result<ProcessedGroupOperation, GroupOperationError> {
@@ -361,10 +358,9 @@ impl DsGroupState {
         // Now we have to update the group state and distribute.
 
         // We first accept the message into the group state ...
-        self.group.accept_processed_message(
+        let retained_welcome_info = self.group.accept_processed_message(
             self.provider.storage(),
             processed_assisted_message_plus.processed_assisted_message,
-            Duration::days(USER_EXPIRATION_DAYS),
         )?;
 
         // Process removes
@@ -375,17 +371,11 @@ impl DsGroupState {
             self.update_membership_profiles(&add_users_state.added_users)?;
         }
 
+        // Persist staged welcome info if any
+        self.stage_welcome_info(retained_welcome_info);
+
         #[cfg(debug_assertions)]
         self.check_member_profiles("t_commit");
-
-        // Record this epoch only when the commit added someone. Welcome info
-        // is served from the ratchet tree mls-assist retains, and it retains
-        // one only for epochs with potential joiners, so a snapshot for any
-        // other epoch could never be served.
-        if added_users_state.is_some() {
-            let epoch = self.group().epoch();
-            self.snapshot_member_profiles(epoch);
-        }
 
         // Process resync operations
         if let Some((encrypted_user_profile_key, client_queue_config)) = external_sender_information
@@ -409,7 +399,7 @@ impl DsGroupState {
     }
 
     /// Returns (serialized message, T added users state, PQ welcome info)
-    pub(crate) fn process_apq_group_operation(
+    pub(super) fn process_apq_group_operation(
         t_group_state: &mut DsGroupState,
         pq_group_state: &mut DsGroupState,
         t_message: AssistedMessageIn,
@@ -495,13 +485,13 @@ impl DsGroupState {
         // Now we have to update the group state and distribute.
 
         // We first accept the message into the group state ...
-        ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
-            .accept_apq_processed_message(
-                t_group_state.provider.storage(),
-                pq_group_state.provider.storage(),
-                processed_assisted_message,
-                Duration::days(USER_EXPIRATION_DAYS),
-            )?;
+        let t_retained_welcome_info =
+            ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
+                .accept_apq_processed_message(
+                    t_group_state.provider.storage(),
+                    pq_group_state.provider.storage(),
+                    processed_assisted_message,
+                )?;
 
         // Process removes
         t_group_state.remove_profiles(t_removed_clients);
@@ -509,15 +499,11 @@ impl DsGroupState {
         // Update membership profiles for added users
         if let Some(ref add_users_state) = t_add_users_state {
             t_group_state.update_membership_profiles(&add_users_state.added_users)?;
+            t_group_state.stage_welcome_info(t_retained_welcome_info);
         }
 
         #[cfg(debug_assertions)]
         t_group_state.check_member_profiles("apq_commit");
-
-        if t_add_users_state.is_some() {
-            let epoch = t_group_state.group().epoch();
-            t_group_state.snapshot_member_profiles(epoch);
-        }
 
         // Process resync operations
         if let Some((encrypted_user_profile_key, client_queue_config)) = external_sender_information
@@ -542,7 +528,7 @@ impl DsGroupState {
         })
     }
 
-    pub(crate) async fn group_operation(
+    pub(super) async fn group_operation(
         &mut self,
         params: GroupOperationParams,
         group_state_ear_key: &GroupStateEarKey,

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -735,6 +735,8 @@ impl DsGroupState {
 
     #[cfg(debug_assertions)]
     pub(crate) fn check_member_profiles(&self, context: &str) {
+        use std::collections::BTreeSet;
+
         let occupied: BTreeSet<LeafNodeIndex> = self.group().members().map(|m| m.index).collect();
         let profiled: BTreeSet<LeafNodeIndex> = self.member_profiles.keys().copied().collect();
         if occupied == profiled {

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 
 use airprotos::client::virtual_client::extract_virtual_client_action;
 use mimi_room_policy::RoleIndex;

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -7,7 +7,10 @@ use std::collections::{BTreeSet, HashSet};
 use airprotos::client::virtual_client::extract_virtual_client_action;
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
-    group::{ApqProcessedAssistedMessagePlus, ProcessedAssistedMessage, apq::ApqGroupRef},
+    group::{
+        ApqProcessedAssistedMessagePlus, ProcessedAssistedMessage,
+        apq::{ApqGroupRef, ApqRetainedWelcomeInfo},
+    },
     messages::{AssistedMessageIn, AssistedWelcome, SerializedMlsMessage},
     openmls::{
         group::StagedCommit,
@@ -371,7 +374,6 @@ impl DsGroupState {
             self.update_membership_profiles(&add_users_state.added_users)?;
         }
 
-        // Persist staged welcome info if any
         self.stage_welcome_info(retained_welcome_info);
 
         #[cfg(debug_assertions)]
@@ -485,13 +487,15 @@ impl DsGroupState {
         // Now we have to update the group state and distribute.
 
         // We first accept the message into the group state ...
-        let t_retained_welcome_info =
-            ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
-                .accept_apq_processed_message(
-                    t_group_state.provider.storage(),
-                    pq_group_state.provider.storage(),
-                    processed_assisted_message,
-                )?;
+        let ApqRetainedWelcomeInfo {
+            t_retained_welcome_info,
+            pq_retained_welcome_info,
+        } = ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
+            .accept_apq_processed_message(
+                t_group_state.provider.storage(),
+                pq_group_state.provider.storage(),
+                processed_assisted_message,
+            )?;
 
         // Process removes
         t_group_state.remove_profiles(t_removed_clients);
@@ -499,11 +503,13 @@ impl DsGroupState {
         // Update membership profiles for added users
         if let Some(ref add_users_state) = t_add_users_state {
             t_group_state.update_membership_profiles(&add_users_state.added_users)?;
-            t_group_state.stage_welcome_info(t_retained_welcome_info);
         }
 
         #[cfg(debug_assertions)]
         t_group_state.check_member_profiles("apq_commit");
+
+        t_group_state.stage_welcome_info(t_retained_welcome_info);
+        pq_group_state.stage_welcome_info_without_profile_keys(pq_retained_welcome_info);
 
         // Process resync operations
         if let Some((encrypted_user_profile_key, client_queue_config)) = external_sender_information

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -15,32 +15,37 @@ use aircommon::{
         errors::{DecryptionError, EncryptionError},
     },
     identifiers::{QsReference, SealedClientReference},
-    messages::client_ds::WelcomeInfoParams,
     mls_group_config::leaf_node_is_virtual_client,
     time::TimeStamp,
 };
 use airprotos::client::component::AirComponent;
 use apqmls::extension::ApqInfo;
-use mimi_room_policy::{MimiProposal, RoleIndex, VerifiedRoomState};
+use mimi_room_policy::{MimiProposal, RoleIndex, RoomState, VerifiedRoomState};
 use mls_assist::{
     MlsAssistRustCrypto,
-    group::Group,
+    group::{Group, RetainedWelcomeInfo},
     openmls::{
         group::GroupId,
         prelude::{GroupEpoch, LeafNodeIndex, StagedCommit},
-        treesync::RatchetTree,
     },
     provider_traits::MlsAssistProvider,
 };
-use sqlx::PgExecutor;
+use sqlx::{PgExecutor, PgTransaction};
 use thiserror::Error;
 use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize, VLBytes};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::errors::{CborMlsAssistStorage, StorageError};
+use crate::{
+    ds::{WELCOME_INFO_EXPIRATION, welcome_info::WelcomeInfoWriteError},
+    errors::{CborMlsAssistStorage, StorageError},
+};
 
-use super::{GROUP_STATE_EXPIRATION, ReservedGroupId, process::ExternalCommitInfo};
+use super::{
+    GROUP_STATE_EXPIRATION, ReservedGroupId,
+    process::ExternalCommitInfo,
+    welcome_info::{DsWelcomeInfo, WelcomeInfoOutbox},
+};
 
 pub(super) mod persistence;
 
@@ -56,20 +61,20 @@ pub(super) struct MemberProfile {
 /// The `DsGroupState` is the per-group state that the DS persists.
 /// It is encrypted-at-rest with a roster key.
 ///
-/// TODO: Past group states are now included in mls-assist. However, we might
-/// have to store user credentials externally.
+/// TODO: We might have to store user credentials externally.
 pub(crate) struct DsGroupState {
     pub(super) room_state: VerifiedRoomState,
     pub(super) group: Group,
     pub(super) provider: MlsAssistRustCrypto<PersistenceCodec>,
     pub(super) member_profiles: BTreeMap<LeafNodeIndex, MemberProfile>,
     pub(super) proposals: Vec<Vec<u8>>,
-    /// Profile keys at each epoch a Welcome could have been issued at.
-    pub(super) past_member_profiles: BTreeMap<GroupEpoch, PastMemberProfiles>,
+
+    /// Transient container for welcome infos (produced on `Add` proposals)
+    /// that we need to persist for a later client to fetch.
+    welcome_info_outbox: WelcomeInfoOutbox,
 }
 
-/// What a joiner needs about one epoch, with the time it was taken so it can
-/// expire alongside the ratchet tree it belongs to.
+/// What a joiner needs about one epoch, as V3 stored it.
 #[derive(Debug, TlsSize, TlsDeserializeBytes, TlsSerialize)]
 pub(super) struct PastMemberProfiles {
     pub(super) created_at: TimeStamp,
@@ -95,13 +100,14 @@ impl DsGroupState {
         };
 
         let client_profiles = [(LeafNodeIndex::new(0u32), creator_client_profile)].into();
+
         Self {
             provider,
             group,
             room_state,
             member_profiles: client_profiles,
             proposals: Vec::new(),
-            past_member_profiles: BTreeMap::new(),
+            welcome_info_outbox: WelcomeInfoOutbox::default(),
         }
     }
 
@@ -165,79 +171,32 @@ impl DsGroupState {
         &self.group
     }
 
-    /// Get a mutable reference to the public group state.
-    pub(crate) fn group_mut(&mut self) -> &mut Group {
-        &mut self.group
-    }
-
-    pub(super) fn welcome_info(
-        &mut self,
-        welcome_info_params: WelcomeInfoParams,
-    ) -> Option<&RatchetTree> {
-        self.group_mut().past_group_state(
-            &welcome_info_params.epoch,
-            &welcome_info_params.sender.into(),
-        )
-    }
-
-    /// Records the current profile keys against `epoch`.
-    pub(super) fn snapshot_member_profiles(&mut self, epoch: GroupEpoch) {
+    /// Stage the welcome information for the epoch `retained` refers to.
+    ///
+    /// Must be called after the commit's membership changes have been applied,
+    /// so the recorded profile keys are the ones a joiner at that epoch needs.
+    pub(super) fn stage_welcome_info(&mut self, retained: Option<RetainedWelcomeInfo>) {
+        let Some(retained) = retained else { return };
         let profiles = self.current_member_profiles().collect();
-        let room_state = match PersistenceCodec::to_vec(self.room_state.unverified()) {
-            Ok(bytes) => bytes.into(),
-            Err(error) => {
-                // Without the snapshot a later join falls back to current-epoch
-                // data, which is the behaviour this replaces. It must not fail
-                // the commit being applied.
-                error!(%error, "failed to snapshot room state; skipping this epoch");
-                return;
-            }
-        };
-        self.past_member_profiles.insert(
-            epoch,
-            PastMemberProfiles {
-                created_at: TimeStamp::now(),
-                profiles,
-                room_state,
-            },
-        );
+        let (epoch, info) = DsWelcomeInfo::new(retained, profiles, &self.room_state);
+        self.welcome_info_outbox
+            .stage(epoch, TimeStamp::now(), info);
     }
 
-    /// Drops snapshots older than the retention used for past group states, so
-    /// this map cannot outgrow the trees it shadows.
-    fn prune_past_member_profiles(&mut self) {
-        self.past_member_profiles
-            .retain(|_, snapshot| !snapshot.created_at.has_expired(GROUP_STATE_EXPIRATION));
+    pub(super) async fn write_staged_welcome_infos(
+        &mut self,
+        txn: &mut PgTransaction<'_>,
+        group_id: Uuid,
+        ear_key: &GroupStateEarKey,
+    ) -> Result<(), WelcomeInfoWriteError> {
+        let outbox = std::mem::take(&mut self.welcome_info_outbox);
+        outbox.write(txn, group_id, ear_key).await
     }
 
-    /// The room state as of `epoch`, falling back to the current one when
-    /// no snapshot was retained (a group written before this was introduced,
-    /// or an epoch whose snapshot has expired).
-    pub(super) fn room_state_at(&self, epoch: GroupEpoch) -> VerifiedRoomState {
-        self.past_member_profiles
-            .get(&epoch)
-            .and_then(|snapshot| {
-                let unverified = PersistenceCodec::from_slice(snapshot.room_state.as_slice())
-                    .inspect_err(|error| error!(%error, "failed to load snapshotted room state"))
-                    .ok()?;
-                VerifiedRoomState::verify(unverified)
-                    .inspect_err(|error| error!(%error, "failed to verify snapshotted room state"))
-                    .ok()
-            })
-            .unwrap_or_else(|| self.room_state.clone())
-    }
-
-    /// The profile keys as of `epoch`, falling back to the current ones when
-    /// no snapshot was retained (a group written before this was introduced,
-    /// or an epoch whose snapshot has expired).
-    pub(super) fn member_profiles_at(
-        &self,
-        epoch: GroupEpoch,
-    ) -> Vec<(LeafNodeIndex, EncryptedUserProfileKey)> {
-        match self.past_member_profiles.get(&epoch) {
-            Some(snapshot) => snapshot.profiles.clone(),
-            None => self.current_member_profiles().collect(),
-        }
+    /// Serve welcome information from a V3 group state, for a joiner whose
+    /// Welcome predates the move to `ds_welcome_info`.
+    pub(super) fn legacy_welcome_info(self, epoch: GroupEpoch) -> Option<DsWelcomeInfo> {
+        self.welcome_info_outbox.take(epoch)
     }
 
     pub(super) fn external_commit_info(&self) -> ExternalCommitInfo {
@@ -264,12 +223,11 @@ impl DsGroupState {
     }
 
     pub(super) fn encrypt(
-        mut self,
+        self,
         ear_key: &GroupStateEarKey,
     ) -> Result<EncryptedDsGroupState, DsGroupStateEncryptionError> {
-        self.prune_past_member_profiles();
         let encrypted =
-            EncryptableDsGroupState::from(SerializableDsGroupStateV3::from_group_state(self)?)
+            EncryptableDsGroupState::from(SerializableDsGroupStateV4::from_group_state(self)?)
                 .encrypt(ear_key)?;
         Ok(encrypted)
     }
@@ -279,7 +237,7 @@ impl DsGroupState {
         ear_key: &GroupStateEarKey,
     ) -> Result<Self, DsGroupStateDecryptionError> {
         let encryptable = EncryptableDsGroupState::decrypt(ear_key, encrypted_group_state)?;
-        let group_state = SerializableDsGroupStateV3::into_group_state(encryptable.into())?;
+        let group_state = DecodedDsGroupState::from(encryptable).into_group_state()?;
         Ok(group_state)
     }
 
@@ -428,6 +386,10 @@ impl<const LOADED_FOR_UPDATE: bool> StorableDsGroupData<LOADED_FOR_UPDATE> {
     pub(super) fn has_expired(&self) -> bool {
         self.last_used.has_expired(GROUP_STATE_EXPIRATION)
     }
+
+    pub(super) fn group_uuid(&self) -> Uuid {
+        self.group_id
+    }
 }
 
 #[derive(TlsSize, TlsDeserializeBytes, TlsSerialize)]
@@ -486,7 +448,42 @@ pub(crate) struct SerializableDsGroupStateV3 {
     past_member_profiles: Vec<(GroupEpoch, PastMemberProfiles)>,
 }
 
-impl SerializableDsGroupStateV3 {
+impl From<SerializableDsGroupStateV3> for DecodedDsGroupState {
+    fn from(v3: SerializableDsGroupStateV3) -> Self {
+        Self {
+            state: SerializableDsGroupStateV4 {
+                group_id: v3.group_id,
+                serialized_provider: v3.serialized_provider,
+                room_state: v3.room_state,
+                member_profiles: v3.member_profiles,
+                proposals: v3.proposals,
+            },
+            // Kept for migration: a joiner whose Welcome
+            // predates `ds_welcome_info` is still served from these.
+            legacy_past_member_profiles: v3.past_member_profiles,
+        }
+    }
+}
+
+/// Welcome information lives in `ds_welcome_info` from V4 on.
+#[derive(TlsSize, TlsDeserializeBytes, TlsSerialize)]
+pub(crate) struct SerializableDsGroupStateV4 {
+    group_id: GroupId,
+    serialized_provider: VLBytes,
+    room_state: VLBytes,
+    member_profiles: Vec<(LeafNodeIndex, MemberProfile)>,
+    // Proposals that are valid in external commits in TLS-serialized form
+    proposals: Vec<Vec<u8>>,
+}
+
+/// A decoded group state, plus whatever legacy welcome information
+/// the blob came with.
+pub(super) struct DecodedDsGroupState {
+    state: SerializableDsGroupStateV4,
+    legacy_past_member_profiles: Vec<(GroupEpoch, PastMemberProfiles)>,
+}
+
+impl SerializableDsGroupStateV4 {
     pub(super) fn from_group_state(
         group_state: DsGroupState,
     ) -> Result<Self, aircommon::codec::Error> {
@@ -505,18 +502,21 @@ impl SerializableDsGroupStateV3 {
             member_profiles: client_profiles,
             room_state,
             proposals: group_state.proposals,
-            past_member_profiles: group_state.past_member_profiles.into_iter().collect(),
         })
     }
+}
 
+impl DecodedDsGroupState {
     pub(super) fn into_group_state(self) -> Result<DsGroupState, aircommon::codec::Error> {
-        let storage = CborMlsAssistStorage::deserialize(self.serialized_provider.as_slice())?;
+        let state = self.state;
+        let storage = CborMlsAssistStorage::deserialize(state.serialized_provider.as_slice())?;
         // We unwrap here, because the constructor ensures that `self` always stores a group
-        let group = Group::load(&storage, &self.group_id)?.unwrap();
-        let client_profiles = self.member_profiles.into_iter().collect();
+        let mut group = Group::load(&storage, &state.group_id)?.unwrap();
+        let client_profiles: BTreeMap<LeafNodeIndex, MemberProfile> =
+            state.member_profiles.into_iter().collect();
         let provider = MlsAssistRustCrypto::from(storage);
 
-        let room_state = PersistenceCodec::from_slice(self.room_state.as_slice())
+        let room_state = PersistenceCodec::from_slice(state.room_state.as_slice())
             .inspect_err(|error| {
                 error!(%error, "Failed to load room state. Falling back to default room state.");
             })
@@ -528,15 +528,55 @@ impl SerializableDsGroupStateV3 {
             })
             .unwrap_or_else(|| fallback_room_state(group.members()));
 
+        let mut legacy_past_member_profiles: BTreeMap<_, _> =
+            self.legacy_past_member_profiles.into_iter().collect();
+
+        let mut staged_welcome_info = WelcomeInfoOutbox::default();
+        for legacy in group.take_legacy_past_group_states() {
+            if TimeStamp::from(legacy.creation_time).has_expired(WELCOME_INFO_EXPIRATION) {
+                continue;
+            }
+            // Absent snapshots fall back to the current profiles and room
+            // state, which is what serving this epoch did before.
+            let (profiles, room_state) = match legacy_past_member_profiles.remove(&legacy.epoch) {
+                Some(snapshot) => (snapshot.profiles, decode_room_state(&snapshot.room_state)),
+                None => {
+                    let current_member_profiles = client_profiles
+                        .iter()
+                        .map(|(index, profile)| {
+                            (*index, profile.encrypted_user_profile_key.clone())
+                        })
+                        .collect();
+
+                    (
+                        current_member_profiles,
+                        Some(room_state.unverified().clone()),
+                    )
+                }
+            };
+
+            let (epoch, created_at, info) =
+                DsWelcomeInfo::from_legacy(legacy, profiles, room_state);
+
+            staged_welcome_info.stage(epoch, created_at, info);
+        }
+
         Ok(DsGroupState {
             provider,
             group,
             member_profiles: client_profiles,
             room_state,
-            proposals: self.proposals,
-            past_member_profiles: self.past_member_profiles.into_iter().collect(),
+            proposals: state.proposals,
+            welcome_info_outbox: staged_welcome_info,
         })
     }
+}
+
+/// Decode a room state snapshotted by V3.
+fn decode_room_state(bytes: &VLBytes) -> Option<RoomState> {
+    PersistenceCodec::from_slice(bytes.as_slice())
+        .inspect_err(|error| error!(%error, "failed to load snapshotted room state"))
+        .ok()
 }
 
 /// Check that a leaf credential matches the group kind.
@@ -578,23 +618,31 @@ pub(super) enum EncryptableDsGroupState {
     V1(SerializableDsGroupStateV1),
     V2(SerializableDsGroupStateV2),
     V3(SerializableDsGroupStateV3),
+    V4(SerializableDsGroupStateV4),
 }
 
-impl From<EncryptableDsGroupState> for SerializableDsGroupStateV3 {
+impl From<EncryptableDsGroupState> for DecodedDsGroupState {
     fn from(encryptable: EncryptableDsGroupState) -> Self {
         match encryptable {
             EncryptableDsGroupState::V1(serializable) => {
-                SerializableDsGroupStateV2::from(serializable).into()
+                SerializableDsGroupStateV3::from(SerializableDsGroupStateV2::from(serializable))
+                    .into()
             }
-            EncryptableDsGroupState::V2(serializable) => serializable.into(),
-            EncryptableDsGroupState::V3(serializable) => serializable,
+            EncryptableDsGroupState::V2(serializable) => {
+                SerializableDsGroupStateV3::from(serializable).into()
+            }
+            EncryptableDsGroupState::V3(serializable) => serializable.into(),
+            EncryptableDsGroupState::V4(serializable) => Self {
+                state: serializable,
+                legacy_past_member_profiles: Vec::new(),
+            },
         }
     }
 }
 
-impl From<SerializableDsGroupStateV3> for EncryptableDsGroupState {
-    fn from(serializable: SerializableDsGroupStateV3) -> Self {
-        EncryptableDsGroupState::V3(serializable)
+impl From<SerializableDsGroupStateV4> for EncryptableDsGroupState {
+    fn from(serializable: SerializableDsGroupStateV4) -> Self {
+        EncryptableDsGroupState::V4(serializable)
     }
 }
 
@@ -621,6 +669,47 @@ mod test {
     fn test_encrypted_ds_group_state_serde_json() {
         let state = EncryptedDsGroupState::dummy();
         insta::assert_json_snapshot!(state);
+    }
+
+    #[test]
+    fn v3_welcome_info_survives_decoding() {
+        let epoch = GroupEpoch::from(4);
+        let v3 = SerializableDsGroupStateV3 {
+            group_id: GroupId::from_slice(b"group"),
+            serialized_provider: vec![].into(),
+            room_state: vec![].into(),
+            member_profiles: Vec::new(),
+            proposals: Vec::new(),
+            past_member_profiles: vec![(
+                epoch,
+                PastMemberProfiles {
+                    created_at: TimeStamp::now(),
+                    profiles: vec![(LeafNodeIndex::new(0), EncryptedUserProfileKey::dummy())],
+                    room_state: vec![1u8, 2, 3].into(),
+                },
+            )],
+        };
+
+        let decoded = DecodedDsGroupState::from(EncryptableDsGroupState::V3(v3));
+
+        assert_eq!(decoded.legacy_past_member_profiles.len(), 1);
+        assert_eq!(decoded.legacy_past_member_profiles[0].0, epoch);
+    }
+
+    /// V4 writes no welcome information, so there is nothing to migrate.
+    #[test]
+    fn v4_carries_no_legacy_welcome_info() {
+        let v4 = SerializableDsGroupStateV4 {
+            group_id: GroupId::from_slice(b"group"),
+            serialized_provider: vec![].into(),
+            room_state: vec![].into(),
+            member_profiles: Vec::new(),
+            proposals: Vec::new(),
+        };
+
+        let decoded = DecodedDsGroupState::from(EncryptableDsGroupState::V4(v4));
+
+        assert!(decoded.legacy_past_member_profiles.is_empty());
     }
 
     #[test]

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -177,8 +177,25 @@ impl DsGroupState {
     /// so the recorded profile keys are the ones a joiner at that epoch needs.
     pub(super) fn stage_welcome_info(&mut self, retained: Option<RetainedWelcomeInfo>) {
         let Some(retained) = retained else { return };
-        let profiles = self.current_member_profiles().collect();
-        let (epoch, info) = DsWelcomeInfo::new(retained, profiles, &self.room_state);
+        let (epoch, info) = DsWelcomeInfo::new(
+            retained,
+            self.current_member_profiles().collect(),
+            &self.room_state,
+        );
+        self.welcome_info_outbox
+            .stage(epoch, TimeStamp::now(), info);
+    }
+
+    /// Same as [`stage_welcome_info`] but
+    /// without member profile keys as an optimisation.
+    ///
+    /// The client never uses them from the PQ leg of an APQ group.
+    pub(super) fn stage_welcome_info_without_profile_keys(
+        &mut self,
+        retained: Option<RetainedWelcomeInfo>,
+    ) {
+        let Some(retained) = retained else { return };
+        let (epoch, info) = DsWelcomeInfo::new(retained, Vec::new(), &self.room_state);
         self.welcome_info_outbox
             .stage(epoch, TimeStamp::now(), info);
     }

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -567,6 +567,7 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
 
         self.cleanup_after_commit(t_qgid.group_uuid(), t_new_epoch)
             .await;
+        self.sweep_welcome_info(pq_qgid.group_uuid()).await;
 
         Ok(value)
     }

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -14,7 +14,7 @@ use aircommon::{
     identifiers::{self, Fqdn, QualifiedGroupId},
     messages::client_ds::{
         self, GroupOperationParams, JoinConnectionGroupParams, QsQueueMessagePayload,
-        UserProfileKeyUpdateParams, WelcomeInfoParams,
+        UserProfileKeyUpdateParams,
     },
     mls_group_config::MAX_PAST_EPOCHS,
     time::TimeStamp,
@@ -34,7 +34,9 @@ use mimi_room_policy::VerifiedRoomState;
 use mls_assist::{
     group::Group,
     messages::{AssistedMessageIn, SerializedMlsMessage},
-    openmls::prelude::{LeafNodeIndex, MlsMessageBodyIn, MlsMessageIn, RatchetTreeIn, Sender},
+    openmls::prelude::{
+        LeafNodeIndex, MlsMessageBodyIn, MlsMessageIn, RatchetTreeIn, Sender, SignaturePublicKey,
+    },
 };
 use semver::Version;
 use sqlx::{PgConnection, PgTransaction};
@@ -55,9 +57,10 @@ use crate::{
 };
 
 use super::{
-    Ds,
+    Ds, WELCOME_INFO_EXPIRATION,
     group_operation::AddUsersState,
     group_state::{DsGroupState, StorableDsGroupData},
+    welcome_info::DsWelcomeInfo,
 };
 
 pub struct GrpcDs<Qep: QsConnector, As: AsConnector> {
@@ -123,6 +126,7 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
         //    return Err(LoadGroupStateError::Expired);
         //}
         let group_state = DsGroupState::decrypt(&group_data.encrypted_group_state, ear_key)?;
+
         Ok((group_data, group_state))
     }
 
@@ -281,15 +285,22 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
         &self,
         txn: &mut PgTransaction<'_>,
         mut group_data: StorableDsGroupData<true>,
-        group_state: DsGroupState,
+        mut group_state: DsGroupState,
         ear_key: &GroupStateEarKey,
     ) -> Result<(), Status> {
+        let group_id = group_data.group_uuid();
+
+        group_state
+            .write_staged_welcome_infos(txn, group_id, ear_key)
+            .await?;
+
         let encrypted_group_state = group_state.encrypt(ear_key)?;
         group_data.encrypted_group_state = encrypted_group_state;
         group_data.update(txn).await.map_err(|error| {
             error!(%error, "Failed to update group state");
             Status::internal("Failed to update group state")
         })?;
+
         Ok(())
     }
 
@@ -311,6 +322,8 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
 
         let value = f(&mut group_state, &mut group_data).await?;
         let new_epoch = group_state.group().epoch().as_u64();
+        // These callers never reach a new epoch a Welcome could refer to, so
+        // the outbox only ever carries migrated legacy entries.
         self.encrypt_and_persist(&mut txn, group_data, group_state, ear_key)
             .await?;
 
@@ -319,10 +332,20 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
             Status::internal("Failed to commit transaction")
         })?;
 
-        // Best-effort cleanup: the transaction is already committed, so failures here are non-fatal.
+        self.cleanup_after_commit(qgid.group_uuid(), new_epoch)
+            .await;
+
+        Ok(value)
+    }
+
+    /// Best-effort cleanup of the per-epoch tables of a group.
+    ///
+    /// Called after the transaction is committed, so failures here are
+    /// non-fatal: the next commit sweeps again.
+    async fn cleanup_after_commit(&self, group_id: uuid::Uuid, new_epoch: u64) {
         super::collision_tags::delete_old(
             &self.ds.db_pool,
-            qgid.group_uuid(),
+            group_id,
             new_epoch,
             MAX_PAST_EPOCHS as u64,
         )
@@ -332,7 +355,17 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
         })
         .ok();
 
-        Ok(value)
+        self.sweep_welcome_info(group_id).await;
+    }
+
+    /// Best-effort sweep of a group's expired welcome information.
+    async fn sweep_welcome_info(&self, group_id: uuid::Uuid) {
+        DsWelcomeInfo::delete_expired(&self.ds.db_pool, group_id, WELCOME_INFO_EXPIRATION)
+            .await
+            .inspect_err(|error| {
+                error!(%error, "Failed to clean up expired welcome info");
+            })
+            .ok();
     }
 
     /// Verifies the given request and applies the necessary changes to the
@@ -388,16 +421,8 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
             Status::internal("Failed to commit transaction")
         })?;
 
-        // Best-effort cleanup: the transaction is already committed, so failures here are non-fatal.
-        super::collision_tags::delete_old(
-            &self.ds.db_pool,
-            qgid.group_uuid(),
-            new_epoch,
-            MAX_PAST_EPOCHS as u64,
-        )
-        .await
-        .inspect_err(|error| error!(%error, "Failed to clean up old collision tags"))
-        .ok();
+        self.cleanup_after_commit(qgid.group_uuid(), new_epoch)
+            .await;
 
         Ok(value)
     }
@@ -540,18 +565,8 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
             };
         }
 
-        // Best-effort cleanup: the transaction is already committed, so failures here are non-fatal.
-        super::collision_tags::delete_old(
-            &self.ds.db_pool,
-            t_qgid.group_uuid(),
-            t_new_epoch,
-            MAX_PAST_EPOCHS as u64,
-        )
-        .await
-        .inspect_err(|error| {
-            error!(%error, "Failed to clean up old collision tags");
-        })
-        .ok();
+        self.cleanup_after_commit(t_qgid.group_uuid(), t_new_epoch)
+            .await;
 
         Ok(value)
     }
@@ -976,24 +991,50 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
 
         let qgid = payload.validated_qgid(&self.ds.own_domain)?;
         let ear_key = payload.ear_key()?;
-        let (_, mut group_state) = self
-            .load_group_state_immutable(&qgid, &ear_key)
-            .await
-            .map_err(to_status)?;
-
         let welcome_epoch = payload.epoch.ok_or_missing_field("epoch")?.into();
-        let welcome_info_params = WelcomeInfoParams {
-            sender: sender.clone(),
-            epoch: welcome_epoch,
-            group_id: qgid.into(),
-        };
-        let profiles_at_epoch = group_state.member_profiles_at(welcome_epoch);
-        let room_state_at_epoch = group_state.room_state_at(welcome_epoch);
-        let ratchet_tree = group_state
-            .welcome_info(welcome_info_params)
-            .ok_or(NoWelcomeInfoFound)?;
+        let joiner = SignaturePublicKey::from(sender);
 
-        let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) = profiles_at_epoch
+        let encrypted_record =
+            DsWelcomeInfo::load(&self.ds.db_pool, qgid.group_uuid(), welcome_epoch)
+                .await
+                .map_err(|error| {
+                    error!(%error, "Failed to load welcome info");
+                    Status::internal("Failed to load welcome info")
+                })?;
+
+        // Both the wrong key and a joiner this epoch never added look the same
+        // from the outside, so the endpoint does not report whether the row is
+        // there.
+        let ds_welcome_info = match encrypted_record {
+            Some(ciphertext) => {
+                DsWelcomeInfo::decrypt(&ear_key, &ciphertext, qgid.group_uuid(), welcome_epoch)
+                    .map_err(|error| {
+                        warn!(%error, "Failed to decrypt welcome info");
+                        NoWelcomeInfoFound
+                    })?
+            }
+            // A Welcome issued before the move to `ds_welcome_info`. Remove with
+            // the rest of the legacy path.
+            None => {
+                let (_, group_state) = self
+                    .load_group_state_immutable(&qgid, &ear_key)
+                    .await
+                    .map_err(to_status)?;
+                group_state
+                    .legacy_welcome_info(welcome_epoch)
+                    .ok_or(NoWelcomeInfoFound)?
+            }
+        };
+
+        if !ds_welcome_info.is_authorized(&joiner) {
+            return Err(NoWelcomeInfoFound.into());
+        }
+        let (ratchet_tree, profiles, room_state) =
+            ds_welcome_info.into_parts().ok_or(NoWelcomeInfoFound)?;
+
+        let ratchet_tree = ratchet_tree.try_ref_into().invalid_tls("ratchet_tree")?;
+
+        let (encrypted_user_profile_keys, indexed_encrypted_user_profile_keys) = profiles
             .into_iter()
             .fold((Vec::new(), Vec::new()), |(mut a, mut b), (index, key)| {
                 a.push(key.clone().into());
@@ -1005,10 +1046,10 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
             });
 
         Ok(Response::new(WelcomeInfoResponse {
-            ratchet_tree: Some(ratchet_tree.try_ref_into().invalid_tls("ratchet_tree")?),
+            ratchet_tree: Some(ratchet_tree),
             encrypted_user_profile_keys,
             room_state: Some(
-                room_state_at_epoch
+                room_state
                     .unverified()
                     .try_ref_into()
                     .invalid_tls("room_state")?,

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -5,7 +5,7 @@
 use aircommon::{
     credentials::LeafCredential,
     messages::client_ds::{AadMessage, AadPayload, JoinConnectionGroupParams},
-    time::{Duration, TimeStamp},
+    time::TimeStamp,
 };
 use mls_assist::{
     group::ProcessedAssistedMessage, messages::SerializedMlsMessage,
@@ -15,10 +15,7 @@ use tls_codec::DeserializeBytes;
 
 use crate::errors::JoinConnectionGroupError;
 
-use super::{
-    group_state::{DsGroupState, MemberProfile, leaf_credential_matches_flag},
-    process::USER_EXPIRATION_DAYS,
-};
+use super::group_state::{DsGroupState, MemberProfile, leaf_credential_matches_flag};
 
 impl DsGroupState {
     pub(super) fn join_connection_group(
@@ -106,10 +103,9 @@ impl DsGroupState {
         let sender_credential = processed_message.credential().clone();
 
         // Finalize processing.
-        self.group.accept_processed_message(
+        let retained_welcome_info = self.group.accept_processed_message(
             self.provider.storage(),
             processed_assisted_message_plus.processed_assisted_message,
-            Duration::days(USER_EXPIRATION_DAYS),
         )?;
 
         // Let's figure out the leaf index of the new member.
@@ -135,6 +131,7 @@ impl DsGroupState {
         };
 
         self.member_profiles.insert(sender, member_profile);
+        self.stage_welcome_info(retained_welcome_info);
 
         // Finally, we create the message for distribution.
         Ok(processed_assisted_message_plus.serialized_mls_message)

--- a/backend/src/ds/mod.rs
+++ b/backend/src/ds/mod.rs
@@ -29,10 +29,14 @@ mod resync;
 mod self_remove;
 pub mod storage;
 mod update_user_profile_key;
+mod welcome_info;
 
 /// Number of days after its last use upon which a group state is considered
 /// expired.
 pub const GROUP_STATE_EXPIRATION: Duration = Duration::days(90);
+
+/// How long the welcome information of an epoch is kept.
+pub const WELCOME_INFO_EXPIRATION: Duration = Duration::days(7);
 
 #[derive(Debug, Clone)]
 pub struct Ds {

--- a/backend/src/ds/mod.rs
+++ b/backend/src/ds/mod.rs
@@ -36,7 +36,7 @@ mod welcome_info;
 pub const GROUP_STATE_EXPIRATION: Duration = Duration::days(90);
 
 /// How long the welcome information of an epoch is kept.
-pub const WELCOME_INFO_EXPIRATION: Duration = Duration::days(7);
+pub const WELCOME_INFO_EXPIRATION: Duration = Duration::days(90);
 
 #[derive(Debug, Clone)]
 pub struct Ds {

--- a/backend/src/ds/process.rs
+++ b/backend/src/ds/process.rs
@@ -161,7 +161,6 @@ use aircommon::{
 
 use super::Ds;
 
-pub const USER_EXPIRATION_DAYS: i64 = 90;
 pub(super) type Provider = MlsAssistRustCrypto<PersistenceCodec>;
 
 impl Ds {

--- a/backend/src/ds/resync.rs
+++ b/backend/src/ds/resync.rs
@@ -8,7 +8,10 @@ use aircommon::{
 };
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
-    group::{ProcessedAssistedMessage, apq::ApqGroupRef},
+    group::{
+        ProcessedAssistedMessage,
+        apq::{ApqGroupRef, ApqRetainedWelcomeInfo},
+    },
     messages::SerializedMlsMessage,
     openmls::prelude::Sender,
     provider_traits::MlsAssistProvider,
@@ -187,7 +190,6 @@ impl DsGroupState {
         #[cfg(debug_assertions)]
         self.check_member_profiles("resync");
 
-        // Persist staged welcome info if any
         self.stage_welcome_info(retained_welcome_info);
 
         Ok(ResyncOutcome {
@@ -342,7 +344,10 @@ impl DsGroupState {
         // Everything seems to be okay.
         // Now we have to update the group state and distribute.
 
-        ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
+        let ApqRetainedWelcomeInfo {
+            t_retained_welcome_info,
+            pq_retained_welcome_info,
+        } = ApqGroupRef::from_groups(&mut t_group_state.group, &mut pq_group_state.group)
             .accept_apq_processed_message(
                 t_group_state.provider.storage(),
                 pq_group_state.provider.storage(),
@@ -356,6 +361,9 @@ impl DsGroupState {
 
         #[cfg(debug_assertions)]
         t_group_state.check_member_profiles("resync_apq");
+
+        t_group_state.stage_welcome_info(t_retained_welcome_info);
+        pq_group_state.stage_welcome_info_without_profile_keys(pq_retained_welcome_info);
 
         Ok(ResyncOutcome {
             message: processed_assisted_message_plus.serialized_apq_message,

--- a/backend/src/ds/resync.rs
+++ b/backend/src/ds/resync.rs
@@ -4,7 +4,7 @@
 
 use aircommon::{
     credentials::LeafCredential, identifiers::QsReference,
-    mls_group_config::leaf_node_is_virtual_client, time::Duration, utils::removed_clients,
+    mls_group_config::leaf_node_is_virtual_client, utils::removed_clients,
 };
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
@@ -22,7 +22,6 @@ use tracing::error;
 use crate::errors::ResyncClientError;
 
 use super::group_state::{DsGroupState, leaf_credential_matches_flag};
-use super::process::USER_EXPIRATION_DAYS;
 
 /// Outcome of a resync: the message to distribute, plus the queue of the leaf the
 /// resync replaced when that leaf is being taken over by a sibling emulator
@@ -176,10 +175,9 @@ impl DsGroupState {
             })?;
 
         // We just accept the message into the group state.
-        self.group.accept_processed_message(
+        let retained_welcome_info = self.group.accept_processed_message(
             self.provider.storage(),
             processed_assisted_message_plus.processed_assisted_message,
-            Duration::days(USER_EXPIRATION_DAYS),
         )?;
 
         self.remove_profiles(removed_indices);
@@ -188,6 +186,9 @@ impl DsGroupState {
 
         #[cfg(debug_assertions)]
         self.check_member_profiles("resync");
+
+        // Persist staged welcome info if any
+        self.stage_welcome_info(retained_welcome_info);
 
         Ok(ResyncOutcome {
             message: processed_assisted_message_plus.serialized_mls_message,
@@ -346,7 +347,6 @@ impl DsGroupState {
                 t_group_state.provider.storage(),
                 pq_group_state.provider.storage(),
                 processed_assisted_message_plus.processed_assisted_message,
-                Duration::days(USER_EXPIRATION_DAYS),
             )?;
 
         t_group_state.remove_profiles(t_removed_indices);

--- a/backend/src/ds/self_remove.rs
+++ b/backend/src/ds/self_remove.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use super::group_state::DsGroupState;
-use super::process::USER_EXPIRATION_DAYS;
 use crate::errors::ClientSelfRemovalError;
-use aircommon::{credentials::LeafCredential, time::Duration};
+use aircommon::credentials::LeafCredential;
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
     group::ProcessedAssistedMessage,
@@ -82,10 +81,9 @@ impl DsGroupState {
         };
 
         // We first accept the message into the group state ...
-        self.group.accept_processed_message(
+        let retained_welcome_info = self.group.accept_processed_message(
             self.provider.storage(),
             processed_assisted_message_plus.processed_assisted_message,
-            Duration::days(USER_EXPIRATION_DAYS),
         )?;
 
         let serialized_mls_message = processed_assisted_message_plus.serialized_mls_message;
@@ -93,6 +91,9 @@ impl DsGroupState {
         // Store the proposal so we can send it to clients requesting external
         // commit info.
         self.proposals.push(serialized_mls_message.0.clone());
+
+        // Persist staged welcome info if any
+        self.stage_welcome_info(retained_welcome_info);
 
         // We remove the user and client profile only when the proposal is committed.
 

--- a/backend/src/ds/self_remove.rs
+++ b/backend/src/ds/self_remove.rs
@@ -92,7 +92,6 @@ impl DsGroupState {
         // commit info.
         self.proposals.push(serialized_mls_message.0.clone());
 
-        // Persist staged welcome info if any
         self.stage_welcome_info(retained_welcome_info);
 
         // We remove the user and client profile only when the proposal is committed.

--- a/backend/src/ds/welcome_info/mod.rs
+++ b/backend/src/ds/welcome_info/mod.rs
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! What a joiner needs about the epoch its Welcome refers to.
+//!
+//! One row per (group, epoch), each holding a padded-AEAD blob under the
+//! group's [`GroupStateEarKey`]. This used to live inside the group state --
+//! the retained ratchet trees dominated it, so every request paid for data only
+//! `welcome_info` ever reads.
+
+use aircommon::{
+    crypto::{
+        aead::{
+            Ciphertext, PaddedAeadDecryptable, PaddedAeadEncryptable,
+            keys::{EncryptedUserProfileKey, GroupStateEarKey},
+        },
+        errors::{DecryptionError, EncryptionError},
+    },
+    time::TimeStamp,
+};
+use airmacros::{DeserializeTaggedMap, SerializeTaggedMap};
+use mimi_room_policy::{RoomState, VerifiedRoomState};
+use mls_assist::{
+    group::{LegacyPastGroupState, RetainedWelcomeInfo},
+    openmls::{
+        prelude::{GroupEpoch, LeafNodeIndex, SignaturePublicKey},
+        treesync::RatchetTree,
+    },
+};
+use sqlx::PgConnection;
+use thiserror::Error;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::errors::StorageError;
+
+pub(super) mod persistence;
+
+#[derive(Debug)]
+pub struct EncryptedWelcomeInfoCtype;
+pub type EncryptedWelcomeInfo = Ciphertext<EncryptedWelcomeInfoCtype>;
+
+/// The welcome information for one epoch of one group.
+#[derive(Debug, Default, PartialEq, SerializeTaggedMap, DeserializeTaggedMap)]
+pub(super) struct DsWelcomeInfo {
+    /// The ratchet tree as of this epoch.
+    #[tag(1)]
+    pub(super) ratchet_tree: Option<RatchetTree>,
+    /// The only signature keys allowed to fetch this record.
+    #[tag(2)]
+    pub(super) potential_joiners: Vec<SignaturePublicKey>,
+    /// The profile keys as of this epoch. Empty for the PQ leg of an APQ group,
+    /// which only ever needs the tree.
+    #[tag(3)]
+    pub(super) profiles: Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
+    #[tag(4)]
+    pub(super) room_state: Option<RoomState>,
+}
+
+/// Binds a record to the group and epoch it was stored under. The EAR key is
+/// the same for every epoch of a group, so without this a row could be moved
+/// between epochs, or between the T and PQ legs, undetected.
+#[derive(Debug, SerializeTaggedMap)]
+struct WelcomeInfoAad {
+    #[tag(1)]
+    group_id: Uuid,
+    #[tag(2)]
+    epoch: u64,
+}
+
+impl PaddedAeadEncryptable<GroupStateEarKey, EncryptedWelcomeInfoCtype> for DsWelcomeInfo {}
+impl PaddedAeadDecryptable<GroupStateEarKey, EncryptedWelcomeInfoCtype> for DsWelcomeInfo {}
+
+impl DsWelcomeInfo {
+    /// A record for the epoch `retained` refers to, with the group's current
+    /// profile keys and room state.
+    pub(super) fn new(
+        retained: RetainedWelcomeInfo,
+        profiles: Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
+        room_state: &VerifiedRoomState,
+    ) -> (GroupEpoch, Self) {
+        let record = Self {
+            ratchet_tree: Some(retained.ratchet_tree),
+            potential_joiners: retained.potential_joiners,
+            profiles,
+            room_state: Some(room_state.unverified().clone()),
+        };
+        (retained.epoch, record)
+    }
+
+    /// A record built from a legacy in-group-state entry, carrying its original
+    /// creation time. However, we expire the old entry with the new shorter retention window.
+    pub(super) fn from_legacy(
+        legacy: LegacyPastGroupState,
+        profiles: Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
+        room_state: Option<RoomState>,
+    ) -> (GroupEpoch, TimeStamp, Self) {
+        let record = Self {
+            ratchet_tree: Some(legacy.ratchet_tree),
+            potential_joiners: legacy.potential_joiners,
+            profiles,
+            room_state,
+        };
+        (legacy.epoch, legacy.creation_time.into(), record)
+    }
+
+    pub(super) fn encrypt(
+        &self,
+        ear_key: &GroupStateEarKey,
+        group_id: Uuid,
+        epoch: GroupEpoch,
+    ) -> Result<EncryptedWelcomeInfo, EncryptionError> {
+        self.encrypt_padded_with_aad(ear_key, &WelcomeInfoAad::new(group_id, epoch))
+    }
+
+    pub(super) fn decrypt(
+        ear_key: &GroupStateEarKey,
+        ciphertext: &EncryptedWelcomeInfo,
+        group_id: Uuid,
+        epoch: GroupEpoch,
+    ) -> Result<Self, DecryptionError> {
+        Self::decrypt_padded_with_aad(ear_key, ciphertext, &WelcomeInfoAad::new(group_id, epoch))
+    }
+
+    /// Returns true if `joiner` is allowed to fetch this record.
+    pub(super) fn is_authorized(&self, joiner: &SignaturePublicKey) -> bool {
+        self.potential_joiners.contains(joiner)
+    }
+
+    /// The ratchet tree and room state, or `None` if either is missing or the
+    /// room state fails to verify.
+    pub(super) fn into_parts(
+        self,
+    ) -> Option<(
+        RatchetTree,
+        Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
+        VerifiedRoomState,
+    )> {
+        let ratchet_tree = self.ratchet_tree.or_else(|| {
+            error!("welcome info record without a ratchet tree");
+            None
+        })?;
+        let room_state = self.room_state.or_else(|| {
+            error!("welcome info record without a room state");
+            None
+        })?;
+        let room_state = VerifiedRoomState::verify(room_state)
+            .inspect_err(|error| error!(%error, "failed to verify stored room state"))
+            .ok()?;
+        Some((ratchet_tree, self.profiles, room_state))
+    }
+}
+
+impl WelcomeInfoAad {
+    fn new(group_id: Uuid, epoch: GroupEpoch) -> Self {
+        Self {
+            group_id,
+            epoch: epoch.as_u64(),
+        }
+    }
+}
+
+/// The welcome information one request produced for one group, to be written
+/// when that group's state is persisted.
+#[derive(Debug, Default)]
+pub(super) struct WelcomeInfoOutbox(Vec<(GroupEpoch, TimeStamp, DsWelcomeInfo)>);
+
+impl WelcomeInfoOutbox {
+    /// Stage a welcome info for persistence at the same time as an update to [`DsGroupState`].
+    pub(super) fn stage(&mut self, epoch: GroupEpoch, created_at: TimeStamp, info: DsWelcomeInfo) {
+        self.0.push((epoch, created_at, info));
+    }
+
+    /// Takes a single entry and discards the rest. This is used in the legacy path, where all entries
+    /// were in a single blob.
+    pub(super) fn take(self, epoch: GroupEpoch) -> Option<DsWelcomeInfo> {
+        self.0
+            .into_iter()
+            .find_map(|(welcome_info_epoch, _, info)| {
+                if epoch == welcome_info_epoch {
+                    Some(info)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Encrypt and store every staged welcome infos.
+    pub(super) async fn write(
+        self,
+        connection: &mut PgConnection,
+        group_id: Uuid,
+        ear_key: &GroupStateEarKey,
+    ) -> Result<(), WelcomeInfoWriteError> {
+        for (epoch, created_at, info) in self.0 {
+            let ciphertext = info.encrypt(ear_key, group_id, epoch)?;
+            DsWelcomeInfo::store(&mut *connection, group_id, epoch, &ciphertext, created_at)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub(super) enum WelcomeInfoWriteError {
+    #[error("Error encrypting welcome info: {0}")]
+    Encryption(#[from] EncryptionError),
+    #[error("Error storing welcome info: {0}")]
+    Storage(#[from] StorageError),
+}
+
+impl From<WelcomeInfoWriteError> for tonic::Status {
+    fn from(error: WelcomeInfoWriteError) -> Self {
+        error!(%error, "failed to write welcome info");
+        Self::internal("failed to write welcome info")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use aircommon::codec::PersistenceCodec;
+
+    use super::*;
+
+    fn record() -> DsWelcomeInfo {
+        DsWelcomeInfo {
+            ratchet_tree: None,
+            potential_joiners: vec![SignaturePublicKey::from(vec![1u8, 2, 3])],
+            profiles: vec![(LeafNodeIndex::new(1), EncryptedUserProfileKey::dummy())],
+            room_state: None,
+        }
+    }
+
+    #[test]
+    fn welcome_info_record_serde_codec() {
+        let bytes = PersistenceCodec::to_vec(&record()).unwrap();
+        let diag = cbor_diag::parse_bytes(&bytes[1..]).unwrap().to_hex();
+        insta::assert_snapshot!(diag);
+    }
+
+    #[test]
+    fn welcome_info_record_round_trip() {
+        let ear_key = GroupStateEarKey::random().unwrap();
+        let group_id = Uuid::new_v4();
+        let epoch = GroupEpoch::from(7);
+
+        let ciphertext = record().encrypt(&ear_key, group_id, epoch).unwrap();
+        let decrypted = DsWelcomeInfo::decrypt(&ear_key, &ciphertext, group_id, epoch).unwrap();
+
+        assert_eq!(decrypted, record());
+    }
+
+    /// Only the joiners the commit added may fetch the record.
+    #[test]
+    fn welcome_info_record_authorization() {
+        let record = record();
+
+        assert!(record.is_authorized(&SignaturePublicKey::from(vec![1u8, 2, 3])));
+        assert!(!record.is_authorized(&SignaturePublicKey::from(vec![4u8, 5, 6])));
+        assert!(
+            !DsWelcomeInfo::default().is_authorized(&SignaturePublicKey::from(vec![1u8, 2, 3]))
+        );
+    }
+
+    /// The AAD binds a record to its group and epoch, so a row moved to another
+    /// epoch (or another group) must not decrypt.
+    #[test]
+    fn welcome_info_record_aad_is_bound() {
+        let ear_key = GroupStateEarKey::random().unwrap();
+        let group_id = Uuid::new_v4();
+        let epoch = GroupEpoch::from(7);
+        let ciphertext = record().encrypt(&ear_key, group_id, epoch).unwrap();
+
+        assert!(
+            DsWelcomeInfo::decrypt(&ear_key, &ciphertext, group_id, GroupEpoch::from(8)).is_err()
+        );
+        assert!(DsWelcomeInfo::decrypt(&ear_key, &ciphertext, Uuid::new_v4(), epoch).is_err());
+    }
+
+    /// Unknown tags are ignored, so a record written by a later version that
+    /// added a field still reads.
+    #[test]
+    fn welcome_info_record_ignores_unknown_tags() {
+        #[derive(SerializeTaggedMap)]
+        struct FutureRecord {
+            #[tag(2)]
+            potential_joiners: Vec<SignaturePublicKey>,
+            #[tag(9)]
+            added_later: u64,
+        }
+
+        let future = FutureRecord {
+            potential_joiners: vec![SignaturePublicKey::from(vec![1u8, 2, 3])],
+            added_later: 42,
+        };
+        let bytes = PersistenceCodec::to_vec(&future).unwrap();
+        let decoded: DsWelcomeInfo = PersistenceCodec::from_slice(&bytes).unwrap();
+
+        assert_eq!(decoded.potential_joiners, future.potential_joiners);
+        assert_eq!(decoded.profiles, vec![]);
+    }
+}

--- a/backend/src/ds/welcome_info/mod.rs
+++ b/backend/src/ds/welcome_info/mod.rs
@@ -37,6 +37,12 @@ use crate::errors::StorageError;
 
 pub(super) mod persistence;
 
+pub(super) type WelcomeInfoParts = (
+    RatchetTree,
+    Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
+    VerifiedRoomState,
+);
+
 #[derive(Debug)]
 pub struct EncryptedWelcomeInfoCtype;
 pub type EncryptedWelcomeInfo = Ciphertext<EncryptedWelcomeInfoCtype>;
@@ -130,13 +136,7 @@ impl DsWelcomeInfo {
 
     /// The ratchet tree and room state, or `None` if either is missing or the
     /// room state fails to verify.
-    pub(super) fn into_parts(
-        self,
-    ) -> Option<(
-        RatchetTree,
-        Vec<(LeafNodeIndex, EncryptedUserProfileKey)>,
-        VerifiedRoomState,
-    )> {
+    pub(super) fn into_parts(self) -> Option<WelcomeInfoParts> {
         let ratchet_tree = self.ratchet_tree.or_else(|| {
             error!("welcome info record without a ratchet tree");
             None

--- a/backend/src/ds/welcome_info/persistence.rs
+++ b/backend/src/ds/welcome_info/persistence.rs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use aircommon::{
+    codec::{BlobDecoded, BlobEncoded},
+    time::{Duration, TimeStamp},
+};
+use mls_assist::openmls::prelude::GroupEpoch;
+use sqlx::{
+    PgExecutor, query, query_scalar,
+    types::chrono::{DateTime, Utc},
+};
+use uuid::Uuid;
+
+use crate::errors::StorageError;
+
+use super::{DsWelcomeInfo, EncryptedWelcomeInfo};
+
+impl DsWelcomeInfo {
+    /// Store the welcome information for one epoch.
+    ///
+    /// An epoch is reached at most once per group, so a conflict means the row is
+    /// already there and there is nothing to change.
+    pub(crate) async fn store(
+        connection: impl PgExecutor<'_>,
+        group_id: Uuid,
+        epoch: GroupEpoch,
+        ciphertext: &EncryptedWelcomeInfo,
+        created_at: TimeStamp,
+    ) -> Result<(), StorageError> {
+        query!(
+            "INSERT INTO
+            ds_welcome_info
+            (group_id, epoch, ciphertext, created_at)
+        VALUES
+            ($1, $2, $3, $4)
+        ON CONFLICT (group_id, epoch) DO NOTHING",
+            group_id,
+            epoch.as_u64() as i64,
+            BlobEncoded(ciphertext) as _,
+            DateTime::<Utc>::from(created_at),
+        )
+        .execute(connection)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn load(
+        connection: impl PgExecutor<'_>,
+        group_id: Uuid,
+        epoch: GroupEpoch,
+    ) -> Result<Option<EncryptedWelcomeInfo>, StorageError> {
+        let ciphertext = query_scalar!(
+            r#"SELECT
+            ciphertext AS "ciphertext: BlobDecoded<EncryptedWelcomeInfo>"
+        FROM
+            ds_welcome_info
+        WHERE
+            group_id = $1 AND epoch = $2"#,
+            group_id,
+            epoch.as_u64() as i64,
+        )
+        .fetch_optional(connection)
+        .await?
+        .map(BlobDecoded::into_inner);
+        Ok(ciphertext)
+    }
+
+    /// Delete the rows of `group_id` that are older than `retention`.
+    ///
+    /// Unlike the group state itself, this needs no key: `created_at` is a plain
+    /// column, so the sweep is ordinary SQL.
+    pub(crate) async fn delete_expired(
+        connection: impl PgExecutor<'_>,
+        group_id: Uuid,
+        retention: Duration,
+    ) -> sqlx::Result<()> {
+        let cutoff = Utc::now() - retention;
+        query!(
+            "DELETE FROM
+            ds_welcome_info
+        WHERE
+            group_id = $1 AND created_at < $2",
+            group_id,
+            cutoff,
+        )
+        .execute(connection)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use aircommon::{crypto::aead::Ciphertext, identifiers::QualifiedGroupId};
+    use sqlx::PgPool;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::{
+        air_service::BackendService,
+        ds::{Ds, group_state::StorableDsGroupData},
+    };
+
+    use super::*;
+
+    /// The rows reference `encrypted_group`, so a group has to exist first.
+    async fn store_group(pool: &PgPool, ds: &Ds) -> anyhow::Result<Uuid> {
+        let group_uuid = Uuid::new_v4();
+        assert!(ds.reserve_group_id(group_uuid).await);
+        let qgid = QualifiedGroupId::new(group_uuid, ds.own_domain.clone());
+        let reserved = ds.claim_reserved_group_id(qgid.group_uuid()).await.unwrap();
+        StorableDsGroupData::new_and_store(pool, reserved, Ciphertext::random()).await?;
+        Ok(group_uuid)
+    }
+
+    async fn new_ds(pool: PgPool) -> anyhow::Result<Ds> {
+        Ok(Ds::new_from_pool(
+            pool,
+            "example.com".parse().unwrap(),
+            None,
+            CancellationToken::new(),
+        )
+        .await?)
+    }
+
+    #[sqlx::test]
+    async fn store_and_load(pool: PgPool) -> anyhow::Result<()> {
+        let ds = new_ds(pool.clone()).await?;
+        let group_id = store_group(&pool, &ds).await?;
+        let epoch = GroupEpoch::from(3);
+        let ciphertext = EncryptedWelcomeInfo::from(Ciphertext::random());
+
+        DsWelcomeInfo::store(&pool, group_id, epoch, &ciphertext, TimeStamp::now()).await?;
+
+        assert_eq!(
+            DsWelcomeInfo::load(&pool, group_id, epoch).await?,
+            Some(ciphertext)
+        );
+        assert_eq!(
+            DsWelcomeInfo::load(&pool, group_id, GroupEpoch::from(4)).await?,
+            None
+        );
+        assert_eq!(
+            DsWelcomeInfo::load(&pool, Uuid::new_v4(), epoch).await?,
+            None
+        );
+
+        Ok(())
+    }
+
+    /// A second store for the same epoch leaves the first row alone.
+    #[sqlx::test]
+    async fn store_is_idempotent(pool: PgPool) -> anyhow::Result<()> {
+        let ds = new_ds(pool.clone()).await?;
+        let group_id = store_group(&pool, &ds).await?;
+        let epoch = GroupEpoch::from(3);
+        let first = EncryptedWelcomeInfo::from(Ciphertext::random());
+        let second = EncryptedWelcomeInfo::from(Ciphertext::random());
+
+        DsWelcomeInfo::store(&pool, group_id, epoch, &first, TimeStamp::now()).await?;
+        DsWelcomeInfo::store(&pool, group_id, epoch, &second, TimeStamp::now()).await?;
+
+        assert_eq!(
+            DsWelcomeInfo::load(&pool, group_id, epoch).await?,
+            Some(first)
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn expiry(pool: PgPool) -> anyhow::Result<()> {
+        let ds = new_ds(pool.clone()).await?;
+        let group_id = store_group(&pool, &ds).await?;
+        let retention = Duration::days(7);
+
+        let fresh = GroupEpoch::from(3);
+        let stale = GroupEpoch::from(4);
+        let stale_time = TimeStamp::from(Utc::now() - retention - Duration::hours(1));
+        DsWelcomeInfo::store(
+            &pool,
+            group_id,
+            fresh,
+            &Ciphertext::random(),
+            TimeStamp::now(),
+        )
+        .await?;
+        DsWelcomeInfo::store(&pool, group_id, stale, &Ciphertext::random(), stale_time).await?;
+        DsWelcomeInfo::delete_expired(&pool, group_id, retention).await?;
+
+        assert!(DsWelcomeInfo::load(&pool, group_id, fresh).await?.is_some());
+        assert!(DsWelcomeInfo::load(&pool, group_id, stale).await?.is_none());
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn deleting_the_group_deletes_its_rows(pool: PgPool) -> anyhow::Result<()> {
+        let ds = new_ds(pool.clone()).await?;
+        let group_id = store_group(&pool, &ds).await?;
+        let epoch = GroupEpoch::from(3);
+        DsWelcomeInfo::store(
+            &pool,
+            group_id,
+            epoch,
+            &Ciphertext::random(),
+            TimeStamp::now(),
+        )
+        .await?;
+
+        let qgid = QualifiedGroupId::new(group_id, ds.own_domain.clone());
+        StorableDsGroupData::<true>::delete(&pool, &qgid).await?;
+
+        assert!(DsWelcomeInfo::load(&pool, group_id, epoch).await?.is_none());
+
+        Ok(())
+    }
+}

--- a/backend/src/ds/welcome_info/snapshots/airbackend__ds__welcome_info__test__welcome_info_record_serde_codec.snap
+++ b/backend/src/ds/welcome_info/snapshots/airbackend__ds__welcome_info__test__welcome_info_record_serde_codec.snap
@@ -1,0 +1,31 @@
+---
+source: backend/src/ds/welcome_info/mod.rs
+expression: diag
+---
+a2                                              # map(2)
+   02                                           #   unsigned(2)
+   81                                           #   array(1)
+      a1                                        #     map(1)
+         65                                     #       text(5)
+            76616c7565                          #         "value"
+         a1                                     #       map(1)
+            63                                  #         text(3)
+               766563                           #           "vec"
+            83                                  #         array(3)
+               01                               #           unsigned(1)
+               02                               #           unsigned(2)
+               03                               #           unsigned(3)
+   03                                           #   unsigned(3)
+   81                                           #   array(1)
+      82                                        #     array(2)
+         01                                     #       unsigned(1)
+         a2                                     #       map(2)
+            6a                                  #         text(10)
+               63697068657274657874             #           "ciphertext"
+            58 20                               #         bytes(32)
+               01010101010101010101010101010101 #           "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+               01010101010101010101010101010101 #           "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+            65                                  #         text(5)
+               6e6f6e6365                       #           "nonce"
+            4c                                  #         bytes(12)
+               010101010101010101010101         #           "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"

--- a/common/src/messages/client_ds.rs
+++ b/common/src/messages/client_ds.rs
@@ -19,7 +19,6 @@ use tls_codec::{
 };
 
 use crate::{
-    credentials::keys::ClientVerifyingKey,
     crypto::{
         aead::{
             AeadDecryptable, AeadEncryptable,
@@ -330,13 +329,6 @@ pub struct CreateGroupParams {
     pub creator_qs_reference: QsReference,
     pub group_info: MlsMessageIn,
     pub room_state: Vec<u8>,
-}
-
-#[derive(Debug)]
-pub struct WelcomeInfoParams {
-    pub group_id: GroupId,
-    pub sender: ClientVerifyingKey,
-    pub epoch: GroupEpoch,
 }
 
 #[derive(Debug)]

--- a/mls-assist/src/group/apq.rs
+++ b/mls-assist/src/group/apq.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use apqmls::processing::ApqProcessedMessage;
-use chrono::Duration;
 use openmls::group::MergeCommitError;
 
 use crate::{
@@ -11,11 +10,16 @@ use crate::{
     provider_traits::MlsAssistStorageProvider,
 };
 
-use super::Group;
+use super::{Group, RetainedWelcomeInfo};
 
 pub struct ApqGroupRef<'a> {
     pub(crate) t_group: &'a mut Group,
     pub(crate) pq_group: &'a mut Group,
+}
+
+pub struct ApqRetainedWelcomeInfo {
+    pub t: Option<RetainedWelcomeInfo>,
+    pub pq: Option<RetainedWelcomeInfo>,
 }
 
 impl<'a> ApqGroupRef<'a> {
@@ -35,19 +39,16 @@ impl<'a> ApqGroupRef<'a> {
                 },
             group_info,
         }: ApqProcessedAssistedMessage,
-        expiration_time: Duration,
-    ) -> Result<(), MergeCommitError<StorageError<StorageProvider>>> {
+    ) -> Result<Option<RetainedWelcomeInfo>, MergeCommitError<StorageError<StorageProvider>>> {
         let (t_group_info, pq_group_info) = group_info.into_parts();
-        self.t_group.accept_processed_message(
+        let t_retained_welcome_info = self.t_group.accept_processed_message(
             t_provider,
             ProcessedAssistedMessage::Commit(t_message, Box::new(t_group_info)),
-            expiration_time,
         )?;
-        self.pq_group.accept_processed_message(
+        let _ = self.pq_group.accept_processed_message(
             pq_provider,
             ProcessedAssistedMessage::Commit(pq_message, Box::new(pq_group_info)),
-            expiration_time,
         )?;
-        Ok(())
+        Ok(t_retained_welcome_info)
     }
 }

--- a/mls-assist/src/group/apq.rs
+++ b/mls-assist/src/group/apq.rs
@@ -18,8 +18,8 @@ pub struct ApqGroupRef<'a> {
 }
 
 pub struct ApqRetainedWelcomeInfo {
-    pub t: Option<RetainedWelcomeInfo>,
-    pub pq: Option<RetainedWelcomeInfo>,
+    pub t_retained_welcome_info: Option<RetainedWelcomeInfo>,
+    pub pq_retained_welcome_info: Option<RetainedWelcomeInfo>,
 }
 
 impl<'a> ApqGroupRef<'a> {
@@ -39,16 +39,19 @@ impl<'a> ApqGroupRef<'a> {
                 },
             group_info,
         }: ApqProcessedAssistedMessage,
-    ) -> Result<Option<RetainedWelcomeInfo>, MergeCommitError<StorageError<StorageProvider>>> {
+    ) -> Result<ApqRetainedWelcomeInfo, MergeCommitError<StorageError<StorageProvider>>> {
         let (t_group_info, pq_group_info) = group_info.into_parts();
         let t_retained_welcome_info = self.t_group.accept_processed_message(
             t_provider,
             ProcessedAssistedMessage::Commit(t_message, Box::new(t_group_info)),
         )?;
-        let _ = self.pq_group.accept_processed_message(
+        let pq_retained_welcome_info = self.pq_group.accept_processed_message(
             pq_provider,
             ProcessedAssistedMessage::Commit(pq_message, Box::new(pq_group_info)),
         )?;
-        Ok(t_retained_welcome_info)
+        Ok(ApqRetainedWelcomeInfo {
+            t_retained_welcome_info,
+            pq_retained_welcome_info,
+        })
     }
 }

--- a/mls-assist/src/group/mod.rs
+++ b/mls-assist/src/group/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     provider_traits::{MlsAssistProvider, MlsAssistStorageProvider},
 };
 use apqmls::{messages::ApqGroupInfo, processing::ApqProcessedMessage};
-use chrono::Duration;
 use errors::StorageError;
 use openmls::{
     error::LibraryError,
@@ -29,10 +28,20 @@ pub mod errors;
 mod past_group_states;
 pub mod process;
 
+pub use past_group_states::LegacyPastGroupState;
+
 pub struct Group {
     public_group: PublicGroup,
     group_info: GroupInfo,
+    /// Legacy retained trees, read-only.
     past_group_states: PastGroupStates,
+}
+
+/// What a joiner added by a commit needs later.
+pub struct RetainedWelcomeInfo {
+    pub epoch: GroupEpoch,
+    pub ratchet_tree: RatchetTree,
+    pub potential_joiners: Vec<SignaturePublicKey>,
 }
 
 impl Group {
@@ -50,19 +59,14 @@ impl Group {
             ProposalStore::default(),
         )?;
         let group_id = group_info.group_context().group_id();
-        let past_group_states = PastGroupStates::default();
         provider
             .storage()
             .write_group_info(group_id, &group_info)
             .map_err(CreationFromExternalError::WriteToStorageError)?;
-        provider
-            .storage()
-            .write_past_group_states(group_id, &past_group_states)
-            .map_err(CreationFromExternalError::WriteToStorageError)?;
         Ok(Self {
             group_info,
             public_group,
-            past_group_states,
+            past_group_states: PastGroupStates::default(),
         })
     }
 
@@ -71,13 +75,12 @@ impl Group {
         group_id: &GroupId,
     ) -> Result<Option<Self>, StorageError<StorageProvider>> {
         let group_info_option = provider.read_group_info(group_id)?;
-        let past_group_states_option = provider.read_past_group_states(group_id)?;
+        let past_group_states = provider
+            .read_legacy_past_group_states(group_id)?
+            .unwrap_or_default();
         let public_group_option = PublicGroup::load(provider, group_id)?;
-        let (Some(group_info), Some(past_group_states), Some(public_group)) = (
-            group_info_option,
-            past_group_states_option,
-            public_group_option,
-        ) else {
+        let (Some(group_info), Some(public_group)) = (group_info_option, public_group_option)
+        else {
             return Ok(None);
         };
         let group = Self {
@@ -101,19 +104,23 @@ impl Group {
         Ok(())
     }
 
+    /// Merge `processed_assisted_message` into the group state.
+    ///
+    /// Returns the ratchet tree and joiner keys of the resulting epoch if the
+    /// message was a commit that added someone.
+    #[must_use = "the retained welcome info might need to be persisted"]
     pub fn accept_processed_message<StorageProvider: MlsAssistStorageProvider>(
         &mut self,
         provider: &StorageProvider,
         processed_assisted_message: ProcessedAssistedMessage,
-        expiration_time: Duration,
-    ) -> Result<(), MergeCommitError<StorageError<StorageProvider>>> {
+    ) -> Result<Option<RetainedWelcomeInfo>, MergeCommitError<StorageError<StorageProvider>>> {
         let processed_message = match processed_assisted_message {
             ProcessedAssistedMessage::NonCommit(processed_message) => processed_message,
             ProcessedAssistedMessage::Commit(processed_message, group_info) => {
                 self.group_info = *group_info;
                 processed_message
             }
-            ProcessedAssistedMessage::PrivateMessage(_) => return Ok(()),
+            ProcessedAssistedMessage::PrivateMessage(_) => return Ok(None),
         };
         let added_potential_joiners = match processed_message.into_content() {
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
@@ -155,25 +162,23 @@ impl Group {
                 Vec::new()
             }
         };
-        // Check if any potential joiners were added.
-        self.past_group_states.add_state(
-            // Note that we're saving the group state after merging the staged
-            // commit.
-            self.public_group.group_context().epoch(),
-            self.public_group.export_ratchet_tree(),
-            &added_potential_joiners,
-        );
-        // Check if any past group state has expired.
-        self.past_group_states
-            .remove_expired_states(expiration_time);
+
+        let retained_welcome_info =
+            (!added_potential_joiners.is_empty()).then(|| RetainedWelcomeInfo {
+                epoch: self.public_group.group_context().epoch(),
+                ratchet_tree: self.public_group.export_ratchet_tree(),
+                potential_joiners: added_potential_joiners,
+            });
         let group_id = self.group_info.group_context().group_id();
         provider
             .write_group_info(group_id, self.group_info())
             .map_err(MergeCommitError::StorageError)?;
+
         provider
-            .write_past_group_states(group_id, &self.past_group_states)
+            .delete_past_group_states(group_id)
             .map_err(MergeCommitError::StorageError)?;
-        Ok(())
+
+        Ok(retained_welcome_info)
     }
 
     pub fn group_info(&self) -> &GroupInfo {
@@ -188,15 +193,20 @@ impl Group {
         self.public_group.group_context().epoch()
     }
 
-    /// Get the nodes of the past group state with the given epoch for the given
-    /// joiner. Returns `None` if there is no past group state for that epoch
-    /// and the given joiner.
-    pub fn past_group_state(
-        &mut self,
+    /// Get the nodes of the legacy retained group state with the given epoch for
+    /// the given joiner. Returns `None` if there is no such entry, which is the
+    /// case for every group written since trees stopped being retained here.
+    pub fn legacy_past_group_state(
+        &self,
         epoch: &GroupEpoch,
         joiner: &SignaturePublicKey,
     ) -> Option<&RatchetTree> {
         self.past_group_states.get_for_joiner(epoch, joiner)
+    }
+
+    /// Move the legacy retained entries out, leaving none behind.
+    pub fn take_legacy_past_group_states(&mut self) -> Vec<LegacyPastGroupState> {
+        self.past_group_states.take_all_past_group_states()
     }
 
     pub fn leaf(&self, leaf_index: LeafNodeIndex) -> Option<&LeafNode> {

--- a/mls-assist/src/group/past_group_states.rs
+++ b/mls-assist/src/group/past_group_states.rs
@@ -2,9 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Legacy retained ratchet trees.
+//! They're now stored in DS as [`DsWelcomeInfo`].
+
 use std::collections::{HashMap, HashSet};
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use openmls::{
     prelude::{GroupEpoch, SignaturePublicKey},
     treesync::RatchetTree,
@@ -19,19 +22,6 @@ struct PastGroupState {
 }
 
 impl PastGroupState {
-    /// Create a new [`PastGroupState`] with the creation time set to now.
-    fn new(nodes: RatchetTree, potential_joiners: &[SignaturePublicKey]) -> Self {
-        let mut potential_joiners_set = HashSet::with_capacity(potential_joiners.len());
-        for joiner in potential_joiners {
-            potential_joiners_set.insert(joiner.clone());
-        }
-        Self {
-            nodes,
-            creation_time: Utc::now(),
-            potential_joiners: potential_joiners_set,
-        }
-    }
-
     /// Get the nodes of this group state.
     fn nodes(&self) -> &RatchetTree {
         &self.nodes
@@ -41,12 +31,14 @@ impl PastGroupState {
     fn is_authorized(&self, joiner: &SignaturePublicKey) -> bool {
         self.potential_joiners.contains(joiner)
     }
+}
 
-    /// Returns true if the creation of this group state is at least
-    /// `expiration_time` seconds ago.
-    fn has_expired(&self, expiration_time: Duration) -> bool {
-        Utc::now() - expiration_time >= self.creation_time
-    }
+/// One legacy entry, moved out of the group state for migration.
+pub struct LegacyPastGroupState {
+    pub epoch: GroupEpoch,
+    pub ratchet_tree: RatchetTree,
+    pub potential_joiners: Vec<SignaturePublicKey>,
+    pub creation_time: DateTime<Utc>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -54,25 +46,7 @@ pub(super) struct PastGroupStates {
     past_group_states: HashMap<GroupEpoch, PastGroupState>,
 }
 
-// TODO: With every processing action, check for expired time stamps
-// TODO: Remove the removal logic upon removal of a group member
-
 impl PastGroupStates {
-    /// Add a new group state with the given nodes for the given epoch
-    /// retrievable by any of the `potential_joiners`.
-    pub(super) fn add_state(
-        &mut self,
-        epoch: GroupEpoch,
-        nodes: RatchetTree,
-        potential_joiners: &[SignaturePublicKey],
-    ) {
-        if potential_joiners.is_empty() {
-            return;
-        }
-        self.past_group_states
-            .insert(epoch, PastGroupState::new(nodes, potential_joiners));
-    }
-
     /// Get the nodes of the past group state with the given epoch for the given
     /// joiner. Returns `None` if there is no past group state for that epoch
     /// and the given joiner.
@@ -93,17 +67,15 @@ impl PastGroupStates {
             })
     }
 
-    /// Remove all past group states where the time of creation was longer than
-    /// `expiration_time` in seconds ago.
-    pub(super) fn remove_expired_states(&mut self, expiration_time: Duration) {
-        let mut expired_epochs = vec![];
-        for (epoch, past_group_state) in self.past_group_states.iter() {
-            if past_group_state.has_expired(expiration_time) {
-                expired_epochs.push(*epoch)
-            }
-        }
-        for expired_epoch in expired_epochs {
-            self.past_group_states.remove(&expired_epoch);
-        }
+    pub(super) fn take_all_past_group_states(&mut self) -> Vec<LegacyPastGroupState> {
+        self.past_group_states
+            .drain()
+            .map(|(epoch, state)| LegacyPastGroupState {
+                epoch,
+                ratchet_tree: state.nodes,
+                potential_joiners: state.potential_joiners.into_iter().collect(),
+                creation_time: state.creation_time,
+            })
+            .collect()
     }
 }

--- a/mls-assist/src/memory_provider.rs
+++ b/mls-assist/src/memory_provider.rs
@@ -380,6 +380,9 @@ impl<C: Codec> PublicStorageProvider<CURRENT_VERSION> for MlsAssistMemoryStorage
 #[derive(Default, Deserialize)]
 struct SerializableMlsAssistMemoryStorage {
     storage_bytes: Vec<(ByteBuf, ByteBuf)>,
+    /// Only read, never written: retained trees now live outside the group
+    /// state.
+    #[serde(default)]
     past_group_states_bytes: Vec<(ByteBuf, ByteBuf)>,
     group_infos_bytes: Vec<(ByteBuf, ByteBuf)>,
 }
@@ -387,7 +390,6 @@ struct SerializableMlsAssistMemoryStorage {
 #[derive(Default, Serialize)]
 struct SerializableMlsAssistMemoryStorageRef<'a> {
     storage_bytes: Vec<(&'a Bytes, ByteBuf)>,
-    past_group_states_bytes: Vec<(&'a Bytes, &'a Bytes)>,
     group_infos_bytes: Vec<(&'a Bytes, &'a Bytes)>,
 }
 
@@ -398,16 +400,6 @@ impl<C: Codec> MlsAssistMemoryStorage<C> {
             .iter()
             .map(|(key, value)| Ok((Bytes::new(key), C::to_vec(value)?.into())))
             .collect::<Result<Vec<_>, _>>()?;
-        let past_group_states = self.past_group_states.read().unwrap();
-        let past_group_states_bytes = past_group_states
-            .iter()
-            .map(|(group_id_bytes, past_group_states_bytes)| {
-                (
-                    Bytes::new(group_id_bytes),
-                    Bytes::new(past_group_states_bytes),
-                )
-            })
-            .collect();
         let group_infos = self.group_infos.read().unwrap();
         let group_infos_bytes = group_infos
             .iter()
@@ -417,7 +409,6 @@ impl<C: Codec> MlsAssistMemoryStorage<C> {
             .collect();
         let serialized = SerializableMlsAssistMemoryStorageRef {
             storage_bytes,
-            past_group_states_bytes,
             group_infos_bytes,
         };
         C::to_vec(&serialized)
@@ -456,19 +447,7 @@ impl<C: Codec> MlsAssistMemoryStorage<C> {
 }
 
 impl<C: Codec> MlsAssistStorageProvider for MlsAssistMemoryStorage<C> {
-    fn write_past_group_states(
-        &self,
-        group_id: &impl GroupId<CURRENT_VERSION>,
-        past_group_states: &impl serde::Serialize,
-    ) -> Result<(), StorageError<Self>> {
-        let group_id_bytes = C::to_vec(group_id)?;
-        let past_group_states_bytes = C::to_vec(past_group_states)?;
-        let mut past_group_states = self.past_group_states.write().unwrap();
-        past_group_states.insert(group_id_bytes, past_group_states_bytes);
-        Ok(())
-    }
-
-    fn read_past_group_states<PastGroupStates: DeserializeOwned>(
+    fn read_legacy_past_group_states<PastGroupStates: DeserializeOwned>(
         &self,
         group_id: &impl GroupId<CURRENT_VERSION>,
     ) -> Result<Option<PastGroupStates>, StorageError<Self>> {

--- a/mls-assist/src/provider_traits.rs
+++ b/mls-assist/src/provider_traits.rs
@@ -13,13 +13,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::group::errors::StorageError;
 
 pub trait MlsAssistStorageProvider: PublicStorageProvider {
-    fn write_past_group_states(
-        &self,
-        group_id: &impl GroupId<CURRENT_VERSION>,
-        past_group_states: &impl Serialize,
-    ) -> Result<(), StorageError<Self>>;
-
-    fn read_past_group_states<PastGroupStates: DeserializeOwned>(
+    fn read_legacy_past_group_states<PastGroupStates: DeserializeOwned>(
         &self,
         group_id: &impl GroupId<CURRENT_VERSION>,
     ) -> Result<Option<PastGroupStates>, StorageError<Self>>;


### PR DESCRIPTION
Into a more granular set of rows mapping (group_id, epoch_id) to its relevant welcome info snapshot. This is necessary to avoid `DsGroupState` to grow by a factor of N*M where N is the number of commits with `Add` proposals and M the number of members in a group.