### PR TITLE
perf(app): load chat participants from room state instead of MLS group

### DIFF
--- a/common/src/credentials/leaf.rs
+++ b/common/src/credentials/leaf.rs
@@ -5,7 +5,7 @@
 //! Parsed MLS leaf credentials.
 
 use mls_assist::openmls::prelude::{BasicCredentialError, Credential, CredentialType};
-use tls_codec::Serialize as _;
+use tls_codec::{DeserializeBytes, Serialize as _};
 use uuid::Uuid;
 
 use crate::identifiers::UserId;
@@ -43,6 +43,17 @@ impl RoomPolicyIdentity {
         match self {
             Self::User(user_id) => user_id.tls_serialize_detached(),
             Self::Client(client_id) => Ok(client_id.into_bytes().to_vec()),
+        }
+    }
+
+    /// Decodes a [`RoomPolicyIdentity`] from a byte slice.
+    ///
+    /// [`UserId`] bytes are always longer than the 16 bytes for a non-malicious payload. So, we
+    /// assume here that the identity was verified beforehand and does *not* contain spoofed bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, tls_codec::Error> {
+        match <[u8; 16]>::try_from(bytes) {
+            Ok(raw) => Ok(Self::Client(Uuid::from_bytes(raw))),
+            Err(_) => Ok(Self::User(UserId::tls_deserialize_exact_bytes(bytes)?)),
         }
     }
 }

--- a/coreclient/.sqlx/query-7af3c7d3036bee010d770292432504671097b69faa03cfea416f3acba3343fc2.json
+++ b/coreclient/.sqlx/query-7af3c7d3036bee010d770292432504671097b69faa03cfea416f3acba3343fc2.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT g.room_state AS \"room_state: BlobDecoded<VerifiedRoomState>\"\n            FROM \"group\" g\n            INNER JOIN chat c ON c.group_id = g.group_id\n            WHERE c.chat_id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "room_state: BlobDecoded<VerifiedRoomState>",
+        "ordinal": 0,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "group",
+            "name": "room_state"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7af3c7d3036bee010d770292432504671097b69faa03cfea416f3acba3343fc2"
+}

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -667,20 +667,13 @@ impl CoreUser {
 
     /// Returns None if there is no chat with the given id.
     pub async fn chat_participants(&self, chat_id: ChatId) -> Option<HashSet<UserId>> {
-        self.try_chat_participants(chat_id)
+        Group::load_participants(self.db().read().await.ok()?.as_mut(), chat_id)
             .await
-            .inspect_err(|e| error!(?e, "Error loading chat participants"))
-            .ok()?
-    }
-
-    pub(crate) async fn try_chat_participants(
-        &self,
-        chat_id: ChatId,
-    ) -> Result<Option<HashSet<UserId>>> {
-        let Some(group) = Group::load_with_chat_id(self.db().read().await?, chat_id).await? else {
-            return Ok(None);
-        };
-        Ok(Some(group.participants()?))
+            .inspect_err(|error| {
+                error!(%error, %chat_id, "Failed to load chat participants");
+            })
+            .ok()
+            .flatten()
     }
 
     pub async fn pending_removes(&self, chat_id: ChatId) -> Option<Vec<UserId>> {

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -672,7 +672,7 @@ impl Group {
 
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &mls_group, false).await?;
-        ensure_room_state_matches_members(&room_state, &mls_group, false)?;
+        ensure_room_state_users_are_members(&room_state, &mls_group)?;
 
         let sender_user_id = verifiable_attribution_info.sender();
         let sender_user_credential =
@@ -892,7 +892,7 @@ impl Group {
         );
         let credentials =
             verify_member_credentials(txn, api_clients, &t_mls_group, is_self_group).await?;
-        ensure_room_state_matches_members(&room_state, &t_mls_group, false)?;
+        ensure_room_state_users_are_members(&room_state, &t_mls_group)?;
 
         let sender_user_credential =
             match StorableUserCredential::load_by_user_id(&mut *txn, &sender_user_id).await? {
@@ -1198,7 +1198,7 @@ impl Group {
         // which is only accepted inside our own self group.
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &mls_group, is_self_group).await?;
-        ensure_room_state_matches_members(&room_state, &mls_group, true)?;
+        ensure_room_state_users_are_members(&room_state, &mls_group)?;
 
         let group = Self {
             mls_group,
@@ -1362,7 +1362,7 @@ impl Group {
         // only accepted inside our own self group.
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &t_group, is_self_group).await?;
-        ensure_room_state_matches_members(&room_state, &t_group, true)?;
+        ensure_room_state_users_are_members(&room_state, &t_group)?;
 
         // Store the group, credentials and member profile infos
         let now = TimeStamp::now();
@@ -2754,42 +2754,33 @@ async fn verify_member_credentials(
     Ok(verified)
 }
 
-/// Ensure that the users of `room_state` are exactly the members of `mls_group`.
-fn ensure_room_state_matches_members(
+/// Ensure that every user of `room_sate` is a member of `mls_group`.
+///
+/// Members missing from the room state are tolerated: the DS does not add external joiners of
+/// connection groups to its room state, clients patch that locally.
+fn ensure_room_state_users_are_members(
     room_state: &VerifiedRoomState,
     mls_group: &MlsGroup,
-    external_commit: bool,
 ) -> anyhow::Result<()> {
-    let mut expected = HashSet::new();
+    let mut members = HashSet::new();
     for member in mls_group.members() {
         let identity = LeafCredential::from_credential(&member.credential)?
             .room_policy_identity()
             .to_bytes()?;
-        expected.insert(identity);
+        members.insert(identity);
     }
-
     let users = room_state.users();
-    let matches = |expected: &HashSet<Vec<u8>>| {
-        users.len() == expected.len() && users.keys().all(|key| expected.contains(key))
-    };
-    if matches(&expected) {
-        return Ok(());
+    ensure!(
+        users.keys().all(|identity| members.contains(identity)),
+        "room state lists users which are not group members"
+    );
+    if users.len() < members.len() {
+        warn!(
+            group_id = ?mls_group.group_id(),
+            "room state is missing group members",
+        );
     }
-
-    // For external commits we might be missing in the room state, on resync though we are already
-    // listed => accept both sets.
-    if external_commit {
-        let own_leaf = mls_group.own_leaf_node().context("missing own leaf")?;
-        let own_identity = LeafCredential::from_credential(own_leaf.credential())?
-            .room_policy_identity()
-            .to_bytes()?;
-        expected.remove(&own_identity);
-        if matches(&expected) {
-            return Ok(());
-        }
-    }
-
-    bail!("room state users do not match group members");
+    Ok(())
 }
 
 /// Classify the leaf credentials of all group members for verification.

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -441,16 +441,6 @@ impl Group {
         self.room_state
     }
 
-    /// Returns the set of users currently in the room according to
-    /// `room_state`.
-    pub(crate) fn participants(&self) -> Result<HashSet<UserId>> {
-        self.room_state
-            .users()
-            .keys()
-            .map(|bytes| Ok(UserId::tls_deserialize_exact_bytes(bytes)?))
-            .collect()
-    }
-
     /// Errors if this group (or its PQ counterpart, for APQ groups) has a
     /// pending commit. Used by clean loaders to refuse to hand out a
     /// `Group` whose MLS state has an in-flight commit, since further
@@ -682,6 +672,7 @@ impl Group {
 
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &mls_group, false).await?;
+        ensure_room_state_matches_members(&room_state, &mls_group, false)?;
 
         let sender_user_id = verifiable_attribution_info.sender();
         let sender_user_credential =
@@ -901,6 +892,7 @@ impl Group {
         );
         let credentials =
             verify_member_credentials(txn, api_clients, &t_mls_group, is_self_group).await?;
+        ensure_room_state_matches_members(&room_state, &t_mls_group, false)?;
 
         let sender_user_credential =
             match StorableUserCredential::load_by_user_id(&mut *txn, &sender_user_id).await? {
@@ -1206,6 +1198,7 @@ impl Group {
         // which is only accepted inside our own self group.
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &mls_group, is_self_group).await?;
+        ensure_room_state_matches_members(&room_state, &mls_group, true)?;
 
         let group = Self {
             mls_group,
@@ -1369,6 +1362,7 @@ impl Group {
         // only accepted inside our own self group.
         let credentials =
             verify_member_credentials(&mut *txn, api_clients, &t_group, is_self_group).await?;
+        ensure_room_state_matches_members(&room_state, &t_group, true)?;
 
         // Store the group, credentials and member profile infos
         let now = TimeStamp::now();
@@ -2758,6 +2752,44 @@ async fn verify_member_credentials(
         verified.push(credential);
     }
     Ok(verified)
+}
+
+/// Ensure that the users of `room_state` are exactly the members of `mls_group`.
+fn ensure_room_state_matches_members(
+    room_state: &VerifiedRoomState,
+    mls_group: &MlsGroup,
+    external_commit: bool,
+) -> anyhow::Result<()> {
+    let mut expected = HashSet::new();
+    for member in mls_group.members() {
+        let identity = LeafCredential::from_credential(&member.credential)?
+            .room_policy_identity()
+            .to_bytes()?;
+        expected.insert(identity);
+    }
+
+    let users = room_state.users();
+    let matches = |expected: &HashSet<Vec<u8>>| {
+        users.len() == expected.len() && users.keys().all(|key| expected.contains(key))
+    };
+    if matches(&expected) {
+        return Ok(());
+    }
+
+    // For external commits we might be missing in the room state, on resync though we are already
+    // listed => accept both sets.
+    if external_commit {
+        let own_leaf = mls_group.own_leaf_node().context("missing own leaf")?;
+        let own_identity = LeafCredential::from_credential(own_leaf.credential())?
+            .room_policy_identity()
+            .to_bytes()?;
+        expected.remove(&own_identity);
+        if matches(&expected) {
+            return Ok(());
+        }
+    }
+
+    bail!("room state users do not match group members");
 }
 
 /// Classify the leaf credentials of all group members for verification.

--- a/coreclient/src/groups/persistence.rs
+++ b/coreclient/src/groups/persistence.rs
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::ops::Deref;
+use std::{collections::HashSet, ops::Deref};
 
 use aircommon::{
     codec::{BlobDecoded, BlobEncoded, PersistenceCodec},
-    credentials::{GroupStorageWitness, LeafCredential, UserCredential},
+    credentials::{GroupStorageWitness, LeafCredential, RoomPolicyIdentity, UserCredential},
     crypto::aead::keys::{GroupStateEarKey, IdentityLinkWrapperKey},
     identifiers::UserId,
     time::TimeStamp,
@@ -16,9 +16,9 @@ use mimi_room_policy::{RoomState, VerifiedRoomState};
 use openmls::group::{GroupId, MlsGroup, MlsGroupState};
 use openmls::prelude::{LeafNodeIndex, StagedCommit};
 use openmls_traits::{OpenMlsProvider, storage::StorageProvider};
-use sqlx::{SqliteConnection, query, query_as, query_scalar};
+use sqlx::{SqliteConnection, SqliteExecutor, query, query_as, query_scalar};
 use tls_codec::Serialize as _;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     ChatId,
@@ -585,6 +585,40 @@ impl Group {
             .inspect_err(|error| error!(%error, ?group_id, "Failed to load own leaf index"))
             .ok()
             .flatten()
+    }
+
+    pub(crate) async fn load_participants(
+        executor: impl SqliteExecutor<'_>,
+        chat_id: ChatId,
+    ) -> anyhow::Result<Option<HashSet<UserId>>> {
+        let Some(BlobDecoded(room_state)) = query_scalar!(
+            r#"SELECT g.room_state AS "room_state: BlobDecoded<VerifiedRoomState>"
+            FROM "group" g
+            INNER JOIN chat c ON c.group_id = g.group_id
+            WHERE c.chat_id = ?"#,
+            chat_id,
+        )
+        .fetch_optional(executor)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let user_ids = room_state
+            .users()
+            .keys()
+            .filter_map(|identity_bytes| {
+                let identity = RoomPolicyIdentity::from_bytes(identity_bytes)
+                    .inspect_err(|error| {
+                        warn!(%error, "malformed room state identity");
+                    })
+                    .ok()?;
+                match identity {
+                    RoomPolicyIdentity::User(user_id) => Some(user_id),
+                    RoomPolicyIdentity::Client(_) => None,
+                }
+            })
+            .collect();
+        Ok(Some(user_ids))
     }
 }
 


### PR DESCRIPTION
After introducing additional state containing the list of members per chat to the `ChatsDataSource`, the loading of chats on cold start became so slow, that an empty chat list is visible before chats are loaded.

This commit loads the participants from the room state directly from the db, instead of loading the MLS group first.

Also, fix a security issue where a malicious client could spoof the room policy identity of a user.