### PR TITLE
chore: bump openmls and adapt air to changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1879,7 +1879,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2692,7 +2692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4833,7 +4833,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5072,7 +5072,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "aes",
  "fpe",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "hex",
  "log",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5180,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "openmls_serialization_helpers"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5191,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5202,7 +5202,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/phnx-im/openmls?rev=8671133aba7db4955c24c19e147096aeb741262d#8671133aba7db4955c24c19e147096aeb741262d"
+source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
 dependencies = [
  "serde",
  "tls_codec",
@@ -6022,7 +6022,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6492,7 +6492,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6896,7 +6896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7258,10 +7258,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7886,7 +7886,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8346,7 +8346,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,7 +5072,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "openmls_libcrux_crypto"
 version = "0.4.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "aes",
  "fpe",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "hex",
  "log",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5180,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "openmls_serialization_helpers"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5191,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "openmls_sqlite_storage"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5202,7 +5202,7 @@ dependencies = [
 [[package]]
 name = "openmls_test"
 version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=7cee93e26800a64a59b2173888fe17bbcccdb3e0#7cee93e26800a64a59b2173888fe17bbcccdb3e0"
+source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
 dependencies = [
  "serde",
  "tls_codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,10 @@ minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 num_enum = "0.7"
-openmls = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["clonable"] }
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["clonable"] }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,10 @@ minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 num_enum = "0.7"
-openmls = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["clonable"] }
-openmls_rust_crypto = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { git = "https://github.com/phnx-im/openmls", rev = "8671133aba7db4955c24c19e147096aeb741262d", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["clonable"] }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/openmls/openmls", rev = "7cee93e26800a64a59b2173888fe17bbcccdb3e0", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"

--- a/apqmls/src/commit_builder.rs
+++ b/apqmls/src/commit_builder.rs
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use openmls::{
-    components::vc_derivation_info::EpochId,
     group::{
         CommitBuilder as MlsGroupCommitBuilder, CommitBuilderStageError, CommitMessageBundle,
-        CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, Initial, MlsGroup,
+        CreateCommitError as OpenMlsCreateCommitError, GroupEpoch, GroupId, Initial, MlsGroup,
         QueuedProposal,
     },
     prelude::{
@@ -117,7 +116,8 @@ struct ConfigValues {
     proposed_adds: Vec<ApqKeyPackage>,
     proposed_removals: Vec<LeafNodeIndex>,
     create_group_info: bool,
-    vc_epoch_id: Option<EpochId>,
+    vc_emulation_group_id: Option<GroupId>,
+    derivation_epoch: bool,
 }
 
 impl ConfigValues {
@@ -130,6 +130,10 @@ impl ConfigValues {
         }
         if let Some(force) = self.force_self_update {
             builder = builder.force_self_update(force);
+        }
+        // Emulation state lives on the classical leg only.
+        if IS_TRADITIONAL && self.derivation_epoch {
+            builder = builder.derivation_epoch(true);
         }
         let leaf_node_parameters = if IS_TRADITIONAL {
             &self.t_leaf_node_parameters
@@ -190,9 +194,18 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
-    /// Sets the virtual-client emulation epoch.
-    pub fn vc_emulation(mut self, epoch_id: EpochId) -> Self {
-        self.values.vc_epoch_id = Some(epoch_id);
+    /// Sets the emulation group whose newest derivation epoch the commit
+    /// derives from.
+    pub fn vc_emulation(mut self, emulation_group_id: GroupId) -> Self {
+        self.values.vc_emulation_group_id = Some(emulation_group_id);
+        self
+    }
+
+    /// Asks the emulation group to start a new derivation epoch with this
+    /// commit. Only meaningful on the emulation group itself. See
+    /// [`MlsGroupCommitBuilder::derivation_epoch`].
+    pub fn derivation_epoch(mut self, derivation_epoch: bool) -> Self {
+        self.values.derivation_epoch = derivation_epoch;
         self
     }
 
@@ -303,9 +316,9 @@ impl<'a> CommitBuilder<'a> {
             .pq_group
             .commit_builder()
             .pipe(|b| self.values.apply::<false>(b));
-        let pq_builder = match &self.values.vc_epoch_id {
-            Some(epoch_id) => {
-                pq_builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id.clone())?
+        let pq_builder = match &self.values.vc_emulation_group_id {
+            Some(group_id) => {
+                pq_builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?
             }
             None => pq_builder,
         };
@@ -338,9 +351,9 @@ impl<'a> CommitBuilder<'a> {
             .t_group
             .commit_builder()
             .pipe(|b| self.values.apply::<true>(b));
-        let t_builder = match &self.values.vc_epoch_id {
-            Some(epoch_id) => {
-                t_builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id.clone())?
+        let t_builder = match &self.values.vc_emulation_group_id {
+            Some(group_id) => {
+                t_builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?
             }
             None => t_builder,
         };

--- a/apqmls/src/external_commit_builder.rs
+++ b/apqmls/src/external_commit_builder.rs
@@ -4,10 +4,9 @@
 
 use openmls::{
     component::ComponentData,
-    components::vc_derivation_info::EpochId,
     group::{
         CommitMessageBundle, CreateCommitError, ExternalCommitBuilder, ExternalCommitBuilderError,
-        ExternalCommitBuilderFinalizeError, GroupEpoch, LeafNodeLifetimePolicy, MlsGroup,
+        ExternalCommitBuilderFinalizeError, GroupEpoch, GroupId, LeafNodeLifetimePolicy, MlsGroup,
         MlsGroupJoinConfig,
     },
     prelude::{
@@ -57,7 +56,7 @@ pub struct ApqExternalCommitBuilder {
     leaf_node_parameters: Option<(LeafNodeParameters, LeafNodeParameters)>,
     create_group_info: bool,
     t_psk_proposals: Vec<PreSharedKeyProposal>,
-    vc_epoch_id: Option<EpochId>,
+    vc_emulation_group_id: Option<GroupId>,
 }
 
 impl ApqExternalCommitBuilder {
@@ -102,9 +101,10 @@ impl ApqExternalCommitBuilder {
         self
     }
 
-    /// Sets the virtual-client emulation epoch.
-    pub fn vc_emulation(mut self, epoch_id: EpochId) -> Self {
-        self.vc_epoch_id = Some(epoch_id);
+    /// Sets the emulation group whose newest derivation epoch the commit
+    /// derives from.
+    pub fn vc_emulation(mut self, emulation_group_id: GroupId) -> Self {
+        self.vc_emulation_group_id = Some(emulation_group_id);
         self
     }
 
@@ -132,7 +132,7 @@ impl ApqExternalCommitBuilder {
             leaf_node_parameters,
             create_group_info,
             t_psk_proposals,
-            vc_epoch_id,
+            vc_emulation_group_id,
         } = self;
 
         let VerifiableApqGroupInfo {
@@ -186,7 +186,7 @@ impl ApqExternalCommitBuilder {
             component_data.clone(),
             Vec::new(),
             create_group_info,
-            vc_epoch_id.clone(),
+            vc_emulation_group_id.clone(),
             signer.pq_signer(),
         )?;
 
@@ -228,7 +228,7 @@ impl ApqExternalCommitBuilder {
                 component_data,
                 t_psk_proposals,
                 create_group_info,
-                vc_epoch_id,
+                vc_emulation_group_id,
                 signer.t_signer(),
             )
         })();
@@ -263,7 +263,7 @@ fn build_and_finalize_leg<Provider: OpenMlsProvider>(
     component_data: ComponentData,
     psk_proposals: Vec<PreSharedKeyProposal>,
     create_group_info: bool,
-    vc_epoch_id: Option<EpochId>,
+    vc_emulation_group_id: Option<GroupId>,
     signer: &impl Signer,
 ) -> Result<(MlsGroup, CommitMessageBundle), ApqExternalCommitBuilderError<Provider::StorageError>>
 {
@@ -280,9 +280,9 @@ fn build_and_finalize_leg<Provider: OpenMlsProvider>(
     let vc_builder = external_builder
         .build_group(provider, group_info, credential_with_key)?
         .leaf_node_parameters(leaf_node_parameters);
-    let vc_builder = match vc_epoch_id {
-        Some(epoch_id) => {
-            vc_builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?
+    let vc_builder = match &vc_emulation_group_id {
+        Some(group_id) => {
+            vc_builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?
         }
         None => vc_builder,
     };

--- a/apqmls/src/group_builder.rs
+++ b/apqmls/src/group_builder.rs
@@ -5,8 +5,8 @@
 use openmls::{
     component::ComponentData,
     group::{
-        GroupContext, GroupEpoch, GroupId, MlsGroupBuilder, NewGroupError as OpenMlsNewGroupError,
-        WireFormatPolicy,
+        GroupContext, GroupEpoch, GroupId, MlsGroup, MlsGroupCreateConfigBuilder,
+        NewGroupError as OpenMlsNewGroupError, WireFormatPolicy,
     },
     prelude::{
         AppDataDictionaryExtension, Capabilities, Extension, ExtensionType, Extensions,
@@ -46,14 +46,15 @@ impl<StorageError> From<InvalidExtensionError> for NewGroupError<StorageError> {
 /// A builder for creating a new [`ApqMlsGroup`].
 #[derive(Debug, Default)]
 pub struct GroupBuilder {
-    t_group_builder: MlsGroupBuilder,
-    pq_group_builder: MlsGroupBuilder,
+    t_config_builder: MlsGroupCreateConfigBuilder,
+    pq_config_builder: MlsGroupCreateConfigBuilder,
     // We keep track of the values below so we can do some post-processing
     // later.
     group_ids: Option<ApqGroupId>,
     mode: PqtMode,
     ciphersuite: Option<ApqCiphersuite>,
     capabilities: Capabilities,
+    emulation_group: bool,
     t_extensions: Extensions<GroupContext>,
     pq_extensions: Extensions<GroupContext>,
     t_leaf_extensions: Extensions<LeafNode>,
@@ -80,12 +81,18 @@ impl GroupBuilder {
 
     /// Sets the group ID of the [`ApqMlsGroup`].
     pub fn with_group_ids(mut self, t_group_id: GroupId, pq_group_id: GroupId) -> Self {
-        self.t_group_builder = self.t_group_builder.with_group_id(t_group_id.clone());
-        self.pq_group_builder = self.pq_group_builder.with_group_id(pq_group_id.clone());
         self.group_ids = Some(ApqGroupId {
             t_group_id,
             pq_group_id,
         });
+        self
+    }
+
+    /// Marks the T group as an emulation group, so derivation epochs are
+    /// registered implicitly, starting with the initial epoch. The PQ leg
+    /// holds no emulation state.
+    pub fn emulation_group(mut self, emulation_group: bool) -> Self {
+        self.emulation_group = emulation_group;
         self
     }
 
@@ -135,30 +142,37 @@ impl GroupBuilder {
         ensure_group_context_component_support(&mut self.t_extensions, info_component.clone())?;
         ensure_group_context_component_support(&mut self.pq_extensions, info_component)?;
 
-        let t_group = self
-            .t_group_builder
+        // Capabilities have to be set before the leaf node extensions, which
+        // are validated against them.
+        let t_config = self
+            .t_config_builder
             .ciphersuite(ciphersuite.t_ciphersuite)
             .with_group_context_extensions(self.t_extensions)
-            .with_group_id(apq_group_id.t_group_id.clone())
-            .with_capabilities(capabilities.clone())
+            .capabilities(capabilities.clone())
             .with_leaf_node_extensions(self.t_leaf_extensions)?
-            .build(
-                provider,
-                signer.t_signer(),
-                credential_with_key.t_credential,
-            )?;
-        let pq_group = self
-            .pq_group_builder
+            .emulation_group(self.emulation_group)
+            .build();
+        let t_group = MlsGroup::new_with_group_id(
+            provider,
+            signer.t_signer(),
+            &t_config,
+            apq_group_id.t_group_id.clone(),
+            credential_with_key.t_credential,
+        )?;
+        let pq_config = self
+            .pq_config_builder
             .ciphersuite(ciphersuite.pq_ciphersuite)
             .with_group_context_extensions(self.pq_extensions)
-            .with_group_id(apq_group_id.pq_group_id.clone())
-            .with_capabilities(capabilities)
+            .capabilities(capabilities)
             .with_leaf_node_extensions(self.pq_leaf_extensions)?
-            .build(
-                provider,
-                signer.pq_signer(),
-                credential_with_key.pq_credential,
-            )?;
+            .build();
+        let pq_group = MlsGroup::new_with_group_id(
+            provider,
+            signer.pq_signer(),
+            &pq_config,
+            apq_group_id.pq_group_id.clone(),
+            credential_with_key.pq_credential,
+        )?;
 
         Ok(ApqMlsGroup { pq_group, t_group })
     }
@@ -167,19 +181,17 @@ impl GroupBuilder {
 
     /// Sets the `wire_format` property of the ApqMlsGroup.
     pub fn with_wire_format_policy(mut self, wire_format_policy: WireFormatPolicy) -> Self {
-        self.t_group_builder = self
-            .t_group_builder
-            .with_wire_format_policy(wire_format_policy);
-        self.pq_group_builder = self
-            .pq_group_builder
-            .with_wire_format_policy(wire_format_policy);
+        self.t_config_builder = self.t_config_builder.wire_format_policy(wire_format_policy);
+        self.pq_config_builder = self
+            .pq_config_builder
+            .wire_format_policy(wire_format_policy);
         self
     }
 
     /// Sets the `padding_size` property of the ApqMlsGroup.
     pub fn padding_size(mut self, padding_size: usize) -> Self {
-        self.t_group_builder = self.t_group_builder.padding_size(padding_size);
-        self.pq_group_builder = self.pq_group_builder.padding_size(padding_size);
+        self.t_config_builder = self.t_config_builder.padding_size(padding_size);
+        self.pq_config_builder = self.pq_config_builder.padding_size(padding_size);
         self
     }
 
@@ -194,29 +206,29 @@ impl GroupBuilder {
     /// the same epoch in which they were generated. The number for `max_epochs` should be
     /// as low as possible.
     pub fn max_past_epochs(mut self, max_past_epochs: usize) -> Self {
-        self.t_group_builder = self.t_group_builder.max_past_epochs(max_past_epochs);
+        self.t_config_builder = self.t_config_builder.max_past_epochs(max_past_epochs);
         // pq group is not used for application messages, so we don't set it there
         self
     }
 
     /// Sets the `number_of_resumption_psks` property of the ApqMlsGroup.
     pub fn number_of_resumption_psks(mut self, number_of_resumption_psks: usize) -> Self {
-        self.t_group_builder = self
-            .t_group_builder
+        self.t_config_builder = self
+            .t_config_builder
             .number_of_resumption_psks(number_of_resumption_psks);
-        self.pq_group_builder = self
-            .pq_group_builder
+        self.pq_config_builder = self
+            .pq_config_builder
             .number_of_resumption_psks(number_of_resumption_psks);
         self
     }
 
     /// Sets the `use_ratchet_tree_extension` property of the MlsGroup.
     pub fn use_ratchet_tree_extension(mut self, use_ratchet_tree_extension: bool) -> Self {
-        self.t_group_builder = self
-            .t_group_builder
+        self.t_config_builder = self
+            .t_config_builder
             .use_ratchet_tree_extension(use_ratchet_tree_extension);
-        self.pq_group_builder = self
-            .pq_group_builder
+        self.pq_config_builder = self
+            .pq_config_builder
             .use_ratchet_tree_extension(use_ratchet_tree_extension);
         self
     }
@@ -227,8 +239,8 @@ impl GroupBuilder {
         mut self,
         sender_ratchet_configuration: SenderRatchetConfiguration,
     ) -> Self {
-        self.t_group_builder = self
-            .t_group_builder
+        self.t_config_builder = self
+            .t_config_builder
             .sender_ratchet_configuration(sender_ratchet_configuration);
         // pq group does not use application messages, so we don't set the
         // configuration there
@@ -237,8 +249,8 @@ impl GroupBuilder {
 
     /// Sets the `lifetime` of the group creator's leaf.
     pub fn lifetime(mut self, lifetime: Lifetime) -> Self {
-        self.t_group_builder = self.t_group_builder.lifetime(lifetime);
-        self.pq_group_builder = self.pq_group_builder.lifetime(lifetime);
+        self.t_config_builder = self.t_config_builder.lifetime(lifetime);
+        self.pq_config_builder = self.pq_config_builder.lifetime(lifetime);
         self
     }
 

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 
-use airprotos::client::virtual_client::extract_virtual_client_action;
+use airprotos::client::virtual_client::extract_virtual_client_commit_data;
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
     group::{ApqProcessedAssistedMessagePlus, ProcessedAssistedMessage, apq::ApqGroupRef},
@@ -138,6 +138,23 @@ impl DsGroupState {
         }
 
         let is_self_group = self.is_self_group();
+
+        // Temporary measure to prevent old clients from derailing self-groups on new clients. Will
+        // be removed shortly.
+        if is_self_group
+            && staged_commit.add_proposals().next().is_none()
+            && staged_commit.remove_proposals().next().is_none()
+        {
+            let commit_data =
+                extract_virtual_client_commit_data(processed_message).map_err(|error| {
+                    error!(%error, "Failed to extract virtual client commit data from safe AAD");
+                    GroupOperationError::InvalidMessage
+                })?;
+            if commit_data.is_none() {
+                warn!("Self-group commit without membership change or commit data");
+                return Err(GroupOperationError::InvalidMessage);
+            }
+        }
 
         // If the commit carries an update path, the sender's new leaf credential must match the
         // group kind.
@@ -803,12 +820,14 @@ impl DsGroupState {
 fn extract_virtual_client_hint(
     processed_message: &ProcessedMessage,
 ) -> Result<Option<QsVirtualClientHint>, GroupOperationError> {
-    extract_virtual_client_action(processed_message)
-        .map_err(|error| {
-            error!(%error, "Failed to extract KeyPackageUpload from safe AAD");
-            GroupOperationError::InvalidMessage
-        })
-        .map(|action| action.map(From::from))
+    let commit_data = extract_virtual_client_commit_data(processed_message).map_err(|error| {
+        error!(%error, "Failed to extract virtual client commit data from safe AAD");
+        GroupOperationError::InvalidMessage
+    })?;
+    Ok(commit_data
+        .as_ref()
+        .and_then(|commit_data| commit_data.key_package_uploads().next())
+        .map(From::from))
 }
 
 pub(crate) type AddedUserInfo = (KeyPackage, EncryptedUserProfileKey);

--- a/backend/src/messages/intra_backend.rs
+++ b/backend/src/messages/intra_backend.rs
@@ -11,7 +11,7 @@ use aircommon::{
     time::TimeStamp,
     virtual_client::KeyPackageBatchId,
 };
-use airprotos::client::virtual_client::VirtualClientAction;
+use mls_assist::openmls::components::vc_derivation_info::KeyPackageUpload;
 use tls_codec::{TlsDeserializeBytes, TlsSerialize, TlsSize};
 
 // === DS to QS ===
@@ -79,16 +79,8 @@ pub enum QsVirtualClientHint {
     PromoteStagedKeyPackages(KeyPackageBatchId),
 }
 
-impl From<VirtualClientAction> for QsVirtualClientHint {
-    fn from(action: VirtualClientAction) -> Self {
-        match action {
-            VirtualClientAction::KeyPackageUpload(upload) => {
-                Self::PromoteStagedKeyPackages(KeyPackageBatchId {
-                    epoch_id: upload.epoch_id,
-                    leaf_index: upload.leaf_index,
-                    generation: upload.generation,
-                })
-            }
-        }
+impl From<&KeyPackageUpload> for QsVirtualClientHint {
+    fn from(upload: &KeyPackageUpload) -> Self {
+        Self::PromoteStagedKeyPackages(KeyPackageBatchId::from(upload))
     }
 }

--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -29,7 +29,6 @@ use anyhow::{Context, anyhow, bail};
 use apqmls::authentication::ApqCredentialWithKey;
 use apqmls::messages::ApqKeyPackage;
 use chrono::Utc;
-use openmls::components::vc_derivation_info::EpochId;
 use openmls::group::GroupId;
 use openmls::prelude::{Credential, CredentialType, SignaturePublicKey};
 use openmls::{
@@ -52,8 +51,6 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 use uuid::Uuid;
 
-use crate::db::access::WriteConnection;
-use crate::groups::self_group::SelfGroup;
 use crate::{
     Chat, ChatId, ChatStatus, ChatType, Contact,
     clients::{
@@ -692,18 +689,6 @@ impl CoreUser {
             .await?;
 
         Ok(())
-    }
-
-    /// Register a virtual-clients emulation epoch on the self group.
-    pub(crate) async fn register_self_group_vc_emulation_epoch(
-        mut connection: impl WriteConnection,
-    ) -> anyhow::Result<EpochId> {
-        let mut self_group = SelfGroup::load(&mut connection)
-            .await?
-            .context("self group not found")?;
-        let epoch_id = self_group.register_vc_emulation_epoch(connection)?;
-        debug!(?epoch_id, "registered self-group VC emulation epoch");
-        Ok(epoch_id)
     }
 
     /// Poll our QS queue until the self-group Welcome arrives.

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -20,10 +20,7 @@ use aircommon::{
     utils::removed_client,
     virtual_client::KeyPackageBatchId,
 };
-use airprotos::client::{
-    group::GroupData,
-    virtual_client::{VirtualClientAction, extract_virtual_client_action},
-};
+use airprotos::client::{group::GroupData, virtual_client::extract_virtual_client_commit_data};
 use anyhow::{Context, Result, bail, ensure};
 use apqmls::messages::ApqMlsMessageIn;
 use chrono::Utc;
@@ -430,7 +427,7 @@ impl CoreUser {
             client: self.signing_key(),
             self_group: own_client_info.self_group_signing_key.as_ref(),
         };
-        let (mut group, sender_user_id, member_profile_info) = Box::pin(Group::join_apq_group(
+        let (group, sender_user_id, member_profile_info) = Box::pin(Group::join_apq_group(
             welcome_bundle,
             &self.inner.key_store.wai_ear_key,
             txn,
@@ -450,17 +447,6 @@ impl CoreUser {
             };
             let chat = Chat::new_group_chat(group.group_id().clone(), attributes);
             chat.store(&mut *txn).await?;
-
-            // Register the emulation epoch at the epoch we joined into. The
-            // sibling that added us registers at the same epoch when it merges
-            // its Add commit, so both derive the same `EpochId`. Joining does
-            // not go through `Group::merge_pending_commit`, which covers every
-            // later epoch of the self group.
-            let epoch_id = group.register_vc_emulation_epoch(&mut *txn)?;
-            debug!(
-                ?epoch_id,
-                "registered self-group VC emulation epoch on join"
-            );
 
             return Ok(QsMessageOutcome::new_chat(
                 chat.id(),
@@ -1743,11 +1729,10 @@ fn own_commit_key_package_batch(
     ) {
         return Ok(None);
     }
-    let Some(action) = extract_virtual_client_action(processed_message)? else {
+    let Some(commit_data) = extract_virtual_client_commit_data(processed_message)? else {
         return Ok(None);
     };
-    let VirtualClientAction::KeyPackageUpload(upload) = action;
-    Ok(Some(KeyPackageBatchId::from(&upload)))
+    Ok(commit_data.key_package_uploads().next().map(From::from))
 }
 
 #[cfg(test)]
@@ -1763,6 +1748,7 @@ mod tests {
         components::vc_derivation_info::{KeyPackageUpload, VC_COMPONENT_ID},
         prelude::tls_codec::Serialize as _,
     };
+    use openmls_traits::OpenMlsProvider as _;
     use uuid::Uuid;
 
     use crate::{
@@ -1821,7 +1807,15 @@ mod tests {
                 OwnClientInfo::set_self_group(&mut *txn, group.group_id(), &signing_key).await?;
 
                 let mut self_group = SelfGroup::load(&mut *txn).await?.context("no self-group")?;
-                let epoch_id = self_group.register_vc_emulation_epoch(&mut *txn)?;
+                // Creating the self group registers its initial derivation epoch.
+                let epoch_id = {
+                    let provider = AirOpenMlsProvider::new(txn.as_mut());
+                    self_group
+                        .group()
+                        .mls_group()
+                        .newest_vc_derivation_epoch(provider.storage())?
+                        .context("no derivation epoch in the self-group")?
+                };
                 let leaf_index = self_group.group().mls_group().own_leaf_index();
                 let upload = KeyPackageUpload {
                     epoch_id: epoch_id.clone(),

--- a/coreclient/src/clients/test_utils.rs
+++ b/coreclient/src/clients/test_utils.rs
@@ -15,7 +15,10 @@ use airprotos::client::{component::AirComponent, group::GroupData};
 use crate::{
     chats::GroupDataExt,
     groups::{GroupDataBytes, self_group::SelfGroup},
-    job::pending_chat_operation::{PendingChatOperation, test_utils::PendingChatOperationInfo},
+    job::{
+        chat_operation::DerivationEpoch,
+        pending_chat_operation::{PendingChatOperation, test_utils::PendingChatOperationInfo},
+    },
     outbound_service::resync::Resync,
 };
 
@@ -278,6 +281,7 @@ impl CoreUser {
                     chat_id,
                     Some(legacy_group_data),
                     None,
+                    DerivationEpoch::Keep,
                 )
                 .await
             })
@@ -313,6 +317,7 @@ impl CoreUser {
                     chat_id,
                     Some(group_data_bytes),
                     None,
+                    DerivationEpoch::Keep,
                 )
                 .await
             })

--- a/coreclient/src/clients/update_key.rs
+++ b/coreclient/src/clients/update_key.rs
@@ -8,7 +8,7 @@ use crate::{
     Chat, ChatAttributes, ChatId, ChatMessage, ChatType, SystemMessage,
     chats::messages::TimestampedMessage,
     db::access::{WriteConnection, WriteDbTransaction},
-    job::chat_operation::ChatOperation,
+    job::chat_operation::{ChatOperation, DerivationEpoch},
 };
 
 use super::CoreUser;
@@ -27,7 +27,7 @@ impl CoreUser {
 
     /// Same as [`Self::update_key`], but also updates the PQ key material.
     pub async fn update_apq_key(&self, chat_id: ChatId) -> anyhow::Result<Vec<ChatMessage>> {
-        let job = ChatOperation::apq_update(chat_id);
+        let job = ChatOperation::apq_update(chat_id, DerivationEpoch::Keep);
         Ok(self.execute_job(job).await?)
     }
 
@@ -36,7 +36,7 @@ impl CoreUser {
         chat_id: ChatId,
         new_chat_attributes: Option<ChatAttributes>,
     ) -> anyhow::Result<Vec<ChatMessage>> {
-        let job = ChatOperation::update(chat_id, new_chat_attributes);
+        let job = ChatOperation::update(chat_id, new_chat_attributes, DerivationEpoch::Keep);
         Ok(self.execute_job(job).await?)
     }
 }

--- a/coreclient/src/groups/apq_group.rs
+++ b/coreclient/src/groups/apq_group.rs
@@ -108,6 +108,9 @@ impl Group {
             .with_group_context_extensions(gc_extensions.clone(), gc_extensions)?
             .sender_ratchet_configuration(default_sender_ratchet_configuration())
             .max_past_epochs(MAX_PAST_EPOCHS)
+            // The self group is the emulation group of the virtual client, so its
+            // initial epoch already has to be a derivation epoch.
+            .emulation_group(matches!(signer, LeafSigningKey::SelfGroup(_)))
             .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
             .build(&provider, signer, apq_credential_with_key)?
             .into_groups();

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -104,15 +104,16 @@ use crate::{
         targeted_message::TargetedMessageContent,
     },
     contacts::{ContactAddInfos, ContactKeyPackage},
-    db::access::{WriteConnection, WriteDbTransaction},
+    db::access::{ReadConnection, WriteConnection, WriteDbTransaction},
     groups::{apq_group::PqGroup, client_auth_info::VerifiableUserCredentialExt},
+    job::chat_operation::DerivationEpoch,
     key_stores::as_credentials::AsCredentials,
     outbound_service::resync::Resync,
 };
 
 use openmls::{
     component::ComponentType,
-    components::vc_derivation_info::{EpochId, GenerationId},
+    components::vc_derivation_info::GenerationId,
     group::{
         CreateCommitError, ExportSecretError, ExternalCommitBuilder, GroupEpoch, JoinBuilder,
         ProcessedWelcome, ProposalValidationError, UnconfirmedMessage,
@@ -858,12 +859,20 @@ impl Group {
                 signer,
             )
             .await?;
+
+        let is_self_group = OwnClientInfo::is_own_self_group(&mut *txn, t_group_id).await?;
+
         let t_mls_group = {
             let provider = AirOpenMlsProvider::new(txn.as_mut());
             let t_builder = JoinBuilder::new(&provider, processed_t_welcome)
                 .skip_lifetime_validation()
                 .with_ratchet_tree(t_ratchet_tree);
-            t_builder.build()?.into_group(&provider)?
+            // The self group is the emulation group, so joining it registers the
+            // derivation epoch we join into.
+            t_builder
+                .build()?
+                .emulation_group(is_self_group)
+                .into_group(&provider)?
         };
 
         // Phase 5: Verify WAI + extract sender
@@ -880,10 +889,6 @@ impl Group {
 
         // Phase 6: Construct and persist Group.
         //
-        // Self-group leaves carry a SelfGroupCredential, which has nothing to verify against the
-        // AS. We accept it only inside our own self group.
-        let is_self_group =
-            OwnClientInfo::is_own_self_group(&mut *txn, t_mls_group.group_id()).await?;
         // A group flagged as self-group may only be joined during device linking, i.e. when it is
         // recorded as our own self-group. Conversely, our own self-group must carry the flag,
         // since its self-group credentials are only accepted there.
@@ -1077,7 +1082,7 @@ impl Group {
         connection_offer_hash: Option<ConnectionOfferHash>,
         // Should be Some if we are joining as an emulator of a virtual client
         // that is already a member.
-        vc_epoch_id: Option<EpochId>,
+        vc_group_id: Option<GroupId>,
     ) -> anyhow::Result<
         Result<
             (Self, MlsMessageOut, MlsMessageOut, DecryptedProfileInfos),
@@ -1131,7 +1136,7 @@ impl Group {
                 None => None,
             };
 
-            let leaf_node_extensions = if vc_epoch_id.is_some() {
+            let leaf_node_extensions = if vc_group_id.is_some() {
                 vc_leaf_node_extensions::<AirComponent>()
             } else {
                 default_leaf_node_extensions::<AirComponent>()
@@ -1159,8 +1164,8 @@ impl Group {
 
             // Must come after `leaf_node_parameters`: the VC leaf configuration
             // is validated against them before an operation secret is spent.
-            if let Some(epoch_id) = vc_epoch_id {
-                builder = builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?;
+            if let Some(group_id) = &vc_group_id {
+                builder = builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?;
             }
 
             if let Some(psk_proposal) = psk_proposal {
@@ -1237,7 +1242,7 @@ impl Group {
         group_state_ear_key: GroupStateEarKey,
         identity_link_wrapper_key: IdentityLinkWrapperKey,
         aad: AadMessage,
-        vc_epoch_id: Option<EpochId>,
+        vc_group_id: Option<GroupId>,
     ) -> anyhow::Result<
         Result<(Self, ApqCommitMessageBundle, DecryptedProfileInfos), LeafNodeValidationError>,
     > {
@@ -1308,7 +1313,7 @@ impl Group {
 
         // Build the group
         let mls_group_config = default_mls_group_join_config();
-        let leaf_node_extensions = if vc_epoch_id.is_some() {
+        let leaf_node_extensions = if vc_group_id.is_some() {
             vc_leaf_node_extensions::<AirComponent>()
         } else {
             default_leaf_node_extensions::<AirComponent>()
@@ -1331,8 +1336,8 @@ impl Group {
             .skip_lifetime_validation()
             .leaf_node_parameters(leaf_node_params.clone(), leaf_node_params)
             .create_group_info(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let res = builder.build(&provider, signer, credential_with_key, group_info);
         let (apq_mls_group, commit_bundle) = match res {
@@ -1438,15 +1443,15 @@ impl Group {
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
 
         let (mls_commit, welcome_option, group_info_option) = {
             let provider = AirOpenMlsProvider::new(connection.as_mut());
             self.mls_group
                 .set_aad(aad_message.tls_serialize_detached()?);
             let mut builder = self.mls_group.commit_builder().force_self_update(true);
-            if let Some(epoch_id) = vc_epoch_id {
-                builder = builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?;
+            if let Some(group_id) = &vc_group_id {
+                builder = builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?;
             }
             let res = builder
                 .propose_adds(key_packages)
@@ -1564,7 +1569,7 @@ impl Group {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
 
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
@@ -1580,8 +1585,8 @@ impl Group {
         if let Some(proposal) = app_ephemeral {
             builder = builder.add_t_proposal(proposal);
         }
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let bundle = match builder.finalize(&provider, signer, |_| true, |_| true) {
             Ok(bundle) => bundle,
@@ -1654,12 +1659,12 @@ impl Group {
         });
         let aad = AadMessage::from(aad_payload).tls_serialize_detached()?;
         self.mls_group.set_aad(aad);
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
         let mut builder = self.mls_group.commit_builder().force_self_update(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?;
+        if let Some(group_id) = &vc_group_id {
+            builder = builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?;
         }
         let (mls_message, _welcome_option, group_info_option) = builder
             .propose_removals(remove_indices)
@@ -1722,7 +1727,7 @@ impl Group {
         }
         ensure!(members.is_empty(), "Not all members to remove were found");
 
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
         let provider = AirOpenMlsProvider::new(connection.as_mut());
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
 
@@ -1737,8 +1742,8 @@ impl Group {
                 .force_self_update(true)
                 .propose_removals(remove_indices)
                 .create_group_info(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let bundle = builder.finalize(&provider, signer, |_| true, |_| true)?;
 
@@ -1759,7 +1764,7 @@ impl Group {
         mut connection: impl WriteConnection,
         signer: &UserSigningKey,
     ) -> anyhow::Result<DeleteGroupParamsOut> {
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
         let provider = AirOpenMlsProvider::new(connection.as_mut());
         let remove_indices = self
             .mls_group()
@@ -1779,8 +1784,8 @@ impl Group {
         self.mls_group.set_aad(aad);
 
         let mut builder = self.mls_group.commit_builder().force_self_update(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?;
+        if let Some(group_id) = &vc_group_id {
+            builder = builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?;
         }
         let (mls_message, _welcome_option, group_info_option) = builder
             .propose_removals(remove_indices)
@@ -1804,7 +1809,7 @@ impl Group {
         mut connection: impl WriteConnection,
         signer: &UserSigningKey,
     ) -> anyhow::Result<ApqCommitMessageBundle> {
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut connection).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut connection).await?;
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
         let removed_indices = self
@@ -1829,8 +1834,8 @@ impl Group {
             .force_self_update(true)
             .propose_removals(removed_indices)
             .create_group_info(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let bundle = builder.finalize(&provider, signer, |_| true, |_| true)?;
         debug_assert!(bundle.welcome.is_none());
@@ -1953,26 +1958,6 @@ impl Group {
         self.pending_diff = None;
         self.send_message_collision_key = None;
         self.clear_commit_failed(&mut *txn).await?;
-
-        // The emulation `EpochId` is derived from this epoch's exporter, so a
-        // self-group epoch change invalidates it. Re-register here: every
-        // emulator client passes through this point when the self group
-        // advances.
-        //
-        // Skipped when the merged commit removed us: a non-member cannot derive
-        // the new epoch's exporter, and it has no further commit to emulate. This
-        // is the path a device takes when a sibling unlinks it.
-        if AirComponent::is_self_group_context(self.mls_group.extensions())
-            && self.mls_group.is_active()
-        {
-            let epoch = self.mls_group.epoch();
-            let epoch_id = self.register_vc_emulation_epoch(&mut *txn)?;
-            debug!(
-                ?epoch_id,
-                ?epoch,
-                "registered self-group VC emulation epoch"
-            );
-        }
 
         // The linked-device list joins metadata with the live self-group
         // members. Notify its self-chat listener whenever a commit changes the
@@ -2152,6 +2137,7 @@ impl Group {
         txn: &mut WriteDbTransaction<'_>,
         signer: &LeafSigningKey,
         new_group_data: Option<GroupDataBytes>,
+        derivation_epoch: DerivationEpoch,
     ) -> Result<GroupOperationParamsOut> {
         // We don't expect there to be a welcome.
         let aad = AadMessage::from(AadPayload::GroupOperation(GroupOperationParamsAad {
@@ -2178,7 +2164,7 @@ impl Group {
         // A leaf shared with sibling emulator clients must be replaced with key
         // material derived from the emulation epoch, or the siblings cannot
         // rederive it and drop out of the group.
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut *txn).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut *txn).await?;
 
         self.mls_group.set_aad(aad);
         let (mls_message, group_info) = {
@@ -2191,9 +2177,10 @@ impl Group {
 
             let mut builder = builder
                 .force_self_update(true)
-                .leaf_node_parameters(leaf_node_parameters);
-            if let Some(epoch_id) = vc_epoch_id {
-                builder = builder.vc_emulation(provider.crypto(), provider.storage(), epoch_id)?;
+                .leaf_node_parameters(leaf_node_parameters)
+                .derivation_epoch(derivation_epoch.rotates());
+            if let Some(group_id) = &vc_group_id {
+                builder = builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?;
             }
 
             let (mls_message, _welcome_option, group_info_option) = builder
@@ -2225,6 +2212,7 @@ impl Group {
         &mut self,
         txn: &mut WriteDbTransaction<'_>,
         signer: &LeafSigningKey,
+        derivation_epoch: DerivationEpoch,
     ) -> anyhow::Result<ApqGroupOperationParamsOut> {
         let aad = AadMessage::from(AadPayload::GroupOperation(GroupOperationParamsAad {
             new_encrypted_user_profile_keys: Vec::new(),
@@ -2248,7 +2236,7 @@ impl Group {
             self.own_leaf_capabilities(),
         )?;
 
-        let vc_epoch_id = self.resolve_vc_emulation_epoch(&mut *txn).await?;
+        let vc_group_id = self.resolve_vc_emulation_group(&mut *txn).await?;
 
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
@@ -2256,9 +2244,10 @@ impl Group {
             apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
                 .force_self_update(true)
                 .leaf_node_parameters(t_leaf_node_parameters, pq_leaf_node_parameters)
+                .derivation_epoch(derivation_epoch.rotates())
                 .create_group_info(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let bundle = builder.finalize(&provider, signer, |_| true, |_| true)?;
 
@@ -2627,46 +2616,22 @@ impl Group {
             .is_some_and(leaf_node_is_virtual_client)
     }
 
-    /// Register a virtual-clients emulation epoch for this group's current
-    /// epoch, and return its [`EpochId`].
-    ///
-    /// Only meaningful on the self group, which is the emulation group. The
-    /// emulation state lives on the classical leg; the PQ leg has none.
-    ///
-    /// Idempotent per epoch: registration punctures the exporter, so a repeated
-    /// call in the same epoch returns the recorded [`EpochId`] rather than
-    /// deriving a new one.
-    pub(crate) fn register_vc_emulation_epoch(
-        &mut self,
-        mut connection: impl WriteConnection,
-    ) -> Result<EpochId> {
-        let provider = AirOpenMlsProvider::new(connection.as_mut());
-        let (t_group, _) = self.apq_mls_groups_mut()?;
-        t_group
-            .register_vc_emulation_epoch(provider.crypto(), provider.storage())
-            .context("register VC emulation epoch")
-    }
-
-    /// The emulation epoch a commit replacing our leaf has to derive from, or
+    /// The emulation group a commit replacing our leaf has to derive from, or
     /// `None` if this leaf is not shared with sibling emulator clients.
     ///
-    /// The epoch is registered when the self group advances (see
-    /// [`Group::merge_pending_commit`]), so this is expected to be a lookup of
-    /// the epoch every emulator client already recorded, not a fresh
-    /// registration.
-    async fn resolve_vc_emulation_epoch(
+    /// The emulation group is the self group. openmls resolves the concrete
+    /// derivation epoch from it, always taking the newest one.
+    async fn resolve_vc_emulation_group(
         &self,
-        mut connection: impl WriteConnection,
-    ) -> Result<Option<EpochId>> {
+        connection: impl ReadConnection,
+    ) -> Result<Option<GroupId>> {
         if !self.own_leaf_is_virtual_client() {
             return Ok(None);
         }
-        let mut self_group = self_group::SelfGroup::load(&mut connection)
+        let group_id = OwnClientInfo::load_self_group_id(connection)
             .await?
             .context("no self group to derive the emulation epoch from")?;
-        Ok(Some(
-            self_group.register_vc_emulation_epoch(&mut connection)?,
-        ))
+        Ok(Some(group_id))
     }
 
     pub(crate) fn store_connection_offer_psk(

--- a/coreclient/src/groups/openmls_provider/storage_provider.rs
+++ b/coreclient/src/groups/openmls_provider/storage_provider.rs
@@ -785,15 +785,15 @@ impl StorageProvider<CURRENT_VERSION> for SqliteStorageProvider<'_> {
         block_async_in_place(task)
     }
 
-    fn write_vc_emulation_epoch_state<
+    fn write_vc_derivation_epoch_state<
         EpochId: traits::VcEpochId<CURRENT_VERSION>,
-        VcEmulationEpochState: traits::VcEmulationEpochState<CURRENT_VERSION>,
+        VcDerivationEpochState: traits::VcDerivationEpochState<CURRENT_VERSION>,
     >(
         &self,
         epoch_id: &EpochId,
-        vc_emulation_epoch_state: &VcEmulationEpochState,
+        vc_derivation_epoch_state: &VcDerivationEpochState,
     ) -> Result<(), Self::Error> {
-        let storable = StorableVcSecretRef(vc_emulation_epoch_state);
+        let storable = StorableVcSecretRef(vc_derivation_epoch_state);
         let mut connection = self.connection.borrow_mut();
         let task = storable.store_vc_emulation_group_secret(
             &mut **connection,
@@ -803,13 +803,13 @@ impl StorageProvider<CURRENT_VERSION> for SqliteStorageProvider<'_> {
         block_async_in_place(task)
     }
 
-    fn vc_emulation_epoch_state<
+    fn vc_derivation_epoch_state<
         EpochId: traits::VcEpochId<CURRENT_VERSION>,
-        VcEmulationEpochState: traits::VcEmulationEpochState<CURRENT_VERSION>,
+        VcDerivationEpochState: traits::VcDerivationEpochState<CURRENT_VERSION>,
     >(
         &self,
         epoch_id: &EpochId,
-    ) -> Result<Option<VcEmulationEpochState>, Self::Error> {
+    ) -> Result<Option<VcDerivationEpochState>, Self::Error> {
         let storable = StorableVcEpochIdRef(epoch_id);
         let mut connection = self.connection.borrow_mut();
         let task = storable.load_vc_emulation_group_secret(
@@ -856,13 +856,13 @@ impl StorageProvider<CURRENT_VERSION> for SqliteStorageProvider<'_> {
         block_async_in_place(task)
     }
 
-    fn write_registered_vc_emulation_epoch<
+    fn write_registered_vc_derivation_epoch<
         GroupId: traits::GroupId<CURRENT_VERSION>,
-        RegisteredVcEmulationEpoch: traits::RegisteredVcEmulationEpoch<CURRENT_VERSION>,
+        RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<CURRENT_VERSION>,
     >(
         &self,
         group_id: &GroupId,
-        registered: &RegisteredVcEmulationEpoch,
+        registered: &RegisteredVcDerivationEpoch,
     ) -> Result<(), Self::Error> {
         let storable = StorableRegisteredVcEmulationEpochRef(registered);
         let mut connection = self.connection.borrow_mut();
@@ -870,20 +870,20 @@ impl StorageProvider<CURRENT_VERSION> for SqliteStorageProvider<'_> {
         block_async_in_place(task)
     }
 
-    fn registered_vc_emulation_epoch<
+    fn registered_vc_derivation_epoch<
         GroupId: traits::GroupId<CURRENT_VERSION>,
-        RegisteredVcEmulationEpoch: traits::RegisteredVcEmulationEpoch<CURRENT_VERSION>,
+        RegisteredVcDerivationEpoch: traits::RegisteredVcDerivationEpoch<CURRENT_VERSION>,
     >(
         &self,
         group_id: &GroupId,
-    ) -> Result<Option<RegisteredVcEmulationEpoch>, Self::Error> {
+    ) -> Result<Option<RegisteredVcDerivationEpoch>, Self::Error> {
         let storable = StorableGroupIdRef(group_id);
         let mut connection = self.connection.borrow_mut();
         let task = storable.load_registered_vc_emulation_epoch(&mut **connection);
         block_async_in_place(task)
     }
 
-    fn delete_registered_vc_emulation_epoch<GroupId: traits::GroupId<CURRENT_VERSION>>(
+    fn delete_registered_vc_derivation_epoch<GroupId: traits::GroupId<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
     ) -> Result<(), Self::Error> {
@@ -972,7 +972,9 @@ impl StorageProvider<CURRENT_VERSION> for SqliteStorageProvider<'_> {
         block_async_in_place(task)
     }
 
-    fn delete_vc_emulation_state_if_unreferenced<EpochId: traits::VcEpochId<CURRENT_VERSION>>(
+    fn delete_vc_derivation_epoch_state_if_unreferenced<
+        EpochId: traits::VcEpochId<CURRENT_VERSION>,
+    >(
         &self,
         epoch_id: &EpochId,
     ) -> Result<bool, Self::Error> {

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -160,12 +160,12 @@ impl Group {
                     return Ok(ProcessMessageResult::ResyncRequired);
                 }
                 Err(ProcessMessageError::InvalidCommit(StageCommitError::VirtualClientsError(
-                    error @ VirtualClientsError::MissingEmulationEpochState
+                    error @ VirtualClientsError::MissingDerivationEpochState
                     | error @ VirtualClientsError::MissingOperationTree
                     | error @ VirtualClientsError::OperationGenerationConsumed
                     | error @ VirtualClientsError::OperationGenerationTooDistant,
                 ))) => {
-                    // The commit was not built against a virtual client emulation epoch we hold.
+                    // The commit was not built against a virtual client derivation epoch we hold.
                     // Only a resync can get us back onto the same shared leaf.
                     //
                     // TODO(gabriel): Like for the other desyncs, there's no automatic resyncing.
@@ -883,7 +883,7 @@ impl Group {
             }
             Err(ApqProcessMessageError::Processing(ProcessMessageError::InvalidCommit(
                 StageCommitError::VirtualClientsError(
-                    error @ VirtualClientsError::MissingEmulationEpochState
+                    error @ VirtualClientsError::MissingDerivationEpochState
                     | error @ VirtualClientsError::MissingOperationTree
                     | error @ VirtualClientsError::OperationGenerationConsumed
                     | error @ VirtualClientsError::OperationGenerationTooDistant,

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -19,14 +19,15 @@ use aircommon::{
 use airprotos::client::{
     component::AirComponent,
     group::{EncryptedGroupTitle, GroupData},
-    virtual_client::{VirtualClientAction, extract_virtual_client_action},
+    virtual_client::{
+        VirtualClientAction, VirtualClientCommitData, extract_virtual_client_commit_data,
+    },
 };
 use anyhow::{Context, bail, ensure};
 use openmls::{
     components::vc_derivation_info::{
-        EpochId, KeyPackageUpload, VC_COMPONENT_ID, process_vc_key_package_upload,
+        KeyPackageUpload, VC_COMPONENT_ID, process_vc_key_package_upload,
     },
-    framing::SafeAadItem,
     group::GroupId,
     prelude::{LeafNodeIndex, ProcessedMessage},
 };
@@ -117,15 +118,6 @@ impl SelfGroup {
         self.group.identity_link_wrapper_key()
     }
 
-    /// Register a virtual-clients emulation epoch for the self group's current
-    /// epoch. See [`Group::register_vc_emulation_epoch`].
-    pub(crate) fn register_vc_emulation_epoch(
-        &mut self,
-        connection: impl WriteConnection,
-    ) -> anyhow::Result<EpochId> {
-        self.group.register_vc_emulation_epoch(connection)
-    }
-
     /// Stages an empty self-update commit on the self-group carrying a [`KeyPackageUpload`] in its
     /// SafeAAD.
     ///
@@ -141,9 +133,9 @@ impl SelfGroup {
         let (t_mls_group, pq_mls_group) = self.group.apq_mls_groups_mut()?;
 
         // SafeAAD hint the DS extracts from the T commit to trigger promotion.
-        let action_bytes =
-            VirtualClientAction::KeyPackageUpload(upload).tls_serialize_detached()?;
-        t_mls_group.set_safe_aad(vec![SafeAadItem::new(VC_COMPONENT_ID, action_bytes)])?;
+        let commit_data =
+            VirtualClientCommitData::new(vec![VirtualClientAction::KeyPackageUpload(upload)])?;
+        t_mls_group.set_safe_aad(vec![commit_data.to_safe_aad_item()?])?;
 
         // Regular AAD tail (required by DS commit validation)
         let aad_payload = AadPayload::GroupOperation(GroupOperationParamsAad {
@@ -198,9 +190,9 @@ impl SelfGroup {
             "clients to remove are not in the self group: {client_ids:?}"
         );
 
-        let vc_epoch_id = self
+        let vc_group_id = self
             .group
-            .resolve_vc_emulation_epoch(&mut connection)
+            .resolve_vc_emulation_group(&mut connection)
             .await?;
         let provider = AirOpenMlsProvider::new(connection.as_mut());
         let (t_mls_group, pq_mls_group) = self.group.apq_mls_groups_mut()?;
@@ -216,8 +208,8 @@ impl SelfGroup {
                 .force_self_update(true)
                 .propose_removals(remove_indices)
                 .create_group_info(true);
-        if let Some(epoch_id) = vc_epoch_id {
-            builder = builder.vc_emulation(epoch_id);
+        if let Some(group_id) = vc_group_id {
+            builder = builder.vc_emulation(group_id);
         }
         let bundle = builder.finalize(&provider, signer, |_| true, |_| true)?;
 
@@ -384,47 +376,46 @@ impl Group {
         processed_message: &ProcessedMessage,
         sender_index: LeafNodeIndex,
     ) -> anyhow::Result<()> {
-        let Some(action) = extract_virtual_client_action(processed_message)? else {
+        let Some(commit_data) = extract_virtual_client_commit_data(processed_message)? else {
             return Ok(());
         };
-        let VirtualClientAction::KeyPackageUpload(upload) = action;
 
         let own_client_info = OwnClientInfo::load(&mut *txn).await?;
         ensure!(
             own_client_info.self_group_id.as_ref() == Some(self.group_id()),
-            "KeyPackageUpload component outside the self-group"
-        );
-        ensure!(
-            upload.leaf_index == sender_index,
-            "KeyPackageUpload for a leaf other than the sender"
-        );
-        ensure!(
-            upload.leaf_index != self.mls_group().own_leaf_index(),
-            "Sibling KeyPackageUpload from own leaf"
+            "virtual-client component outside the self-group"
         );
 
-        {
-            let provider = AirOpenMlsProvider::new(txn.as_mut());
-            // A passive sibling may not have registered this epoch's
-            // operation tree yet. Registration is idempotent and must happen
-            // at the pre-merge epoch, which is the epoch the upload
-            // references.
-            let epoch_id = self
-                .mls_group_mut()
-                .register_vc_emulation_epoch(provider.crypto(), provider.storage())?;
+        for upload in commit_data.key_package_uploads() {
             ensure!(
-                epoch_id == upload.epoch_id,
-                "KeyPackageUpload references a foreign emulation epoch"
+                upload.leaf_index == sender_index,
+                "KeyPackageUpload for a leaf other than the sender"
             );
-            process_vc_key_package_upload(&provider, &upload)?;
-        }
+            ensure!(
+                upload.leaf_index != self.mls_group().own_leaf_index(),
+                "Sibling KeyPackageUpload from own leaf"
+            );
 
-        // The sibling's batch replaces the served set; track it as live.
-        let (plain_refs, apq_refs) =
-            HeterogeneousVcKeyPackageBatch::split_vc_batch_refs(&upload.key_package_info)?;
-        mark_key_packages_as_live(&mut *txn, &plain_refs, false).await?;
-        mark_key_packages_as_live(&mut *txn, &apq_refs, true).await?;
-        delete_orphaned_key_packages(&mut *txn).await?;
+            {
+                let provider = AirOpenMlsProvider::new(txn.as_mut());
+                let epoch_id = self
+                    .mls_group()
+                    .newest_vc_derivation_epoch(provider.storage())?
+                    .context("self group has no derivation epoch")?;
+                ensure!(
+                    epoch_id == upload.epoch_id,
+                    "KeyPackageUpload references a foreign emulation epoch"
+                );
+                process_vc_key_package_upload(&provider, upload)?;
+            }
+
+            // The sibling's batch replaces the served set; track it as live.
+            let (plain_refs, apq_refs) =
+                HeterogeneousVcKeyPackageBatch::split_vc_batch_refs(&upload.key_package_info)?;
+            mark_key_packages_as_live(&mut *txn, &plain_refs, false).await?;
+            mark_key_packages_as_live(&mut *txn, &apq_refs, true).await?;
+            delete_orphaned_key_packages(&mut *txn).await?;
+        }
 
         Ok(())
     }

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -40,6 +40,7 @@ use airprotos::client::{
     self_group::{
         AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate, TokenSeed,
     },
+    virtual_client::VirtualClientCommitData,
 };
 use anyhow::{Result, anyhow, ensure};
 use openmls::prelude::{
@@ -241,6 +242,12 @@ impl Group {
 
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
+
+        // Temporary measure, to be removed with the DS-side check it exists
+        // for.
+        let commit_data = VirtualClientCommitData::new(Vec::new())?;
+        t_mls_group.set_safe_aad(vec![commit_data.to_safe_aad_item()?])?;
+
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
             .force_self_update(true)
             .add_t_proposal(proposal)

--- a/coreclient/src/job/chat_operation.rs
+++ b/coreclient/src/job/chat_operation.rs
@@ -39,8 +39,25 @@ enum ChatOperationType {
     },
     Leave,
     Delete,
-    Update(Option<ChatAttributes>),
-    ApqUpdate,
+    Update(Option<ChatAttributes>, DerivationEpoch),
+    ApqUpdate(DerivationEpoch),
+}
+
+/// Whether a self-update commit also opens a new virtual-client derivation
+/// epoch.
+///
+/// Only the emulation group, i.e. the self group, has derivation epochs, and
+/// only its periodic self-update rotates them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DerivationEpoch {
+    Rotate,
+    Keep,
+}
+
+impl DerivationEpoch {
+    pub(crate) fn rotates(self) -> bool {
+        self == Self::Rotate
+    }
 }
 
 pub(crate) struct ChatOperation {
@@ -134,17 +151,21 @@ impl ChatOperation {
         }
     }
 
-    pub(crate) fn update(chat_id: ChatId, chat_attributes: Option<ChatAttributes>) -> Self {
+    pub(crate) fn update(
+        chat_id: ChatId,
+        chat_attributes: Option<ChatAttributes>,
+        derivation_epoch: DerivationEpoch,
+    ) -> Self {
         ChatOperation {
             chat_id,
-            operation: ChatOperationType::Update(chat_attributes),
+            operation: ChatOperationType::Update(chat_attributes, derivation_epoch),
         }
     }
 
-    pub(crate) fn apq_update(chat_id: ChatId) -> Self {
+    pub(crate) fn apq_update(chat_id: ChatId, derivation_epoch: DerivationEpoch) -> Self {
         ChatOperation {
             chat_id,
-            operation: ChatOperationType::ApqUpdate,
+            operation: ChatOperationType::ApqUpdate(derivation_epoch),
         }
     }
 
@@ -200,8 +221,8 @@ impl ChatOperation {
             ChatOperationType::AddClient { .. }
             | ChatOperationType::Leave
             | ChatOperationType::Delete
-            | ChatOperationType::Update(_)
-            | ChatOperationType::ApqUpdate => {}
+            | ChatOperationType::Update(..)
+            | ChatOperationType::ApqUpdate(_) => {}
         }
         Ok(())
     }
@@ -241,10 +262,14 @@ impl ChatOperation {
             } => self.execute_add_client(context, *key_package, device).await,
             ChatOperationType::Leave => self.execute_leave_chat(context).await,
             ChatOperationType::Delete => self.execute_delete(context).await,
-            ChatOperationType::Update(chat_attributes) => {
-                self.execute_update(context, chat_attributes).await
+            ChatOperationType::Update(chat_attributes, derivation_epoch) => {
+                self.execute_update(context, chat_attributes, derivation_epoch)
+                    .await
             }
-            ChatOperationType::ApqUpdate => self.execute_apq_self_update(context).await,
+            ChatOperationType::ApqUpdate(derivation_epoch) => {
+                self.execute_apq_self_update(context, derivation_epoch)
+                    .await
+            }
         }
     }
 
@@ -361,6 +386,7 @@ impl ChatOperation {
         self,
         context: &mut JobContext<'_, '_>,
         chat_attributes: Option<ChatAttributes>,
+        derivation_epoch: DerivationEpoch,
     ) -> Result<Vec<ChatMessage>, JobError<ChatOperationError>> {
         let JobContext {
             api_clients,
@@ -451,6 +477,7 @@ impl ChatOperation {
                     self.chat_id,
                     group_data,
                     new_chat_picture,
+                    derivation_epoch,
                 )
                 .await
             })
@@ -462,6 +489,7 @@ impl ChatOperation {
     async fn execute_apq_self_update(
         self,
         context: &mut JobContext<'_, '_>,
+        derivation_epoch: DerivationEpoch,
     ) -> Result<Vec<ChatMessage>, JobError<ChatOperationError>> {
         let JobContext { db, key_store, .. } = context;
         let job = db
@@ -472,6 +500,7 @@ impl ChatOperation {
                     txn,
                     &key_store.signing_key,
                     self.chat_id,
+                    derivation_epoch,
                 )
                 .await
             })

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -50,7 +50,8 @@ use crate::{
         self_group::SelfGroup,
     },
     job::{
-        Job, JobContext, JobContextReadConnection, JobError, chat_operation::ChatOperationError,
+        Job, JobContext, JobContextReadConnection, JobError,
+        chat_operation::{ChatOperationError, DerivationEpoch},
     },
     key_stores::{
         indexed_keys::StorableIndexedKey,
@@ -786,6 +787,7 @@ impl PendingChatOperation {
         chat_id: ChatId,
         new_group_data: Option<GroupData>,
         new_chat_picture: Option<Vec<u8>>,
+        derivation_epoch: DerivationEpoch,
     ) -> anyhow::Result<Self> {
         let group_data_bytes = new_group_data.map(|data| data.encode()).transpose()?;
         Self::create_update_with_raw_group_data(
@@ -794,6 +796,7 @@ impl PendingChatOperation {
             chat_id,
             group_data_bytes,
             new_chat_picture,
+            derivation_epoch,
         )
         .await
     }
@@ -802,12 +805,16 @@ impl PendingChatOperation {
         txn: &mut WriteDbTransaction<'_>,
         signer: &UserSigningKey,
         chat_id: ChatId,
+        derivation_epoch: DerivationEpoch,
     ) -> anyhow::Result<Self> {
         let mut group = Group::load_with_chat_id_clean_verified(&mut *txn, chat_id)
             .await?
             .with_context(|| format!("Can't find group with chat id {chat_id}"))?;
         let signer = OwnClientInfo::signer_for_group(&mut *txn, group.group_id(), signer).await?;
-        let params = group.group_mut().apq_update(txn, &signer).await?;
+        let params = group
+            .group_mut()
+            .apq_update(txn, &signer, derivation_epoch)
+            .await?;
         let job = Self::new(group, OperationType::apq_other(params));
         job.store(txn).await?;
         Ok(job)
@@ -982,6 +989,7 @@ impl PendingChatOperation {
         chat_id: ChatId,
         group_data_bytes: Option<GroupDataBytes>,
         new_chat_picture: Option<Vec<u8>>,
+        derivation_epoch: DerivationEpoch,
     ) -> anyhow::Result<Self> {
         let mut group = Group::load_with_chat_id_clean_verified(&mut *txn, chat_id)
             .await?
@@ -990,7 +998,7 @@ impl PendingChatOperation {
         let signer = OwnClientInfo::signer_for_group(&mut *txn, group.group_id(), signer).await?;
         let params = group
             .group_mut()
-            .update(&mut *txn, &signer, group_data_bytes)
+            .update(&mut *txn, &signer, group_data_bytes, derivation_epoch)
             .await?;
 
         let job = Self::new(
@@ -1950,9 +1958,13 @@ mod tests {
                     Chat::new_group_chat(t_group_id, ChatAttributes::new("Notes".to_owned(), None));
                 chat.store(&mut *txn).await?;
 
-                let job =
-                    PendingChatOperation::create_apq_self_update(txn, &user_signing_key, chat.id())
-                        .await?;
+                let job = PendingChatOperation::create_apq_self_update(
+                    txn,
+                    &user_signing_key,
+                    chat.id(),
+                    DerivationEpoch::Keep,
+                )
+                .await?;
 
                 let staged = job
                     .group

--- a/coreclient/src/key_stores/mod.rs
+++ b/coreclient/src/key_stores/mod.rs
@@ -20,6 +20,7 @@ use apqmls::{
 };
 use openmls::{
     components::vc_derivation_info::{EpochId, KeyPackageInfo},
+    group::GroupId,
     prelude::{
         Credential, CredentialType, CredentialWithKey, Extension, KeyPackage, KeyPackageBuilder,
         KeyPackageRef, LastResortExtension, OpenMlsProvider, SignaturePublicKey, UnknownExtension,
@@ -224,7 +225,7 @@ impl MemoryUserKeyStore {
         &self,
         mut connection: impl WriteConnection,
         qs_client_id: &QsClientId,
-        epoch_id: EpochId,
+        emulation_group_id: &GroupId,
         config: VcKeyPackageBatchConfig,
     ) -> Result<HeterogeneousVcKeyPackageBatch> {
         let t_credential = CredentialWithKey {
@@ -244,8 +245,11 @@ impl MemoryUserKeyStore {
 
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
-        let mut batch_builder =
-            VcKeyPackageBatchBuilder::with_capacity(&provider, epoch_id, config.num_plain())?;
+        let mut batch_builder = VcKeyPackageBatchBuilder::with_capacity(
+            &provider,
+            emulation_group_id,
+            config.num_plain(),
+        )?;
 
         for is_last_resort in (0..config.key_packages)
             .map(|_| false)
@@ -286,6 +290,7 @@ impl MemoryUserKeyStore {
         let batch = batch_builder.finalize(&provider)?;
 
         let mut res = HeterogeneousVcKeyPackageBatch {
+            epoch_id: batch.epoch_id,
             generation: batch.generation,
             key_packages: Vec::with_capacity(config.num_plain()),
             apq_key_packages: Vec::with_capacity(config.num_apq()),
@@ -341,6 +346,8 @@ impl VcKeyPackageBatchConfig {
 }
 
 pub(crate) struct HeterogeneousVcKeyPackageBatch {
+    /// The derivation epoch the batch was built from.
+    pub(crate) epoch_id: EpochId,
     pub(crate) generation: u32,
     pub(crate) key_packages: Vec<KeyPackage>,
     pub(crate) apq_key_packages: Vec<ApqKeyPackage>,

--- a/coreclient/src/outbound_service/chat_messages.rs
+++ b/coreclient/src/outbound_service/chat_messages.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::db::access::WriteDbTransaction;
 use crate::groups::{Group, handle_group_not_found_on_ds};
 use crate::job::JobError;
-use crate::job::chat_operation::ChatOperation;
+use crate::job::chat_operation::{ChatOperation, DerivationEpoch};
 use crate::job::pending_chat_operation::PendingChatOperation;
 use crate::outbound_service::error::OutboundServiceError;
 use crate::outbound_service::resync::Resync;
@@ -394,7 +394,10 @@ impl OutboundServiceContext {
         &self,
         chat_id: ChatId,
     ) -> Result<CommitOutcome, OutboundServiceError> {
-        match self.execute_job(ChatOperation::update(chat_id, None)).await {
+        match self
+            .execute_job(ChatOperation::update(chat_id, None, DerivationEpoch::Keep))
+            .await
+        {
             Ok(_) => Ok(CommitOutcome::Committed),
             Err(JobError::Blocked) => Ok(CommitOutcome::ChatBlocked),
             Err(JobError::NetworkError) => Err(OutboundServiceError::recoverable(anyhow!(

--- a/coreclient/src/outbound_service/key_packages.rs
+++ b/coreclient/src/outbound_service/key_packages.rs
@@ -102,7 +102,7 @@ impl OutboundServiceContext {
 
     async fn upload_via_self_group(&self, mut self_group: SelfGroup) -> anyhow::Result<Duration> {
         // Generate key packages
-        let Some((epoch_id, generated)) = self
+        let Some(generated) = self
             .db
             .with_write_transaction(async |txn| -> anyhow::Result<_> {
                 // Pending chat operation guard
@@ -127,16 +127,13 @@ impl OutboundServiceContext {
                     .mls_group
                     .clear_pending_commit(provider.storage())?;
 
-                let epoch_id = self_group
-                    .group_mut()
-                    .mls_group_mut()
-                    .register_vc_emulation_epoch(provider.crypto(), provider.storage())?;
+                let emulation_group_id = self_group.group().mls_group().group_id().clone();
 
                 // TODO: Heavy CPU operation, do we have to spawn_blocking here?
                 let generated = self.key_store.generate_vc_key_package_batch(
                     &mut *txn,
                     &self.qs_client_id,
-                    epoch_id.clone(),
+                    &emulation_group_id,
                     VcKeyPackageBatchConfig {
                         key_packages: KEY_PACKAGES,
                         last_resort: true,
@@ -145,7 +142,7 @@ impl OutboundServiceContext {
                     },
                 )?;
 
-                Ok(Some((epoch_id, generated)))
+                Ok(Some(generated))
             })
             .await?
         else {
@@ -154,6 +151,7 @@ impl OutboundServiceContext {
 
         // Upload and stage key packages
         let HeterogeneousVcKeyPackageBatch {
+            epoch_id,
             generation,
             key_packages,
             apq_key_packages,

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -27,6 +27,7 @@ use crate::{
         CoreUser,
         api_clients::ApiClients,
         multi_device::{ConnectionContact, HigherLevelGroup},
+        own_client_info::OwnClientInfo,
     },
     db::access::{WriteConnection, WriteDbTransaction},
     groups::{
@@ -410,8 +411,12 @@ impl Resync {
         // Delete any old group states if they exist
         Group::delete_from_db(txn, &self.group_id).await?;
 
-        let vc_epoch_id = if self.shares_vc_leaf {
-            Some(CoreUser::register_self_group_vc_emulation_epoch(&mut *txn).await?)
+        let vc_group_id = if self.shares_vc_leaf {
+            Some(
+                OwnClientInfo::load_self_group_id(&mut *txn)
+                    .await?
+                    .context("self group not found")?,
+            )
         } else {
             None
         };
@@ -428,7 +433,7 @@ impl Resync {
                 self.group_state_ear_key,
                 self.identity_link_wrapper_key,
                 aad,
-                vc_epoch_id,
+                vc_group_id,
             )
             .await??;
             Ok((
@@ -451,7 +456,7 @@ impl Resync {
                 self.identity_link_wrapper_key,
                 aad,
                 None, // This is not in response to a connection offer.
-                vc_epoch_id,
+                vc_group_id,
             )
             .await??;
             Ok((

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use aircommon::identifiers::USERNAME_REFRESH_THRESHOLD;
-use airprotos::{auth_service::v1::OperationType, client::group::GroupData};
+use airprotos::{
+    auth_service::v1::OperationType,
+    client::{component::AirComponent, group::GroupData},
+};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
@@ -16,7 +19,7 @@ use crate::{
     groups::Group,
     job::{
         JobError,
-        chat_operation::ChatOperation,
+        chat_operation::{ChatOperation, DerivationEpoch},
         operation::{Operation, OperationData, OperationId, OperationKind},
         pending_chat_operation::PendingChatOperation,
     },
@@ -515,19 +518,40 @@ impl OutboundServiceContext {
 
         let migration_attrs = legacy_group_data_migration(&group, is_connection, erase_attributes);
 
+        // The periodic self-update of the emulation group, i.e. the self group,
+        // doubles as the rotation of its derivation epoch. openmls rejects the
+        // marker on any other group.
+        let derivation_epoch = if group.mls_group().is_emulation_group() {
+            DerivationEpoch::Rotate
+        } else {
+            // A self group without a registered derivation epoch loads as a
+            // non-emulation group and cannot register one. An unmarked
+            // self-update would only bounce off the DS, so skip it and leave a
+            // diagnosable trace.
+            if AirComponent::is_self_group_context(group.mls_group().extensions()) {
+                error!(
+                    %chat_id,
+                    "self group has no derivation epoch and cannot register one, \
+                     skipping its self-update"
+                );
+                return Ok(SelfUpdateOutcome::Skipped);
+            }
+            DerivationEpoch::Keep
+        };
+
         let job = if migration_attrs.is_some() {
             // Migration takes precedence over PQ self-update (PQ interval is long, so this is
             // fine).
             info!(%chat_id, "Migrating legacy group data");
-            ChatOperation::update(chat_id, migration_attrs)
+            ChatOperation::update(chat_id, migration_attrs, derivation_epoch)
         } else if pq_due {
             // Both T and PQ are due and no migration is needed, so the joint APQ update covers
             // both.
             info!(%chat_id, "Performing joint APQ self-update");
-            ChatOperation::apq_update(chat_id)
+            ChatOperation::apq_update(chat_id, derivation_epoch)
         } else {
             // Pure T-only update
-            ChatOperation::update(chat_id, None)
+            ChatOperation::update(chat_id, None, derivation_epoch)
         };
         match self.execute_job(job).await {
             Ok(_messages) => Ok(SelfUpdateOutcome::Updated),

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,7 @@ allow-git = [
     "https://github.com/RustCrypto/RSA",
     # includes an unreleased patch of ml-dsa
     "https://github.com/RustCrypto/signatures",
+    "https://github.com/openmls/openmls",
 ]
 
 [sources.allow-org]

--- a/protos/src/client/virtual_client.rs
+++ b/protos/src/client/virtual_client.rs
@@ -2,47 +2,24 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use openmls::{
-    components::vc_derivation_info::{KeyPackageUpload, VC_COMPONENT_ID},
-    prelude::ProcessedMessage,
+//! Emulator client actions, communicated in the SafeAAD of a self-group commit.
+//!
+//! The wire format is defined by the mls-virtual-clients draft and implemented
+//! in openmls, see [`VirtualClientCommitData`].
+
+pub use openmls::components::vc_commit_data::{
+    VcCommitDataError, VirtualClientAction, VirtualClientCommitData,
 };
-use tls_codec::{DeserializeBytes, TlsDeserializeBytes, TlsSerialize, TlsSize};
+use openmls::{components::vc_derivation_info::VC_COMPONENT_ID, prelude::ProcessedMessage};
 
-/// Emulator client action to communicate in the SafeAAD key package component of a commit in the
-/// self-group.
-///
-/// TODO: Will be moved to the openmls crate.
-///
-/// ```tls
-/// enum {
-///   reserved(0),
-///   key_package_upload(1),
-///   (255)
-/// } ActionType;
-///
-/// struct {
-///   ActionType action_type;
-///   select (VirtualClientAction.action_type) {
-///     case key_package_upload:
-///       KeyPackageUpload key_package_upload;
-///   };
-/// } VirtualClientAction;
-/// ```
-#[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize)]
-#[repr(u8)]
-pub enum VirtualClientAction {
-    #[tls_codec(discriminant = 1)]
-    KeyPackageUpload(KeyPackageUpload),
-}
-
-/// Extract the [`VirtualClientAction`] from the message's safe AAD component.
+/// Extract the [`VirtualClientCommitData`] from the message's safe AAD component.
 ///
 /// Returns `None` if the component is not present.
-pub fn extract_virtual_client_action(
+pub fn extract_virtual_client_commit_data(
     message: &ProcessedMessage,
-) -> Result<Option<VirtualClientAction>, tls_codec::Error> {
+) -> Result<Option<VirtualClientCommitData>, VcCommitDataError> {
     message
         .safe_aad_item(VC_COMPONENT_ID)
-        .map(VirtualClientAction::tls_deserialize_exact_bytes)
+        .map(VirtualClientCommitData::from_safe_aad_item_data)
         .transpose()
 }


### PR DESCRIPTION
This PR bumps OpenMLS to `main` and adapts Air to any API changes.

Virtual clients has introduced derivation epochs, which means that Air now has to explicitly mark a commit that it wants to create a derivation epoch. This happens for the daily updates only. Other commits only create derivation epochs if they change self-group membership.

Also, the SafeAAD struct of the virtual clients component changed in a backwards incompatible way. This PR adds a temporary check on the DS that disallows self-group commits that don't change membership. This is to protect updated clients from old clients derailing the self-group or higher-level groups.

Under the current multi-client testing regime for internal testers, nothing should break.