### PR TITLE
chore: remove backwards compat guards

### DIFF
--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -139,23 +139,6 @@ impl DsGroupState {
 
         let is_self_group = self.is_self_group();
 
-        // Temporary measure to prevent old clients from derailing self-groups on new clients. Will
-        // be removed shortly.
-        if is_self_group
-            && staged_commit.add_proposals().next().is_none()
-            && staged_commit.remove_proposals().next().is_none()
-        {
-            let commit_data =
-                extract_virtual_client_commit_data(processed_message).map_err(|error| {
-                    error!(%error, "Failed to extract virtual client commit data from safe AAD");
-                    GroupOperationError::InvalidMessage
-                })?;
-            if commit_data.is_none() {
-                warn!("Self-group commit without membership change or commit data");
-                return Err(GroupOperationError::InvalidMessage);
-            }
-        }
-
         // If the commit carries an update path, the sender's new leaf credential must match the
         // group kind.
         if let Some(update_leaf) = staged_commit.update_path_leaf_node() {

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -40,7 +40,6 @@ use airprotos::client::{
     self_group::{
         AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate, TokenSeed,
     },
-    virtual_client::VirtualClientCommitData,
 };
 use anyhow::{Result, anyhow, ensure};
 use openmls::prelude::{
@@ -242,11 +241,6 @@ impl Group {
 
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let (t_mls_group, pq_mls_group) = self.apq_mls_groups_mut()?;
-
-        // Temporary measure, to be removed with the DS-side check it exists
-        // for.
-        let commit_data = VirtualClientCommitData::new(Vec::new())?;
-        t_mls_group.set_safe_aad(vec![commit_data.to_safe_aad_item()?])?;
 
         let bundle = apqmls::commit_builder::CommitBuilder::from_groups(t_mls_group, pq_mls_group)
             .force_self_update(true)


### PR DESCRIPTION
#1478 introduced two guards meant to protect groups on main clients from being derailed by unpatched linked clients. This PR removes those guards.