### PR TITLE
perf(app): add missing index on attachment table

### DIFF
--- a/coreclient/migrations/20260825160810_message_unsent_index.sql
+++ b/coreclient/migrations/20260825160810_message_unsent_index.sql
@@ -1,0 +1,15 @@
+-- SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Speeds up looking up attachments by status, optionally restricted or ordered
+-- by creation time (stale uploads, pending downloads).
+CREATE INDEX IF NOT EXISTS idx_attachment_status_created_at ON attachment (status, created_at);
+DROP INDEX IF EXISTS idx_attachment_pending_ordered;
+
+-- Speeds up finding messages that have not been sent yet. Unsent messages are
+-- transient and few, so the partial index stays tiny.
+CREATE INDEX IF NOT EXISTS idx_message_unsent ON message (message_id, chat_id, status)
+WHERE
+    sent = 0;


### PR DESCRIPTION
#1468 included some changes to the way we query the `attachment` table, and the existing indices did not cover the new read pattern. This cause significant lag on my Android phone when doing operations such as sending messages (since looking at stale uploads would take over a second).

The next also helps with another query that would perform a full table scan (visible as slow query on my phone).