### PR TITLE
fix(app): configure reqwest::Client with timeouts

### DIFF
--- a/coreclient/src/clients/create_user.rs
+++ b/coreclient/src/clients/create_user.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::time::Duration;
+
 use crate::{
     DisplayName,
     clients::registration::RegistrationError,
@@ -34,6 +36,21 @@ use aircommon::{
 use tracing::debug;
 
 use super::*;
+
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// Builds the HTTP client used for object storage transfers.
+///
+/// No read timeout: reqwest applies it as a deadline for the response head
+/// counted from the start of the request, which would cut off large uploads.
+fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(HTTP_CONNECT_TIMEOUT)
+        .tcp_keepalive(HTTP_TCP_KEEPALIVE)
+        .build()
+        .expect("failed to build HTTP client")
+}
 
 /// State before any network queries
 ///
@@ -408,7 +425,7 @@ impl PersistedUserState {
             qs_client_id,
         } = self.state;
 
-        let http_client = reqwest::Client::new();
+        let http_client = build_http_client();
         let outbound_service = OutboundService::new(
             db.clone(),
             api_clients.clone(),

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -242,7 +242,17 @@ impl<C: OutboundServiceWork> OutboundServiceTask<C> {
             };
 
             {
-                let _guard = match global_lock.lock().await {
+                // Another holder (e.g. a push worker in the same process) can keep the lock for a
+                // whole run. The wait must stay cancellable, otherwise `stop()` hangs.
+                let lock_result = tokio::select! {
+                    result = global_lock.lock() => result,
+                    _ = run_token.cancel.cancelled() => {
+                        debug!("cancelled while waiting for global lock");
+                        run_token.mark_as_done();
+                        continue;
+                    }
+                };
+                let _guard = match lock_result {
                     Ok(guard) => guard,
                     Err(error) => {
                         error!(
@@ -529,6 +539,39 @@ mod test {
         timeout(Duration::from_secs(5), service.stop())
             .await
             .expect("stop must not hang when the lock cannot be acquired");
+    }
+
+    #[tokio::test]
+    async fn stop_resolves_while_lock_is_held_elsewhere() {
+        init_test_tracing();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lockfile");
+
+        let mut other = GlobalLock::from_path(&path).unwrap();
+        let other_guard = other.lock().await.unwrap();
+
+        let context = DelayedCounterContext::default();
+        let service =
+            OutboundService::with_context(context.clone(), GlobalLock::from_path(&path).unwrap());
+
+        let start = service.start();
+        tokio::pin!(start);
+        timeout(Duration::from_millis(200), &mut start)
+            .await
+            .expect_err("start must be parked in the lock wait");
+
+        timeout(Duration::from_secs(5), service.stop())
+            .await
+            .expect("stop must not be parked behind another lock holder");
+        assert_eq!(0, context.counter.load(Ordering::SeqCst));
+
+        // The background task is still alive and runs once the lock is free.
+        drop(other_guard);
+        timeout(Duration::from_secs(5), service.start())
+            .await
+            .expect("the background task must keep serving requests");
+        assert_eq!(1, context.counter.load(Ordering::SeqCst));
     }
 
     /// A short wake interval used in tests so the periodic ticker fires quickly.

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -242,17 +242,7 @@ impl<C: OutboundServiceWork> OutboundServiceTask<C> {
             };
 
             {
-                // Another holder (e.g. a push worker in the same process) can keep the lock for a
-                // whole run. The wait must stay cancellable, otherwise `stop()` hangs.
-                let lock_result = tokio::select! {
-                    result = global_lock.lock() => result,
-                    _ = run_token.cancel.cancelled() => {
-                        debug!("cancelled while waiting for global lock");
-                        run_token.mark_as_done();
-                        continue;
-                    }
-                };
-                let _guard = match lock_result {
+                let _guard = match global_lock.lock().await {
                     Ok(guard) => guard,
                     Err(error) => {
                         error!(
@@ -539,39 +529,6 @@ mod test {
         timeout(Duration::from_secs(5), service.stop())
             .await
             .expect("stop must not hang when the lock cannot be acquired");
-    }
-
-    #[tokio::test]
-    async fn stop_resolves_while_lock_is_held_elsewhere() {
-        init_test_tracing();
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("lockfile");
-
-        let mut other = GlobalLock::from_path(&path).unwrap();
-        let other_guard = other.lock().await.unwrap();
-
-        let context = DelayedCounterContext::default();
-        let service =
-            OutboundService::with_context(context.clone(), GlobalLock::from_path(&path).unwrap());
-
-        let start = service.start();
-        tokio::pin!(start);
-        timeout(Duration::from_millis(200), &mut start)
-            .await
-            .expect_err("start must be parked in the lock wait");
-
-        timeout(Duration::from_secs(5), service.stop())
-            .await
-            .expect("stop must not be parked behind another lock holder");
-        assert_eq!(0, context.counter.load(Ordering::SeqCst));
-
-        // The background task is still alive and runs once the lock is free.
-        drop(other_guard);
-        timeout(Duration::from_secs(5), service.start())
-            .await
-            .expect("the background task must keep serving requests");
-        assert_eq!(1, context.counter.load(Ordering::SeqCst));
     }
 
     /// A short wake interval used in tests so the periodic ticker fires quickly.


### PR DESCRIPTION
`reqwest` doesn't have default timeouts and the outbound service loop might just end up hanging on e.g. an attachment download if something unusual happened to the TCP connection (like a handover between WiFi and Cellular).