### PR TITLE
chore: wire payloads for multi-client group creation and join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -543,7 +543,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2698,7 +2698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4839,7 +4839,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5077,8 +5077,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openmls"
-version = "0.9.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.9.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5105,8 +5105,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_basic_credential"
-version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.6.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -5121,8 +5121,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_libcrux_crypto"
-version = "0.4.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.4.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "aes",
  "fpe",
@@ -5144,8 +5144,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_memory_storage"
-version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.6.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "hex",
  "log",
@@ -5157,8 +5157,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_rust_crypto"
-version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.6.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5185,8 +5185,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_serialization_helpers"
-version = "0.1.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.1.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5196,8 +5196,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_sqlite_storage"
-version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.3.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "openmls_traits",
  "refinery",
@@ -5207,8 +5207,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_test"
-version = "0.3.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.3.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "openmls_libcrux_crypto",
  "openmls_rust_crypto",
@@ -5220,8 +5220,8 @@ dependencies = [
 
 [[package]]
 name = "openmls_traits"
-version = "0.6.0-rc.1"
-source = "git+https://github.com/openmls/openmls?rev=f8427087333e002b4796793097fa67cf6b3bb2d1#f8427087333e002b4796793097fa67cf6b3bb2d1"
+version = "0.6.0"
+source = "git+https://github.com/openmls/openmls?rev=dce7c4a9ff1d0f77d38531e77eab5147a6620d1b#dce7c4a9ff1d0f77d38531e77eab5147a6620d1b"
 dependencies = [
  "serde",
  "tls_codec",
@@ -6028,7 +6028,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6498,7 +6498,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6902,7 +6902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7267,7 +7267,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8352,7 +8352,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
 criterion = { version = "0.8.2", features = ["html_reports", "async", "async_tokio"] }
 dashmap = "6.1.0"
-derive_more = { version = "2.1.1", features = ["from"] }
+derive_more = { version = "2.1.1", features = ["display", "from"] }
 deunicode = "1.6.2"
 digest-io = "0.1.0"
 displaydoc = "0.2.5"
@@ -87,10 +87,10 @@ minicbor-serde = { version = "0.6", features = ["std"] }
 mockall = "0.13.1"
 mockito = "1.7.0"
 num_enum = "0.7"
-openmls = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["clonable"] }
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
-openmls_traits = { git = "https://github.com/openmls/openmls", rev = "f8427087333e002b4796793097fa67cf6b3bb2d1", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls = { git = "https://github.com/openmls/openmls", rev = "dce7c4a9ff1d0f77d38531e77eab5147a6620d1b", features = ["draft-ietf-mls-pq-ciphersuites", "unchecked-conversions", "0-8-1-storage-format", "virtual-clients-draft"] }
+openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "dce7c4a9ff1d0f77d38531e77eab5147a6620d1b", features = ["clonable"] }
+openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "dce7c4a9ff1d0f77d38531e77eab5147a6620d1b", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
+openmls_traits = { git = "https://github.com/openmls/openmls", rev = "dce7c4a9ff1d0f77d38531e77eab5147a6620d1b", features = ["draft-ietf-mls-pq-ciphersuites", "virtual-clients-draft"] }
 parking_lot = "0.12"
 pin-project = "1.1.10"
 png = "0.18.1"

--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -48,7 +48,10 @@ use apqmls::commit_builder::ApqCommitMessageBundle;
 use mimi_room_policy::VerifiedRoomState;
 use mls_assist::{
     messages::AssistedMessageOut,
-    openmls::prelude::{GroupEpoch, GroupId, LeafNodeIndex, MlsMessageOut},
+    openmls::prelude::{
+        GroupEpoch, GroupId, LeafNodeIndex, MlsMessageIn, MlsMessageOut,
+        tls_codec::DeserializeBytes as _,
+    },
 };
 use tonic::Code;
 use tracing::error;
@@ -500,6 +503,11 @@ impl ApiClient {
             )
             .map_err(|_| DsRequestError::UnexpectedResponse)?,
             pq,
+            join_commit: response
+                .join_commit
+                .map(|bytes| MlsMessageIn::tls_deserialize_exact_bytes(&bytes))
+                .transpose()
+                .map_err(|_| DsRequestError::UnexpectedResponse)?,
         })
     }
 
@@ -563,6 +571,7 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             external_commit: Some(external_commit.try_ref_into()?),
             qs_client_reference: Some(qs_client_reference.into()),
+            group_bootstrap: None,
         };
         let response = self
             .ds_grpc_client()

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1226,6 +1226,12 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
         let request = request.into_inner();
         self.verify_client_version(request.client_metadata.as_ref())?;
 
+        // Echoing the group bootstrap to the joiner's other clients lands with
+        // the DS-side part of multi-client group creation.
+        if request.group_bootstrap.is_some() {
+            return Err(Status::unimplemented("group bootstrap"));
+        }
+
         let external_commit: AssistedMessageIn = request
             .external_commit
             .ok_or_missing_field("external_commit")?

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -8,14 +8,58 @@ use aircommon::{
     time::TimeStamp,
 };
 use mls_assist::{
-    group::ProcessedAssistedMessage, messages::SerializedMlsMessage,
-    openmls::prelude::ProcessedMessageContent, provider_traits::MlsAssistProvider,
+    group::ProcessedAssistedMessage,
+    messages::SerializedMlsMessage,
+    openmls::{
+        group::StagedCommit,
+        prelude::{ProcessedMessageContent, Proposal},
+    },
+    provider_traits::MlsAssistProvider,
 };
 use tls_codec::DeserializeBytes;
 
 use crate::errors::JoinConnectionGroupError;
 
 use super::group_state::{DsGroupState, MemberProfile, leaf_credential_matches_flag};
+
+/// Reject any proposal an external commit joining a connection group must not
+/// carry.
+///
+/// Permitted are the `ExternalInit` every external commit is built on and the
+/// PSK proposal carrying the connection offer. A joiner has no standing to
+/// propose anything else, membership changes least of all. The group bootstrap
+/// blob for the joiner's sibling emulator clients does not ride in the commit
+/// either: it travels as a request parameter and reaches only the sibling
+/// queues, as a DS echo.
+fn validate_join_proposal(proposal: &Proposal) -> Result<(), JoinConnectionGroupError> {
+    match proposal {
+        Proposal::ExternalInit(_) | Proposal::PreSharedKey(_) => Ok(()),
+        Proposal::Add(_)
+        | Proposal::Update(_)
+        | Proposal::Remove(_)
+        | Proposal::ReInit(_)
+        | Proposal::GroupContextExtensions(_)
+        | Proposal::AppDataUpdate(_)
+        | Proposal::AppEphemeral(_)
+        | Proposal::SelfRemove
+        | Proposal::Custom(_) => {
+            tracing::warn!(
+                proposal_type = ?proposal.proposal_type(),
+                "Unexpected proposal in a connection-group external commit"
+            );
+            Err(JoinConnectionGroupError::InvalidMessage)
+        }
+    }
+}
+
+/// Reject an external commit whose proposals a connection-group join must not
+/// contain. See [`validate_join_proposal`] for what is permitted.
+fn validate_join_proposals(staged_commit: &StagedCommit) -> Result<(), JoinConnectionGroupError> {
+    for proposal in staged_commit.queued_proposals() {
+        validate_join_proposal(proposal.proposal())?;
+    }
+    Ok(())
+}
 
 impl DsGroupState {
     pub(super) fn join_connection_group(
@@ -47,16 +91,12 @@ impl DsGroupState {
                 return Err(JoinConnectionGroupError::InvalidMessage);
             };
 
-        // The external commit joining the client into the group should contain only the path.
+        // The external commit joining the client into the group carries the path plus, at most, the
+        // proposals `validate_join_proposals` permits.
         if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
             processed_message.content()
         {
-            if staged_commit.add_proposals().count() > 0
-                || staged_commit.update_proposals().count() > 0
-                || staged_commit.remove_proposals().count() > 0
-            {
-                return Err(JoinConnectionGroupError::InvalidMessage);
-            }
+            validate_join_proposals(staged_commit)?;
             if !self.self_group_flag_unchanged(staged_commit) {
                 tracing::warn!("Commit would toggle the self-group flag");
                 return Err(JoinConnectionGroupError::InvalidMessage);
@@ -77,7 +117,7 @@ impl DsGroupState {
                 return Err(JoinConnectionGroupError::InvalidMessage);
             }
         } else {
-            tracing::warn!("Invalid message: External commit contained unexpected proposals.");
+            tracing::warn!("Invalid message: Commit content is not a staged commit.");
             return Err(JoinConnectionGroupError::InvalidMessage);
         };
 
@@ -135,5 +175,65 @@ impl DsGroupState {
 
         // Finally, we create the message for distribution.
         Ok(processed_assisted_message_plus.serialized_mls_message)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use airprotos::client::component::AIR_COMPONENT_ID;
+    use mls_assist::{
+        openmls::{
+            prelude::{
+                AppDataUpdateProposal, AppEphemeralProposal, Ciphersuite, CustomProposal,
+                ExternalInitProposal, OpenMlsProvider, PreSharedKeyProposal,
+            },
+            schedule::{ExternalPsk, PreSharedKeyId, Psk},
+        },
+        openmls_rust_crypto::OpenMlsRustCrypto,
+    };
+
+    use super::*;
+
+    fn psk_proposal() -> Proposal {
+        let provider = OpenMlsRustCrypto::default();
+        let psk_id = PreSharedKeyId::new(
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+            provider.rand(),
+            Psk::External(ExternalPsk::new(vec![1u8; 32])),
+        )
+        .unwrap();
+        Proposal::PreSharedKey(Box::new(PreSharedKeyProposal::new(psk_id)))
+    }
+
+    #[test]
+    fn external_init_and_psk_are_permitted() {
+        validate_join_proposal(&Proposal::ExternalInit(Box::new(
+            ExternalInitProposal::from(vec![1u8; 32]),
+        )))
+        .unwrap();
+        validate_join_proposal(&psk_proposal()).unwrap();
+    }
+
+    #[test]
+    fn proposals_outside_the_allowlist_are_rejected() {
+        let rejected = [
+            Proposal::SelfRemove,
+            Proposal::Custom(Box::new(CustomProposal::new(0xf00d, vec![1u8; 8]))),
+            Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+                AIR_COMPONENT_ID,
+                vec![1u8; 8],
+            ))),
+            Proposal::AppEphemeral(Box::new(AppEphemeralProposal::new(
+                AIR_COMPONENT_ID,
+                vec![1u8; 8],
+            ))),
+        ];
+        for proposal in rejected {
+            let result = validate_join_proposal(&proposal);
+            assert!(
+                matches!(result, Err(JoinConnectionGroupError::InvalidMessage)),
+                "{proposal:?} was permitted"
+            );
+        }
     }
 }

--- a/common/src/crypto/aead/keys.rs
+++ b/common/src/crypto/aead/keys.rs
@@ -11,7 +11,7 @@ use crate::crypto::{
     indexed_aead::keys::{Key, RandomlyGeneratable},
     kdf::{
         KdfDerivable,
-        keys::{RatchetSecret, SelfGroupExporterSecret},
+        keys::{RatchetSecret, SelfGroupExporterSecret, VcApplicationSecret},
     },
 };
 
@@ -142,10 +142,10 @@ impl KdfDerivable<SelfGroupExporterSecret, Vec<u8>, AEAD_KEY_SIZE> for SelfGroup
 /// Key that encrypts `GroupBootstrap` payloads, which convey a newly created or
 /// externally joined group to the sibling clients of a virtual client.
 ///
-/// It is derived from the [`SelfGroupExporterSecret`] of the self-group epoch
-/// whose registration minted the emulation epoch that derives the creating or
-/// joining leaf. That secret is already scoped to group, epoch and component,
-/// so callers pass an empty `Vec<u8>` as additional info to the derivation.
+/// It is derived from a [`VcApplicationSecret`], one application-ratchet
+/// generation of the emulation epoch that also derives the creating or joining
+/// leaf. That secret is already scoped to epoch, sender leaf and generation, so
+/// callers pass an empty `Vec<u8>` as additional info to the derivation.
 #[derive(Debug)]
 pub struct GroupBootstrapKeyType;
 
@@ -153,6 +153,6 @@ pub type GroupBootstrapKey = Key<GroupBootstrapKeyType>;
 
 impl AeadKey for GroupBootstrapKey {}
 
-impl KdfDerivable<SelfGroupExporterSecret, Vec<u8>, AEAD_KEY_SIZE> for GroupBootstrapKey {
+impl KdfDerivable<VcApplicationSecret, Vec<u8>, AEAD_KEY_SIZE> for GroupBootstrapKey {
     const LABEL: &'static str = "group bootstrap key";
 }

--- a/common/src/crypto/kdf/keys.rs
+++ b/common/src/crypto/kdf/keys.rs
@@ -50,3 +50,17 @@ impl RawKey for SelfGroupExporterSecretType {}
 impl KdfKey for SelfGroupExporterSecret {
     const ADDITIONAL_LABEL: &'static str = "SelfGroupExporterSecret";
 }
+
+/// One 32-byte application secret from a virtual client's operation secret tree.
+///
+/// It is later used to derive a
+/// [`crate::crypto::aead::keys::GroupBootstrapKey`].
+#[derive(Debug)]
+pub struct VcApplicationSecretType;
+pub type VcApplicationSecret = Key<VcApplicationSecretType>;
+
+impl RawKey for VcApplicationSecretType {}
+
+impl KdfKey for VcApplicationSecret {
+    const ADDITIONAL_LABEL: &'static str = "VcApplicationSecret";
+}

--- a/common/src/messages/client_ds.rs
+++ b/common/src/messages/client_ds.rs
@@ -66,6 +66,7 @@ pub enum QsQueueMessageType {
     TargetedMessage = 3,
     DsResponse = 4,
     GroupCreationEcho = 7,
+    GroupJoinEcho = 8,
 }
 
 // TODO: Check if TLS serialization is actually used
@@ -130,8 +131,14 @@ impl QsQueueMessagePayload {
                 ExtractedQsQueueMessagePayload::DsCommitResponse(response)
             }
             QsQueueMessageType::GroupCreationEcho => {
-                let echo = GroupCreationEcho::tls_deserialize_exact_bytes(self.payload.as_slice())?;
+                let echo =
+                    GroupBootstrapEcho::tls_deserialize_exact_bytes(self.payload.as_slice())?;
                 ExtractedQsQueueMessagePayload::GroupCreationEcho(echo)
+            }
+            QsQueueMessageType::GroupJoinEcho => {
+                let echo =
+                    GroupBootstrapEcho::tls_deserialize_exact_bytes(self.payload.as_slice())?;
+                ExtractedQsQueueMessagePayload::GroupJoinEcho(echo)
             }
         };
         Ok(ExtractedQsQueueMessage {
@@ -155,23 +162,24 @@ pub struct DsCommitResponse {
     pub key_package_batch: Option<KeyPackageBatchId>,
 }
 
-/// Announces a group a virtual client created. Meant to be put into the QS
-/// queues of all of the creating user's clients.
+/// Announces a group a virtual client created or externally joined. Meant to
+/// be put into the QS queues of all of the acting user's clients. The message
+/// type distinguishes creation from join.
 ///
-/// The DS sends it when it accepts the creation, before any other traffic of
+/// The DS sends it when it accepts the operation, before any other traffic of
 /// that group reaches those queues. A sibling client uses it to join the group
-/// it was not part of creating.
+/// itself.
 #[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone)]
-pub struct GroupCreationEcho {
+pub struct GroupBootstrapEcho {
     pub group_id: GroupId,
     /// Group id of the PQ leg, present iff the group is an APQ group.
     pub pq_group_id: Option<GroupId>,
-    /// Epoch of the snapshot the sibling fetches from the DS, always 0 at
-    /// creation.
+    /// Epoch of the snapshot the sibling fetches from the DS: 0 at creation,
+    /// the pre-commit epoch at an external join.
     pub epoch: GroupEpoch,
     pub timestamp: TimeStamp,
     /// A `GroupBootstrapBlob` (CBOR, defined in `airprotos`), encrypted for the
-    /// creator's siblings. The DS echoes it unread.
+    /// acting client's siblings. The DS echoes it unread.
     pub group_bootstrap: Vec<u8>,
 }
 
@@ -190,7 +198,8 @@ pub enum ExtractedQsQueueMessagePayload {
     UserProfileKeyUpdate(UserProfileKeyUpdateParams),
     TargetedMessage(QsQueueTargetedMessage),
     DsCommitResponse(DsCommitResponse),
-    GroupCreationEcho(GroupCreationEcho),
+    GroupCreationEcho(GroupBootstrapEcho),
+    GroupJoinEcho(GroupBootstrapEcho),
 }
 
 impl QsQueueMessagePayload {
@@ -226,11 +235,20 @@ impl QsQueueMessagePayload {
         })
     }
 
-    pub fn group_creation_echo(echo: GroupCreationEcho) -> Result<Self, tls_codec::Error> {
+    pub fn group_creation_echo(echo: GroupBootstrapEcho) -> Result<Self, tls_codec::Error> {
         let payload = echo.tls_serialize_detached()?;
         Ok(Self {
             timestamp: TimeStamp::now(),
             message_type: QsQueueMessageType::GroupCreationEcho,
+            payload,
+        })
+    }
+
+    pub fn group_join_echo(echo: GroupBootstrapEcho) -> Result<Self, tls_codec::Error> {
+        let payload = echo.tls_serialize_detached()?;
+        Ok(Self {
+            timestamp: TimeStamp::now(),
+            message_type: QsQueueMessageType::GroupJoinEcho,
             payload,
         })
     }

--- a/common/src/messages/client_ds_out.rs
+++ b/common/src/messages/client_ds_out.rs
@@ -16,7 +16,8 @@ use mls_assist::{
     openmls::{
         group::GroupEpoch,
         prelude::{
-            GroupId, LeafNodeIndex, MlsMessageOut, RatchetTreeIn, group_info::VerifiableGroupInfo,
+            GroupId, LeafNodeIndex, MlsMessageIn, MlsMessageOut, RatchetTreeIn,
+            group_info::VerifiableGroupInfo,
         },
         treesync::RatchetTree,
     },
@@ -59,6 +60,10 @@ pub struct EpochSnapshotIn {
     pub room_state: VerifiedRoomState,
     /// Present iff the snapshot is of an APQ group.
     pub pq: Option<PqEpochSnapshotIn>,
+    /// The external commit accepted at this epoch, present iff the snapshot
+    /// was written at an external join. A sibling of the joiner applies it on
+    /// top of the snapshot state.
+    pub join_commit: Option<MlsMessageIn>,
 }
 
 #[derive(Debug)]

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -265,6 +265,13 @@ impl CoreUser {
                 );
                 Ok(QsMessageOutcome::empty())
             }
+            ExtractedQsQueueMessagePayload::GroupJoinEcho(echo) => {
+                warn!(
+                    group_id = ?echo.group_id,
+                    "group join echo processing not yet implemented"
+                );
+                Ok(QsMessageOutcome::empty())
+            }
         };
 
         debug!(elapsed = ?started.elapsed(), "Processed QS message");

--- a/coreclient/src/groups/group_bootstrap.rs
+++ b/coreclient/src/groups/group_bootstrap.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Sealing and opening of group bootstrap blobs on the self group.
+//!
+//! When one emulator client creates a group or joins one via external commit,
+//! it hands its siblings the group's keys and connection context in a
+//! `GroupBootstrap` (see `airprotos::client::group_bootstrap`). The blob key
+//! is derived from one application-ratchet generation of the self group's
+//! newest emulation epoch, whose coordinates travel in the clear inside the
+//! blob.
+
+use aircommon::crypto::{
+    aead::{AEAD_KEY_SIZE, keys::GroupBootstrapKey},
+    kdf::{KdfDerivable, keys::VcApplicationSecret},
+};
+use airprotos::client::group_bootstrap::{
+    GroupBootstrap, GroupBootstrapBlob, GroupBootstrapCarrier,
+};
+use anyhow::{Context, Result, anyhow, ensure};
+use openmls::prelude::GroupId;
+
+use crate::{
+    db::access::WriteDbTransaction,
+    groups::{Group, openmls_provider::AirOpenMlsProvider},
+};
+
+/// Domain separation of the application-ratchet derivation that feeds the
+/// group bootstrap key.
+const OPERATION_CONTEXT: &[u8] = b"group bootstrap";
+
+impl Group {
+    /// Seals `bootstrap` for the sibling emulator clients of this self group.
+    ///
+    /// Errors if called on a group that is not the self group.
+    pub(crate) fn seal_group_bootstrap(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        bootstrap: &GroupBootstrap,
+        carrier: GroupBootstrapCarrier,
+        group_id: &GroupId,
+    ) -> Result<GroupBootstrapBlob> {
+        ensure!(
+            self.is_self_group(),
+            "seal_group_bootstrap must only be called on the self group"
+        );
+        let provider = AirOpenMlsProvider::new(txn.as_mut());
+        let (info, secret) = self
+            .mls_group()
+            .next_vc_application_secret(&provider, OPERATION_CONTEXT)?;
+        let key = bootstrap_key(secret)?;
+        let sealed = bootstrap.seal(&key, carrier, group_id)?;
+        Ok(GroupBootstrapBlob::new(&info, sealed))
+    }
+
+    /// Opens a blob a sibling emulator client sealed on this self group.
+    ///
+    /// Errors if called on a group that is not the self group, or if the blob
+    /// names this client's own ratchet.
+    pub(crate) fn open_group_bootstrap(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        blob: &GroupBootstrapBlob,
+        carrier: GroupBootstrapCarrier,
+        group_id: &GroupId,
+    ) -> Result<GroupBootstrap> {
+        ensure!(
+            self.is_self_group(),
+            "open_group_bootstrap must only be called on the self group"
+        );
+        let info = blob
+            .secret_info()
+            .context("group bootstrap blob without secret coordinates")?;
+        let ciphertext = blob
+            .encrypted_bootstrap
+            .as_ref()
+            .context("group bootstrap blob without ciphertext")?;
+        let provider = AirOpenMlsProvider::new(txn.as_mut());
+        let secret =
+            self.mls_group()
+                .derive_vc_application_secret(&provider, &info, OPERATION_CONTEXT)?;
+        let key = bootstrap_key(secret)?;
+        Ok(GroupBootstrap::open(&key, ciphertext, carrier, group_id)?)
+    }
+}
+
+fn bootstrap_key(secret: Vec<u8>) -> Result<GroupBootstrapKey> {
+    let secret: [u8; AEAD_KEY_SIZE] = secret
+        .try_into()
+        .map_err(|_| anyhow!("unexpected vc application secret length"))?;
+    let secret = VcApplicationSecret::from_bytes(secret);
+    // `secret` is zeroized as it is dropped (its inner secret is
+    // `ZeroizeOnDrop`).
+    Ok(GroupBootstrapKey::derive(&secret, &Vec::new())?)
+}
+
+#[cfg(test)]
+mod tests {
+    use aircommon::{
+        credentials::{
+            keys::{LeafSigningKey, SelfGroupSigningKey},
+            test_utils::create_test_credentials,
+        },
+        crypto::aead::keys::IdentityLinkWrapperKey,
+        identifiers::{QualifiedGroupId, UserId},
+        mls_group_config::AppComponent,
+    };
+    use airprotos::client::component::AirComponent;
+    use uuid::Uuid;
+
+    use crate::{
+        db::access::{DbAccess, WriteConnection, WriteDbTransaction},
+        groups::GroupDataBytes,
+        utils::persistence::open_db_in_memory,
+    };
+
+    use super::*;
+
+    fn random_group_id() -> GroupId {
+        GroupId::from(QualifiedGroupId::new(
+            Uuid::new_v4(),
+            "example.com".parse().unwrap(),
+        ))
+    }
+
+    /// Creates a fresh single-member APQ group. When `is_self_group` is set,
+    /// the group is created as an emulation group, so it has a derivation
+    /// epoch to seal from.
+    fn create_group(
+        txn: &mut WriteDbTransaction<'_>,
+        is_self_group: bool,
+    ) -> anyhow::Result<Group> {
+        let user_id = UserId::random("example.com".parse()?);
+        let signer = if is_self_group {
+            LeafSigningKey::SelfGroup(SelfGroupSigningKey::generate(Uuid::new_v4())?)
+        } else {
+            let (_as_key, client_signer) = create_test_credentials(user_id.clone());
+            LeafSigningKey::User(client_signer)
+        };
+        let air_component = if is_self_group {
+            AirComponent::default_for_self_group()
+        } else {
+            AirComponent::default_for_leaf_or_key_package()
+        };
+        let (group, _params) = Group::create_apq_group(
+            &mut *txn,
+            &signer,
+            user_id,
+            IdentityLinkWrapperKey::random()?,
+            random_group_id(),
+            random_group_id(),
+            GroupDataBytes::from(b"test-group-data".to_vec()),
+            None,
+            air_component,
+        )?;
+        Ok(group)
+    }
+
+    fn carried_group_id() -> GroupId {
+        GroupId::from_slice(b"carried-group-id")
+    }
+
+    fn sample_bootstrap(group_id: &GroupId) -> GroupBootstrap {
+        GroupBootstrap {
+            group_id: Some(group_id.as_slice().to_vec()),
+            pq_group_id: None,
+            group_state_ear_key: None,
+            identity_link_wrapper_key: None,
+            connection: None,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn seal_produces_blob_with_fresh_coordinates() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let group = create_group(&mut txn, true)?;
+        let bootstrap = sample_bootstrap(&carried_group_id());
+
+        let blob = group.seal_group_bootstrap(
+            &mut txn,
+            &bootstrap,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        )?;
+        let info = blob.secret_info().expect("coordinates must be present");
+        assert_eq!(info.leaf_index, group.mls_group().own_leaf_index());
+        assert_eq!(info.generation, 0);
+        assert!(blob.encrypted_bootstrap.is_some());
+
+        // A second seal consumes the next generation.
+        let blob = group.seal_group_bootstrap(
+            &mut txn,
+            &bootstrap,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        )?;
+        assert_eq!(blob.secret_info().unwrap().generation, 1);
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn seal_requires_self_group() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let group = create_group(&mut txn, false)?;
+        let bootstrap = sample_bootstrap(&carried_group_id());
+
+        let result = group.seal_group_bootstrap(
+            &mut txn,
+            &bootstrap,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        );
+        assert!(result.is_err());
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    /// A blob names its sender's ratchet, so the sender itself must not be
+    /// able to open it: rederiving from the own leaf would burn the ratchet
+    /// head.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_rejects_own_blob() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let group = create_group(&mut txn, true)?;
+        let bootstrap = sample_bootstrap(&carried_group_id());
+
+        let blob = group.seal_group_bootstrap(
+            &mut txn,
+            &bootstrap,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        )?;
+        let result = group.open_group_bootstrap(
+            &mut txn,
+            &blob,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        );
+        assert!(result.is_err());
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_requires_coordinates_and_ciphertext() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let group = create_group(&mut txn, true)?;
+        let blob = GroupBootstrapBlob {
+            epoch_id: Some(b"emulation-epoch-id".to_vec()),
+            sender_leaf_index: None,
+            generation: Some(0),
+            encrypted_bootstrap: None,
+        };
+        let result = group.open_group_bootstrap(
+            &mut txn,
+            &blob,
+            GroupBootstrapCarrier::CreationEcho,
+            &carried_group_id(),
+        );
+        assert!(result.is_err());
+
+        txn.commit().await?;
+        Ok(())
+    }
+}

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -11,6 +11,10 @@ pub(crate) mod debug_info;
 #[allow(dead_code)]
 pub(crate) mod diff;
 pub(crate) mod error;
+// The acting and sibling sides of multi-client group creation land separately
+// and wire these helpers up.
+#[cfg_attr(not(test), expect(dead_code, reason = "not yet wired up"))]
+pub(crate) mod group_bootstrap;
 pub(crate) mod openmls_provider;
 pub(crate) mod persistence;
 pub(crate) mod process;

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -300,11 +300,6 @@ impl Group {
 
             let ciphertext = match payload {
                 AppEphemeralPayload::EncryptedSelfGroupMessages(ciphertext) => ciphertext,
-                // Only carried on external commits of higher-level groups.
-                AppEphemeralPayload::GroupBootstrapBlob(_) => {
-                    debug!("Skipping group bootstrap blob in a self-group commit");
-                    continue;
-                }
                 // A payload kind added by a newer client. Nothing to do here.
                 AppEphemeralPayload::Unknown => {
                     debug!("Skipping unknown self-group app-ephemeral payload");

--- a/protos/api/delivery_service/v1/delivery_service.proto
+++ b/protos/api/delivery_service/v1/delivery_service.proto
@@ -291,6 +291,10 @@ message EpochSnapshotResponse {
   // Present iff the group is an APQ group.
   GroupInfo pq_group_info = 4;
   RatchetTree pq_ratchet_tree = 5;
+  // The serialized external commit accepted at this epoch, present iff the
+  // snapshot was written at an external join. A sibling of the joiner applies
+  // it on top of the snapshot state.
+  optional bytes join_commit = 6;
 }
 
 // connection group info
@@ -317,6 +321,10 @@ message JoinConnectionGroupRequest {
   GroupStateEarKey group_state_ear_key = 1;
   AssistedMessage external_commit = 2;
   QsReference qs_client_reference = 3;
+  // Opaque blob, encrypted for the joiner's sibling clients. Set when a
+  // virtual client joins the group, in which case the DS echoes it unread to
+  // all of the joining user's client queues.
+  optional bytes group_bootstrap = 5;
 }
 
 message JoinConnectionGroupResponse {

--- a/protos/src/client/group_bootstrap.rs
+++ b/protos/src/client/group_bootstrap.rs
@@ -8,17 +8,14 @@
 //! When one emulator client creates a group or joins one via external commit,
 //! its siblings need the group's keys and, for connection groups, the contact
 //! context the acting client persisted. Both travel in a
-//! [`GroupBootstrapBlob`]: at creation as an opaque parameter of the
-//! create-group request which the DS echoes to the sibling queues, at an
-//! external join as an `AppEphemeral` proposal inside the commit.
+//! [`GroupBootstrapBlob`], an opaque parameter of the create-group or
+//! join-connection-group request, which the DS echoes to the sibling queues
+//! and nowhere else.
 //!
 //! The [`GroupBootstrap`] payload is padded-AEAD-encrypted under a
-//! [`GroupBootstrapKey`] derived from the emulation epoch that also derives the
-//! acting client's leaf. Only siblings hold that epoch state, so the AEAD both
-//! hides the payload from the DS and authenticates the blob as
-//! sibling-authored. The epoch id travels in the clear, it tells a receiving
-//! sibling which registered epoch to derive the key from. The padding hides the
-//! variable length of the connection context.
+//! [`GroupBootstrapKey`] derived from one application-ratchet generation of the
+//! emulation epoch's operation secret tree (`next_vc_application_secret` in
+//! OpenMLS).
 //!
 //! A tagged map defaults absent fields, so fields that are required by this
 //! protocol are still `Option`. A receiver rejects a payload that leaves them
@@ -36,14 +33,19 @@
 //! ```
 
 use aircommon::{
-    crypto::aead::{
-        Ciphertext, PaddedAeadDecryptable, PaddedAeadEncryptable, keys::GroupBootstrapKey,
+    crypto::{
+        aead::{Ciphertext, PaddedAeadDecryptable, PaddedAeadEncryptable, keys::GroupBootstrapKey},
+        errors::{DecryptionError, EncryptionError},
     },
     identifiers::{Fqdn, FqdnError, UserId},
     messages::{FriendshipToken, client_as::ConnectionOfferHash},
 };
 use airmacros::{
     DeserializeTaggedMap, DeserializeTaggedUnion, SerializeTaggedMap, SerializeTaggedUnion,
+};
+use openmls::{
+    components::{vc_application_secret::VcApplicationSecretInfo, vc_derivation_info::EpochId},
+    prelude::{GroupId, LeafNodeIndex},
 };
 use uuid::Uuid;
 
@@ -57,28 +59,64 @@ pub type EncryptedGroupBootstrap = Ciphertext<GroupBootstrapCtype>;
 /// Cleartext wrapper around an [`EncryptedGroupBootstrap`].
 ///
 /// This is what travels on the wire: as the `group_bootstrap` parameter of a
-/// create-group request and back out of the DS in a `GroupCreationEcho`, or as
-/// the payload of an `AppEphemeral` proposal in an external commit.
+/// create-group or join-connection-group request, and back out of the DS in a
+/// `GroupBootstrapEcho` queue message to the acting user's clients.
+///
+/// The first three fields are the coordinates of the application secret that
+/// derives the decryption key. They are in the clear so a receiving sibling
+/// knows which ratchet position of which registered emulation epoch to
+/// rederive.
 ///
 /// ## CDDL Definition
 ///
 /// ```cddl
 /// GroupBootstrapBlob = {
-///   epoch_id: bstr .tag 1,
-///   ? encrypted_bootstrap: Ciphertext .tag 2,
+///   ? epoch_id: bstr .tag 1,
+///   ? sender_leaf_index: uint .tag 2,
+///   ? generation: uint .tag 3,
+///   ? encrypted_bootstrap: Ciphertext .tag 4,
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, SerializeTaggedMap, DeserializeTaggedMap)]
 pub struct GroupBootstrapBlob {
     /// Id of the virtual client's emulation epoch that derives the decryption
     /// key.
-    ///
-    /// In the clear so a receiving sibling knows which of its registered
-    /// emulation epochs to use.
     #[tag(1)]
-    pub epoch_id: Vec<u8>,
+    pub epoch_id: Option<Vec<u8>>,
+    /// The acting client's leaf index in the emulation group, identifying the
+    /// application ratchet.
     #[tag(2)]
+    pub sender_leaf_index: Option<u32>,
+    /// The application-ratchet generation the acting client consumed.
+    #[tag(3)]
+    pub generation: Option<u32>,
+    #[tag(4)]
     pub encrypted_bootstrap: Option<EncryptedGroupBootstrap>,
+}
+
+impl GroupBootstrapBlob {
+    /// A blob for the secret at `info`, carrying `encrypted_bootstrap`.
+    pub fn new(
+        info: &VcApplicationSecretInfo,
+        encrypted_bootstrap: EncryptedGroupBootstrap,
+    ) -> Self {
+        Self {
+            epoch_id: Some(info.epoch_id.as_bytes().to_vec()),
+            sender_leaf_index: Some(info.leaf_index.u32()),
+            generation: Some(info.generation),
+            encrypted_bootstrap: Some(encrypted_bootstrap),
+        }
+    }
+
+    /// The coordinates of the application secret that derives the decryption
+    /// key, or `None` if any of them is absent.
+    pub fn secret_info(&self) -> Option<VcApplicationSecretInfo> {
+        Some(VcApplicationSecretInfo {
+            epoch_id: EpochId::new(self.epoch_id.clone()?),
+            leaf_index: LeafNodeIndex::new(self.sender_leaf_index?),
+            generation: self.generation?,
+        })
+    }
 }
 
 /// Plaintext of an [`EncryptedGroupBootstrap`].
@@ -90,7 +128,7 @@ pub struct GroupBootstrapBlob {
 ///
 /// ```cddl
 /// GroupBootstrap = {
-///   group_id: bstr .tag 1,
+///   ? group_id: bstr .tag 1,
 ///   ? pq_group_id: bstr .tag 2,
 ///   ? group_state_ear_key: bstr .size 32 .tag 3,
 ///   ? identity_link_wrapper_key: bstr .size 32 .tag 4,
@@ -104,7 +142,7 @@ pub struct GroupBootstrap {
     /// The receiver checks this id, and [`Self::pq_group_id`], against the
     /// `GroupInfo` it fetches. That binds the keys below to the group.
     #[tag(1)]
-    pub group_id: Vec<u8>,
+    pub group_id: Option<Vec<u8>>,
     /// Group id of the PQ leg, present iff the group is an APQ group.
     #[tag(2)]
     pub pq_group_id: Option<Vec<u8>>,
@@ -122,6 +160,78 @@ pub struct GroupBootstrap {
 
 impl PaddedAeadEncryptable<GroupBootstrapKey, GroupBootstrapCtype> for GroupBootstrap {}
 impl PaddedAeadDecryptable<GroupBootstrapKey, GroupBootstrapCtype> for GroupBootstrap {}
+
+/// The DS echo of a create-group or a join-connection-group request that
+/// carries a [`GroupBootstrapBlob`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupBootstrapCarrier {
+    /// The blob was uploaded with a create-group request.
+    CreationEcho,
+    /// The blob was uploaded with a join-connection-group request.
+    JoinEcho,
+}
+
+impl GroupBootstrapCarrier {
+    fn code(self) -> u8 {
+        match self {
+            Self::CreationEcho => 1,
+            Self::JoinEcho => 2,
+        }
+    }
+}
+
+/// Binds a [`GroupBootstrap`] ciphertext to its carrier.
+///
+/// ## CDDL Definition
+///
+/// ```cddl
+/// GroupBootstrapAad = {
+///   carrier: uint .tag 1,
+///   group_id: bstr .tag 2,
+/// }
+/// ```
+#[derive(Debug, SerializeTaggedMap)]
+struct GroupBootstrapAad {
+    #[tag(1)]
+    carrier: u8,
+    #[tag(2)]
+    group_id: Vec<u8>,
+}
+
+impl GroupBootstrapAad {
+    /// Fixes the canonical AAD bytes of a group id. Sender and receiver must
+    /// agree on them.
+    fn new(carrier: GroupBootstrapCarrier, group_id: &GroupId) -> Self {
+        Self {
+            carrier: carrier.code(),
+            group_id: group_id.as_slice().to_vec(),
+        }
+    }
+}
+
+impl GroupBootstrap {
+    /// Encrypt under `key`, bound to the given carrier and the carried
+    /// group's id (the T leg for APQ groups).
+    pub fn seal(
+        &self,
+        key: &GroupBootstrapKey,
+        carrier: GroupBootstrapCarrier,
+        group_id: &GroupId,
+    ) -> Result<EncryptedGroupBootstrap, EncryptionError> {
+        self.encrypt_padded_with_aad(key, &GroupBootstrapAad::new(carrier, group_id))
+    }
+
+    /// Decrypt with `key`. `carrier` and `group_id` must come from the carrier
+    /// context the blob arrived in, not from the blob itself.
+    pub fn open(
+        key: &GroupBootstrapKey,
+        ciphertext: &EncryptedGroupBootstrap,
+        carrier: GroupBootstrapCarrier,
+        group_id: &GroupId,
+    ) -> Result<Self, DecryptionError> {
+        Self::decrypt_padded_with_aad(key, ciphertext, &GroupBootstrapAad::new(carrier, group_id))
+    }
+}
 
 /// Context a sibling needs to mirror the contact rows of a connection chat.
 ///
@@ -156,7 +266,7 @@ pub enum ConnectionContext {
 ///
 /// ```cddl
 /// HandleInitiatorContext = {
-///   username: tstr .tag 1,
+///   ? username: tstr .tag 1,
 ///   ? friendship_package_ear_key: bstr .size 32 .tag 2,
 ///   ? connection_offer_hash: bstr .size 32 .tag 3,
 /// }
@@ -165,7 +275,7 @@ pub enum ConnectionContext {
 pub struct HandleInitiatorContext {
     /// The handle the offer went to. Validated into a `Username` on receive.
     #[tag(1)]
-    pub username: String,
+    pub username: Option<String>,
     /// Raw `FriendshipPackageEarKey`, 32 bytes.
     #[tag(2)]
     pub friendship_package_ear_key: Option<Vec<u8>>,
@@ -238,33 +348,47 @@ pub struct AcceptContext {
 ///
 /// ```cddl
 /// PeerUserId = {
-///   uuid: bstr .size 16 .tag 1,
-///   domain: tstr .tag 2,
+///   ? uuid: bstr .size 16 .tag 1,
+///   ? domain: tstr .tag 2,
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, SerializeTaggedMap, DeserializeTaggedMap)]
 pub struct PeerUserId {
     #[tag(1)]
-    pub uuid: Uuid,
+    pub uuid: Option<Uuid>,
     #[tag(2)]
-    pub domain: String,
+    pub domain: Option<String>,
 }
 
 impl From<UserId> for PeerUserId {
     fn from(user_id: UserId) -> Self {
         let (uuid, domain) = user_id.into_parts();
         Self {
-            uuid,
-            domain: domain.to_string(),
+            uuid: Some(uuid),
+            domain: Some(domain.to_string()),
         }
     }
 }
 
+/// Error converting a [`PeerUserId`] into a `UserId`.
+#[derive(Debug, thiserror::Error)]
+pub enum PeerUserIdError {
+    /// The uuid or the domain is absent.
+    #[error("missing field in peer user id")]
+    MissingField,
+    /// The domain is not a valid FQDN.
+    #[error(transparent)]
+    InvalidDomain(#[from] FqdnError),
+}
+
 impl TryFrom<PeerUserId> for UserId {
-    type Error = FqdnError;
+    type Error = PeerUserIdError;
 
     fn try_from(peer: PeerUserId) -> Result<Self, Self::Error> {
-        Ok(UserId::new(peer.uuid, peer.domain.parse::<Fqdn>()?))
+        let (Some(uuid), Some(domain)) = (peer.uuid, peer.domain) else {
+            return Err(PeerUserIdError::MissingField);
+        };
+        Ok(UserId::new(uuid, domain.parse::<Fqdn>()?))
     }
 }
 
@@ -274,15 +398,27 @@ mod test {
         codec::PersistenceCodec,
         crypto::{
             aead::AEAD_KEY_SIZE,
-            kdf::{KdfDerivable, keys::SelfGroupExporterSecret},
+            kdf::{KdfDerivable, keys::VcApplicationSecret},
         },
     };
 
     use super::*;
 
     fn bootstrap_key_from(secret_bytes: [u8; 32]) -> GroupBootstrapKey {
-        let exporter = SelfGroupExporterSecret::from_bytes(secret_bytes);
-        GroupBootstrapKey::derive(&exporter, &Vec::new()).unwrap()
+        let secret = VcApplicationSecret::from_bytes(secret_bytes);
+        GroupBootstrapKey::derive(&secret, &Vec::new()).unwrap()
+    }
+
+    fn t_group_id() -> GroupId {
+        GroupId::from_slice(b"t-group-id")
+    }
+
+    fn secret_info() -> VcApplicationSecretInfo {
+        VcApplicationSecretInfo {
+            epoch_id: EpochId::new(b"emulation-epoch-id".to_vec()),
+            leaf_index: LeafNodeIndex::new(3),
+            generation: 7,
+        }
     }
 
     fn key(byte: u8) -> Vec<u8> {
@@ -298,7 +434,7 @@ mod test {
 
     fn sample_bootstrap() -> GroupBootstrap {
         GroupBootstrap {
-            group_id: b"t-group-id".to_vec(),
+            group_id: Some(b"t-group-id".to_vec()),
             pq_group_id: Some(b"pq-group-id".to_vec()),
             group_state_ear_key: Some(key(1)),
             identity_link_wrapper_key: Some(key(2)),
@@ -330,7 +466,7 @@ mod test {
     #[test]
     fn group_bootstrap_of_group_chat_omits_absent_fields() {
         let bootstrap = GroupBootstrap {
-            group_id: b"t-group-id".to_vec(),
+            group_id: Some(b"t-group-id".to_vec()),
             pq_group_id: None,
             group_state_ear_key: Some(key(1)),
             identity_link_wrapper_key: Some(key(2)),
@@ -344,34 +480,88 @@ mod test {
     }
 
     #[test]
-    fn group_bootstrap_encrypt_decrypt_roundtrip() {
+    fn group_bootstrap_seal_open_roundtrip() {
         let key = bootstrap_key_from([7u8; 32]);
         let bootstrap = sample_bootstrap();
-        let encrypted = bootstrap.encrypt_padded(&key).unwrap();
-        let decrypted = GroupBootstrap::decrypt_padded(&key, &encrypted).unwrap();
-        assert_eq!(bootstrap, decrypted);
+        let sealed = bootstrap
+            .seal(&key, GroupBootstrapCarrier::CreationEcho, &t_group_id())
+            .unwrap();
+        let opened = GroupBootstrap::open(
+            &key,
+            &sealed,
+            GroupBootstrapCarrier::CreationEcho,
+            &t_group_id(),
+        )
+        .unwrap();
+        assert_eq!(bootstrap, opened);
 
         let other_key = bootstrap_key_from([8u8; 32]);
-        assert!(GroupBootstrap::decrypt_padded(&other_key, &encrypted).is_err());
+        assert!(
+            GroupBootstrap::open(
+                &other_key,
+                &sealed,
+                GroupBootstrapCarrier::CreationEcho,
+                &t_group_id(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn group_bootstrap_open_rejects_wrong_carrier_or_group() {
+        let key = bootstrap_key_from([7u8; 32]);
+        let sealed = sample_bootstrap()
+            .seal(&key, GroupBootstrapCarrier::CreationEcho, &t_group_id())
+            .unwrap();
+        assert!(
+            GroupBootstrap::open(
+                &key,
+                &sealed,
+                GroupBootstrapCarrier::JoinEcho,
+                &t_group_id(),
+            )
+            .is_err()
+        );
+        assert!(
+            GroupBootstrap::open(
+                &key,
+                &sealed,
+                GroupBootstrapCarrier::CreationEcho,
+                &GroupId::from_slice(b"other-group-id"),
+            )
+            .is_err()
+        );
     }
 
     #[test]
     fn group_bootstrap_blob_roundtrip() {
         let key = bootstrap_key_from([9u8; 32]);
-        let blob = GroupBootstrapBlob {
-            epoch_id: b"emulation-epoch-id".to_vec(),
-            encrypted_bootstrap: Some(sample_bootstrap().encrypt_padded(&key).unwrap()),
-        };
+        let sealed = sample_bootstrap()
+            .seal(&key, GroupBootstrapCarrier::CreationEcho, &t_group_id())
+            .unwrap();
+        let blob = GroupBootstrapBlob::new(&secret_info(), sealed);
         let bytes = PersistenceCodec::to_vec(&blob).unwrap();
         let decoded: GroupBootstrapBlob = PersistenceCodec::from_slice(&bytes).unwrap();
         assert_eq!(blob, decoded);
+        assert_eq!(decoded.secret_info(), Some(secret_info()));
+    }
+
+    #[test]
+    fn group_bootstrap_blob_without_coordinates_yields_no_secret_info() {
+        let blob = GroupBootstrapBlob {
+            epoch_id: Some(b"emulation-epoch-id".to_vec()),
+            sender_leaf_index: None,
+            generation: Some(7),
+            encrypted_bootstrap: None,
+        };
+        assert_eq!(blob.secret_info(), None);
     }
 
     #[test]
     fn connection_context_variants_roundtrip() {
         let contexts = [
             ConnectionContext::HandleInitiator(HandleInitiatorContext {
-                username: "alice".to_owned(),
+                username: Some("alice".to_owned()),
                 friendship_package_ear_key: Some(key(1)),
                 connection_offer_hash: Some(ConnectionOfferHash::from_bytes([2u8; 32])),
             }),
@@ -397,16 +587,29 @@ mod test {
     #[test]
     fn peer_user_id_with_invalid_domain_is_rejected() {
         let peer = PeerUserId {
-            uuid: Uuid::nil(),
-            domain: "not a domain".to_owned(),
+            uuid: Some(Uuid::nil()),
+            domain: Some("not a domain".to_owned()),
         };
         assert!(UserId::try_from(peer).is_err());
+    }
+
+    /// An absent uuid must not decode into the nil user.
+    #[test]
+    fn peer_user_id_with_absent_fields_is_rejected() {
+        let peer = PeerUserId {
+            uuid: None,
+            domain: Some("example.com".to_owned()),
+        };
+        assert!(matches!(
+            UserId::try_from(peer),
+            Err(PeerUserIdError::MissingField)
+        ));
     }
 
     #[test]
     fn connection_context_stability() {
         let context = ConnectionContext::HandleInitiator(HandleInitiatorContext {
-            username: "alice".to_owned(),
+            username: Some("alice".to_owned()),
             friendship_package_ear_key: Some(key(1)),
             connection_offer_hash: Some(ConnectionOfferHash::from_bytes([2u8; 32])),
         });
@@ -453,7 +656,7 @@ mod test {
         };
         let bytes = PersistenceCodec::to_vec(&newer).unwrap();
         let decoded: GroupBootstrap = PersistenceCodec::from_slice(&bytes).unwrap();
-        assert_eq!(decoded.group_id, b"t-group-id".to_vec());
+        assert_eq!(decoded.group_id, Some(b"t-group-id".to_vec()));
         assert_eq!(decoded.group_state_ear_key, Some(key(1)));
         assert_eq!(decoded.identity_link_wrapper_key, None);
         assert_eq!(decoded.connection, None);

--- a/protos/src/client/self_group.rs
+++ b/protos/src/client/self_group.rs
@@ -9,11 +9,9 @@
 //! proposals with component id
 //! `AIR_COMPONENT_ID` inside self-group commits. The proposal data decodes to
 //! an [`AppEphemeralPayload`], whose [`EncryptedSelfGroupMessages`] variant
-//! carries a padded-AEAD-encrypted [`SelfGroupMessages`] payload. That payload
-//! type is shared with commits in other groups, see its own documentation.
-//! Every enum in this module is a tagged union with an `#[unknown]` catch-all,
-//! so a client can adopt new tags before all of a user's devices understand
-//! them.
+//! carries a padded-AEAD-encrypted [`SelfGroupMessages`] payload. Every enum in
+//! this module is a tagged union with an `#[unknown]` catch-all, so a client can
+//! adopt new tags before all of a user's devices understand them.
 
 use aircommon::crypto::aead::{
     Ciphertext, PaddedAeadDecryptable, PaddedAeadEncryptable, keys::SelfGroupMessageKey,
@@ -25,8 +23,6 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
-use super::group_bootstrap::GroupBootstrapBlob;
-
 /// Marker for the ciphertext of [`SelfGroupMessages`].
 #[derive(Debug)]
 pub struct SelfGroupMessagesCtype;
@@ -36,26 +32,17 @@ pub type EncryptedSelfGroupMessages = Ciphertext<SelfGroupMessagesCtype>;
 
 /// Payload of an `AppEphemeralProposal` with component id `AIR_COMPONENT_ID`.
 ///
-/// Used in self-group commits and, for the [`Self::GroupBootstrapBlob`]
-/// variant, in external commits that join a higher-level group.
-///
 /// ## CDDL Definition
 ///
 /// ```cddl
 /// AppEphemeralPayload = {
-///   1: EncryptedSelfGroupMessages //
-///   2: GroupBootstrapBlob
+///   1: EncryptedSelfGroupMessages    ; tagged union, exactly one entry
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, SerializeTaggedUnion, DeserializeTaggedUnion)]
 pub enum AppEphemeralPayload {
     #[tag(1)]
     EncryptedSelfGroupMessages(EncryptedSelfGroupMessages),
-    /// Carried on the external commit that joins a connection group. Its
-    /// contents are readable only by the joining client's sibling emulator
-    /// clients.
-    #[tag(2)]
-    GroupBootstrapBlob(GroupBootstrapBlob),
     /// A payload type this client does not understand; ignored on receive.
     #[unknown]
     Unknown,
@@ -559,7 +546,7 @@ mod test {
     enum AppEphemeralPayloadV2 {
         #[tag(1)]
         EncryptedSelfGroupMessages(EncryptedSelfGroupMessages),
-        #[tag(3)]
+        #[tag(2)]
         Other(u64),
         #[unknown]
         Unknown,


### PR DESCRIPTION
This PR adds the wire formats (and modifies some existing ones) and encryption flows required for sibling self-group clients to process group creations and external joins.

In both cases, a self-group client sends a message (a group bootstrap blob) to the DS and the DS echoes the information required for sibling self-group clients to process it. The bootstrap blob is encrypted under a key derived from the self group, but contains some plain text information that siblings need to derive that key.

There's been a small change in design since the last PR on this feature, which means that for external joins, the group state blob is no longer sent as part of the commit in an AppEphemeral proposal. Instead it's now echoed as a separate message as described above (same as in the group creation flow).