### PR TITLE
fix(app): decrease RSS memory footprint of iOS Share Extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "url",
  "uuid",
  "webpx",
+ "yuv",
 ]
 
 [[package]]
@@ -5244,7 +5245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7264,7 +7265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8928,6 +8929,15 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "yuv"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220655e1c245693beb13b377d3174b9efcb1645018d1d4ec53903fc211b135ae"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log",
 url = "2.5.4"
 uuid = "1.16.0"
 webpx = { version = "0.4.0", default-features = false, features = ["encode", "animation", "std"] }
+yuv = "0.8.17"
 xshell = "0.2"
 zeroize = "1.8.2"
 

--- a/app/ios/ShareExtension/ShareViewController.swift
+++ b/app/ios/ShareExtension/ShareViewController.swift
@@ -361,13 +361,13 @@ class ShareViewController: UIViewController {
     }
 
     // Copies a still image into the App Group caches transcoded to JPEG (PNG
-    // where it has alpha), downscaled to `maxImagePixelSize` if larger.
-    // Returns nil where transcoding does not apply: images the Rust side
-    // decodes itself and that are small enough, animations, and files ImageIO
-    // cannot read are left to the plain copy.
+    // where it has alpha), downscaled to `maxImagePixelSize` if larger and
+    // converted to sRGB. Returns nil where transcoding does not apply: sRGB
+    // images the Rust side decodes itself and that are small enough,
+    // animations, and files ImageIO cannot read are left to the plain copy.
     //
-    // ImageIO scales images in streaming fashion, which prevents from running
-    // out of memory in the share extension.
+    // ImageIO scales and converts images in streaming fashion, which prevents
+    // from running out of memory in the share extension.
     private func transcodedImageCopy(_ url: URL, named name: String)
         -> TranscodedImage?
     {
@@ -391,7 +391,25 @@ class ShareViewController: UIViewController {
                 rustDecodableImageTypes.contains { type.conforms(to: $0) }
             } ?? false
         let oversized = max(width, height) > maxImagePixelSize
-        guard oversized || !rustDecodable else {
+        // Camera photos are tagged Display P3. The Rust side ignores color
+        // profiles and the WebP it produces carries none, so wide-gamut pixels
+        // would be shown as sRGB and look washed out. An untagged image is
+        // sRGB by convention. The sRGB profiles in circulation describe
+        // themselves either as "sRGB ..." or by the standard defining them,
+        // IEC 61966-2-1. The check fails safe: an unrecognized profile means
+        // a transcode, which costs some quality but never color accuracy.
+        let profileName = properties[kCGImagePropertyProfileName] as? String
+        let isSRGB =
+            profileName.map { name in
+                name.localizedCaseInsensitiveContains("sRGB")
+                    || name.contains("61966")
+            } ?? true
+        // For an opaque image the transcode is lossy, and the Rust side
+        // re-encodes once more, so a P3 photo that needs no downscale takes a
+        // second generation of (high quality) loss. That is the price of
+        // correct colors; a lossless intermediate would instead cost time and
+        // cache space in the extension for every camera photo.
+        guard oversized || !rustDecodable || !isSRGB else {
             return nil
         }
 
@@ -413,17 +431,18 @@ class ShareViewController: UIViewController {
 
         // JPEG has no alpha channel; a transparent image goes out as PNG.
         let hasAlpha = properties[kCGImagePropertyHasAlpha] as? Bool ?? false
-        let (targetType, targetExtension, mimeType, encodeOptions):
-            (UTType, String, String, [CFString: Any]) =
-                hasAlpha
-                ? (.png, "png", "image/png", [:])
-                : (
-                    .jpeg, "jpg", "image/jpeg",
-                    [
-                        kCGImageDestinationLossyCompressionQuality:
-                            transcodedImageQuality
-                    ]
-                )
+        let targetType: UTType = hasAlpha ? .png : .jpeg
+        let targetExtension = hasAlpha ? "png" : "jpg"
+        let mimeType = hasAlpha ? "image/png" : "image/jpeg"
+        var encodeOptions: [CFString: Any] = [
+            // Converts the pixels to sRGB while writing, without drawing the
+            // image into a second bitmap.
+            kCGImageDestinationOptimizeColorForSharing: true
+        ]
+        if !hasAlpha {
+            encodeOptions[kCGImageDestinationLossyCompressionQuality] =
+                transcodedImageQuality
+        }
 
         guard let shareCacheURL = shareCacheDirectory() else {
             return nil

--- a/app/ios/ShareExtension/ShareViewController.swift
+++ b/app/ios/ShareExtension/ShareViewController.swift
@@ -29,12 +29,18 @@ private let maxAttachments = 10
 private let maxAttachmentCopyBytes: UInt64 = 32 * 1024 * 1024
 
 // Matches the limit the Rust side resizes images to
-// (MAX_ATTACHMENT_IMAGE_WIDTH/HEIGHT in coreclient), preventing OOM
-// issues in the share extension.
+// (MAX_ATTACHMENT_IMAGE_WIDTH/HEIGHT in coreclient). Larger images are
+// downscaled here, where ImageIO does it in streaming fashion, so the Rust
+// side never decodes more pixels than it would keep. Lower this to trade
+// image quality for memory headroom in the extension.
 private let maxImagePixelSize = 4096
 
 // Matches ATTACHMENT_IMAGE_QUALITY_PERCENT of the Rust re-encode.
-private let downscaledImageQuality = 0.9
+private let transcodedImageQuality = 0.9
+
+// Still images in these formats are copied as they are: the Rust image
+// pipeline decodes them itself. Anything else (like HEIC) is transcoded here.
+private let rustDecodableImageTypes: [UTType] = [.jpeg, .png, .gif, .webP]
 
 // Cache entries older than this are leftovers of a share session that was
 // killed before its cleanup ran. They are removed on the next share.
@@ -309,10 +315,10 @@ class ShareViewController: UIViewController {
             // copy the file into storage owned by the extension.
             let name = self.fileName(for: provider, loadedFrom: url)
             if type.conforms(to: .image),
-                let target = self.downscaledImageCopy(url, named: name)
+                let copy = self.transcodedImageCopy(url, named: name)
             {
                 state.addAttachment(
-                    path: target.path, mimeType: "image/jpeg", at: index)
+                    path: copy.url.path, mimeType: copy.mimeType, at: index)
                 return
             }
             guard let target = self.copyToShareCache(url, named: name)
@@ -354,25 +360,38 @@ class ShareViewController: UIViewController {
         return suggested
     }
 
-    // Copies an oversized still image into the App Group caches downscaled
-    // to `maxImagePixelSize`, transcoded to JPEG. Returns nil where
-    // downscaling does not apply. If the image is small enough, animated, or
-    // not decodable, we leave the plain copy to handle the file.
+    // Copies a still image into the App Group caches transcoded to JPEG (PNG
+    // where it has alpha), downscaled to `maxImagePixelSize` if larger.
+    // Returns nil where transcoding does not apply: images the Rust side
+    // decodes itself and that are small enough, animations, and files ImageIO
+    // cannot read are left to the plain copy.
     //
     // ImageIO scales images in streaming fashion, which prevents from running
     // out of memory in the share extension.
-    private func downscaledImageCopy(_ url: URL, named name: String) -> URL? {
+    private func transcodedImageCopy(_ url: URL, named name: String)
+        -> TranscodedImage?
+    {
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-            // A multi-frame image is an animation, which a downscale to a
+            // A multi-frame image is an animation, which a transcode to a
             // single frame would freeze. The Rust side re-encodes it with
             // its frames intact.
             CGImageSourceGetCount(source) == 1,
             let properties = CGImageSourceCopyPropertiesAtIndex(
                 source, 0, nil) as? [CFString: Any],
             let width = properties[kCGImagePropertyPixelWidth] as? Int,
-            let height = properties[kCGImagePropertyPixelHeight] as? Int,
-            max(width, height) > maxImagePixelSize
+            let height = properties[kCGImagePropertyPixelHeight] as? Int
         else {
+            return nil
+        }
+
+        let sourceType = CGImageSourceGetType(source)
+            .flatMap { UTType($0 as String) }
+        let rustDecodable =
+            sourceType.map { type in
+                rustDecodableImageTypes.contains { type.conforms(to: $0) }
+            } ?? false
+        let oversized = max(width, height) > maxImagePixelSize
+        guard oversized || !rustDecodable else {
             return nil
         }
 
@@ -381,15 +400,30 @@ class ShareViewController: UIViewController {
             // Bakes the EXIF orientation into the pixels, since the
             // orientation tag does not survive the re-encode.
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxImagePixelSize,
+            kCGImageSourceThumbnailMaxPixelSize: min(
+                max(width, height), maxImagePixelSize),
         ]
         guard
-            let scaled = CGImageSourceCreateThumbnailAtIndex(
+            let image = CGImageSourceCreateThumbnailAtIndex(
                 source, 0, options as CFDictionary)
         else {
-            logger.error("Failed to downscale shared image")
+            logger.error("Failed to decode shared image for transcoding")
             return nil
         }
+
+        // JPEG has no alpha channel; a transparent image goes out as PNG.
+        let hasAlpha = properties[kCGImagePropertyHasAlpha] as? Bool ?? false
+        let (targetType, targetExtension, mimeType, encodeOptions):
+            (UTType, String, String, [CFString: Any]) =
+                hasAlpha
+                ? (.png, "png", "image/png", [:])
+                : (
+                    .jpeg, "jpg", "image/jpeg",
+                    [
+                        kCGImageDestinationLossyCompressionQuality:
+                            transcodedImageQuality
+                    ]
+                )
 
         guard let shareCacheURL = shareCacheDirectory() else {
             return nil
@@ -397,7 +431,7 @@ class ShareViewController: UIViewController {
         let targetDir = shareCacheURL.appendingPathComponent(
             UUID().uuidString, isDirectory: true)
         let target = targetDir.appendingPathComponent(
-            (name as NSString).deletingPathExtension + ".jpg")
+            (name as NSString).deletingPathExtension + "." + targetExtension)
         do {
             try FileManager.default.createDirectory(
                 at: targetDir, withIntermediateDirectories: true)
@@ -412,21 +446,18 @@ class ShareViewController: UIViewController {
 
         guard
             let destination = CGImageDestinationCreateWithURL(
-                target as CFURL, UTType.jpeg.identifier as CFString, 1, nil)
+                target as CFURL, targetType.identifier as CFString, 1, nil)
         else {
             logger.error("Failed to create image destination")
             return nil
         }
-        let encodeOptions: [CFString: Any] = [
-            kCGImageDestinationLossyCompressionQuality: downscaledImageQuality
-        ]
         CGImageDestinationAddImage(
-            destination, scaled, encodeOptions as CFDictionary)
+            destination, image, encodeOptions as CFDictionary)
         guard CGImageDestinationFinalize(destination) else {
-            logger.error("Failed to write downscaled shared image")
+            logger.error("Failed to write transcoded shared image")
             return nil
         }
-        return target
+        return TranscodedImage(url: target, mimeType: mimeType)
     }
 
     // Copies the extracted file into the App Group caches, protected like
@@ -526,6 +557,12 @@ class ShareViewController: UIViewController {
         }
         extensionContext?.completeRequest(returningItems: nil)
     }
+}
+
+// A still image re-encoded by the extension, and the MIME type of the result.
+private struct TranscodedImage {
+    let url: URL
+    let mimeType: String
 }
 
 // Turns off the sheet's drag-to-dismiss, so a drag reaches the Flutter view.

--- a/applogic/src/api/chat_details_cubit.rs
+++ b/applogic/src/api/chat_details_cubit.rs
@@ -13,8 +13,9 @@ pub use aircoreclient::{
     RequiredDebugCapabilities,
 };
 use aircoreclient::{
-    AttachmentId, AttachmentProgress, AttachmentStatus, Chat, ChatId, ChatMessage, MarkChatAsRead,
-    MessageId, ProvisionAttachmentError, UploadTaskError, clients::CoreUser,
+    AttachmentId, AttachmentProgress, AttachmentStatus, Chat, ChatId, ChatMessage,
+    ImageMemoryBudget, MarkChatAsRead, MessageId, ProvisionAttachmentError, UploadTaskError,
+    clients::CoreUser,
 };
 use airprotos::client::component::AirComponent;
 use anyhow::{Context as _, bail};
@@ -359,6 +360,7 @@ impl ChatDetailsCubitBase {
                 self.context.chat_id,
                 &path,
                 MarkChatAsRead::Yes,
+                ImageMemoryBudget::Unconstrained,
             ))
             .await?
             {

--- a/applogic/src/api/share_cubit.rs
+++ b/applogic/src/api/share_cubit.rs
@@ -16,8 +16,8 @@ use std::{
 
 use aircommon::{OpenMlsRand, RustCrypto};
 use aircoreclient::{
-    AttachmentProgressEvent, ChatId, MarkChatAsRead, MessageId, ProvisionAttachmentError,
-    UploadTaskError, clients::CoreUser,
+    AttachmentProgressEvent, ChatId, ImageMemoryBudget, MarkChatAsRead, MessageId,
+    ProvisionAttachmentError, UploadTaskError, clients::CoreUser,
 };
 use anyhow::Context as _;
 use flutter_rust_bridge::frb;
@@ -417,14 +417,19 @@ async fn upload_attachment(
 ) -> Result<MessageId, UiShareSendError> {
     let path = PathBuf::from(&attachment.path);
     // Sharing happens without the user looking at the chat, so it must not
-    // mark older messages as read.
-    let provisioned =
-        Box::pin(core_user.upload_chat_attachment(chat_id, &path, MarkChatAsRead::No))
-            .await
-            .map_err(|error| {
-                error!(%error, "Failed to provision shared attachment");
-                UiShareSendError::Other
-            })?;
+    // mark older messages as read. The share extension process has a small
+    // memory budget, so image re-encoding trades speed for memory.
+    let provisioned = Box::pin(core_user.upload_chat_attachment(
+        chat_id,
+        &path,
+        MarkChatAsRead::No,
+        ImageMemoryBudget::Constrained,
+    ))
+    .await
+    .map_err(|error| {
+        error!(%error, "Failed to provision shared attachment");
+        UiShareSendError::Other
+    })?;
 
     let (attachment_id, progress, upload_task) = match provisioned {
         Ok(result) => result,

--- a/coreclient/Cargo.toml
+++ b/coreclient/Cargo.toml
@@ -57,6 +57,7 @@ tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 webpx.workspace = true
+yuv.workspace = true
 
 [dev-dependencies]
 airbackend.workspace = true

--- a/coreclient/src/clients/attachment/upload.rs
+++ b/coreclient/src/clients/attachment/upload.rs
@@ -50,7 +50,7 @@ use crate::{
         },
     },
     groups::Group,
-    utils::image::{ReencodedAttachmentImage, load_attachment_image},
+    utils::image::{ImageMemoryBudget, ReencodedAttachmentImage, load_attachment_image},
 };
 
 impl CoreUser {
@@ -106,6 +106,7 @@ impl CoreUser {
         chat_id: ChatId,
         path: &Path,
         mark_as_read: MarkChatAsRead,
+        memory_budget: ImageMemoryBudget,
     ) -> anyhow::Result<
         Result<
             (
@@ -121,7 +122,7 @@ impl CoreUser {
             .with_context(|| format!("Can't find group with id {chat_id:?}"))?;
 
         // load the attachment data
-        let mut attachment = ProcessedAttachment::from_file(path)?;
+        let mut attachment = ProcessedAttachment::from_file(path, memory_budget)?;
 
         // encrypt the content and provision the attachment, but don't upload it yet
         let ProvisionedAttachment {
@@ -393,13 +394,13 @@ struct ProcessedAttachmentImageData {
 }
 
 impl ProcessedAttachment {
-    fn from_file(path: &Path) -> anyhow::Result<Self> {
+    fn from_file(path: &Path, memory_budget: ImageMemoryBudget) -> anyhow::Result<Self> {
         let (content, content_type, image_data): (AttachmentBytes, _, _) =
             if let Some(ReencodedAttachmentImage {
                 webp_image,
                 image_dimensions: (width, height),
                 blurhash,
-            }) = load_attachment_image(path)?
+            }) = load_attachment_image(path, memory_budget)?
             {
                 let image_data = ProcessedAttachmentImageData {
                     blurhash,

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -57,9 +57,8 @@ pub use crate::{
     privacy_pass::TokenId,
     user_profiles::{Asset, DisplayName, DisplayNameError, UserProfile},
     usernames::UsernameRecord,
-    utils::image::ImageMemoryBudget,
     utils::{
-        image::image_is_animated,
+        image::{ImageMemoryBudget, image_is_animated},
         persistence::{delete_client_database, delete_databases, open_client_db},
     },
 };

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -57,6 +57,7 @@ pub use crate::{
     privacy_pass::TokenId,
     user_profiles::{Asset, DisplayName, DisplayNameError, UserProfile},
     usernames::UsernameRecord,
+    utils::image::ImageMemoryBudget,
     utils::{
         image::image_is_animated,
         persistence::{delete_client_database, delete_databases, open_client_db},

--- a/coreclient/src/utils/image.rs
+++ b/coreclient/src/utils/image.rs
@@ -67,9 +67,8 @@ pub(crate) struct ReencodedAttachmentImage {
 /// The iOS share extension runs within a budget of roughly 120 MB shared
 /// with the Flutter engine, which the re-encode of a 12 MP photo only fits
 /// when libwebp trades speed for memory. The main app has no such limit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageMemoryBudget {
-    #[default]
     Unconstrained,
     Constrained,
 }
@@ -153,8 +152,9 @@ pub fn image_is_animated(bytes: &[u8]) -> bool {
 ///
 /// Peak memory matters here (see [`ImageMemoryBudget`]): nothing may hold a
 /// second full-size copy of the decoded image. The pixels go to libwebp as
-/// YUV planes and the RGB buffer is dropped before encoding, since libwebp's
-/// RGB import would keep an ARGB copy alive for the whole encode.
+/// YUV planes (plus an alpha plane where the image has one) and the RGB(A)
+/// buffer is dropped before encoding, since libwebp's RGB(A) import would
+/// keep an ARGB copy alive for the whole encode.
 fn load_still_image<D: ImageDecoder>(
     mut decoder: D,
     file_size: u64,
@@ -181,22 +181,12 @@ fn load_still_image<D: ImageDecoder>(
         .quality(ATTACHMENT_IMAGE_QUALITY_PERCENT)
         .low_memory(memory_budget == ImageMemoryBudget::Constrained);
 
-    let webp_data = if image.color().has_alpha() {
-        let image_rgba = image.into_rgba8();
-        webpx::Encoder::new_rgba(&image_rgba, width, height)
-            .config(config)
-            .encode(webpx::Unstoppable)
-    } else {
-        let planes = {
-            let image_rgb = image.into_rgb8();
-            YuvPlanes::from_rgb(&image_rgb)?
-            // the RGB buffer is dropped here, before libwebp allocates
-        };
-        webpx::Encoder::new_yuv(planes.as_ref())
-            .config(config)
-            .encode(webpx::Unstoppable)
-    }
-    .context("WebP encode failed")?;
+    // Consumes the image: the RGB(A) buffer is gone before libwebp allocates.
+    let planes = YuvPlanes::from_image(image)?;
+    let webp_data = webpx::Encoder::new_yuv(planes.as_ref())
+        .config(config)
+        .encode(webpx::Unstoppable)
+        .context("WebP encode failed")?;
 
     info!(
         from_bytes = file_size,
@@ -332,32 +322,67 @@ fn compute_blurhash(image: &DynamicImage) -> anyhow::Result<String> {
     )?)
 }
 
-/// An image as planar YUV 4:2:0, the layout libwebp encodes from.
+/// An image as planar YUV 4:2:0 with an optional alpha plane, the layout
+/// libwebp encodes from without making a copy of the pixels.
 struct YuvPlanes {
     planes: yuv::YuvPlanarImageMut<'static, u8>,
+    /// One byte per pixel, `None` for an opaque image.
+    alpha: Option<Vec<u8>>,
 }
 
 impl YuvPlanes {
-    /// Converts an RGB image to YUV 4:2:0.
+    /// Converts an image to YUV 4:2:0, consuming it.
     ///
-    /// BT.601 limited range is what libwebp's own RGB import produces, so the
-    /// result matches what libwebp would have computed from the RGB pixels.
-    fn from_rgb(image: &image::RgbImage) -> anyhow::Result<Self> {
+    /// The RGB(A) buffer is dropped before this returns, so the planes are the
+    /// only full-size copy of the image that outlives the conversion: 1.5
+    /// bytes per pixel, plus one for alpha, where libwebp's own import would
+    /// keep 4.
+    ///
+    /// Matrix and range (BT.601, limited) are the ones libwebp's RGB import
+    /// uses. libwebp averages chroma in linear light where this averages the
+    /// encoded samples, a difference that is not visible.
+    fn from_image(image: DynamicImage) -> anyhow::Result<Self> {
         let (width, height) = image.dimensions();
         let mut planes =
             yuv::YuvPlanarImageMut::alloc(width, height, yuv::YuvChromaSubsampling::Yuv420);
-        yuv::rgb_to_yuv420(
-            &mut planes,
-            image.as_raw(),
-            width * 3,
-            yuv::YuvRange::Limited,
-            yuv::YuvStandardMatrix::Bt601,
-            yuv::YuvConversionMode::Balanced,
-        )
-        .context("RGB to YUV conversion failed")?;
-        Ok(Self { planes })
+        let alpha = if image.color().has_alpha() {
+            let image_rgba = image.into_rgba8();
+            yuv::rgba_to_yuv420(
+                &mut planes,
+                image_rgba.as_raw(),
+                width * 4,
+                yuv::YuvRange::Limited,
+                yuv::YuvStandardMatrix::Bt601,
+                yuv::YuvConversionMode::Balanced,
+            )
+            .context("RGBA to YUV conversion failed")?;
+            let alpha = image_rgba
+                .as_raw()
+                .chunks_exact(4)
+                .map(|pixel| pixel[3])
+                .collect();
+            Some(alpha)
+        } else {
+            let image_rgb = image.into_rgb8();
+            yuv::rgb_to_yuv420(
+                &mut planes,
+                image_rgb.as_raw(),
+                width * 3,
+                yuv::YuvRange::Limited,
+                yuv::YuvStandardMatrix::Bt601,
+                yuv::YuvConversionMode::Balanced,
+            )
+            .context("RGB to YUV conversion failed")?;
+            None
+        };
+        Ok(Self { planes, alpha })
     }
 
+    /// Borrows the planes for libwebp.
+    ///
+    /// With an alpha plane, webpx forces `exact` on, so libwebp keeps the
+    /// color of fully transparent pixels instead of flattening it for better
+    /// compression. Such images come out slightly larger for it.
     fn as_ref(&self) -> webpx::YuvPlanesRef<'_> {
         webpx::YuvPlanesRef {
             y: self.planes.y_plane.borrow(),
@@ -366,10 +391,109 @@ impl YuvPlanes {
             u_stride: self.planes.u_stride as usize,
             v: self.planes.v_plane.borrow(),
             v_stride: self.planes.v_stride as usize,
-            a: None,
-            a_stride: 0,
+            a: self.alpha.as_deref(),
+            a_stride: self.planes.width as usize,
             width: self.planes.width,
             height: self.planes.height,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use image::{Rgb, RgbImage, Rgba, RgbaImage};
+
+    use super::*;
+
+    // Odd dimensions, so the chroma planes are not an exact half of the luma
+    // plane and the plane geometry handed to libwebp must round up.
+    const WIDTH: u32 = 33;
+    const HEIGHT: u32 = 17;
+
+    /// Writes the image as PNG, runs it through the attachment pipeline and
+    /// decodes the resulting WebP.
+    fn round_trip(
+        image: DynamicImage,
+        memory_budget: ImageMemoryBudget,
+    ) -> (DynamicImage, ReencodedAttachmentImage) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("image.png");
+        image.save(&path).unwrap();
+        let reencoded = load_attachment_image(&path, memory_budget)
+            .unwrap()
+            .expect("PNG is an image");
+        let decoded =
+            image::load_from_memory_with_format(&reencoded.webp_image, ImageFormat::WebP).unwrap();
+        (decoded, reencoded)
+    }
+
+    /// Asserts that two color channels agree up to lossy compression and 4:2:0
+    /// chroma subsampling of a smooth gradient.
+    fn assert_channels_close(expected: &[u8], actual: &[u8]) {
+        assert_eq!(expected.len(), actual.len());
+        let diffs: Vec<u32> = expected
+            .iter()
+            .zip(actual)
+            .map(|(a, b)| a.abs_diff(*b) as u32)
+            .collect();
+        let max = diffs.iter().max().copied().unwrap_or(0);
+        let mean = diffs.iter().sum::<u32>() as f64 / diffs.len() as f64;
+        assert!(max <= 24, "max channel difference {max} too large");
+        assert!(mean <= 3.0, "mean channel difference {mean} too large");
+    }
+
+    #[test]
+    fn opaque_image_survives_reencode() {
+        let image = RgbImage::from_fn(WIDTH, HEIGHT, |x, y| {
+            Rgb([(x * 7) as u8, (y * 15) as u8, 255 - (x * 7) as u8])
+        });
+
+        for memory_budget in [
+            ImageMemoryBudget::Unconstrained,
+            ImageMemoryBudget::Constrained,
+        ] {
+            let (decoded, reencoded) =
+                round_trip(DynamicImage::ImageRgb8(image.clone()), memory_budget);
+            assert_eq!(reencoded.image_dimensions, (WIDTH, HEIGHT));
+            assert_eq!(decoded.dimensions(), (WIDTH, HEIGHT));
+            assert!(!decoded.color().has_alpha());
+            assert_channels_close(image.as_raw(), decoded.into_rgb8().as_raw());
+        }
+    }
+
+    #[test]
+    fn transparent_image_keeps_alpha_and_color() {
+        let image = RgbaImage::from_fn(WIDTH, HEIGHT, |x, y| {
+            Rgba([
+                (x * 7) as u8,
+                (y * 15) as u8,
+                255 - (x * 7) as u8,
+                (y * 15) as u8,
+            ])
+        });
+
+        for memory_budget in [
+            ImageMemoryBudget::Unconstrained,
+            ImageMemoryBudget::Constrained,
+        ] {
+            let (decoded, reencoded) =
+                round_trip(DynamicImage::ImageRgba8(image.clone()), memory_budget);
+            assert_eq!(reencoded.image_dimensions, (WIDTH, HEIGHT));
+            assert_eq!(decoded.dimensions(), (WIDTH, HEIGHT));
+            assert!(decoded.color().has_alpha());
+            let decoded = decoded.into_rgba8();
+
+            // WebP stores alpha losslessly.
+            let alpha = |raw: &[u8]| raw.iter().skip(3).step_by(4).copied().collect::<Vec<_>>();
+            assert_eq!(alpha(image.as_raw()), alpha(decoded.as_raw()));
+
+            // The color is kept even under fully transparent pixels.
+            let color = |raw: &[u8]| {
+                raw.chunks_exact(4)
+                    .flat_map(|pixel| pixel[..3].iter().copied())
+                    .collect::<Vec<_>>()
+            };
+            assert_channels_close(&color(image.as_raw()), &color(decoded.as_raw()));
         }
     }
 }

--- a/coreclient/src/utils/image.rs
+++ b/coreclient/src/utils/image.rs
@@ -50,6 +50,7 @@ pub(crate) fn resize_profile_image(image_bytes: &[u8]) -> anyhow::Result<Vec<u8>
 const ATTACHMENT_IMAGE_QUALITY_PERCENT: f32 = 90.0;
 const MAX_ATTACHMENT_IMAGE_WIDTH: u32 = 4096;
 const MAX_ATTACHMENT_IMAGE_HEIGHT: u32 = 4096;
+const BLURHASH_THUMBNAIL_SIZE: u32 = 32;
 /// Floor for per-frame durations. Some animated images declare a 0 ms delay
 /// expecting the renderer to clamp it, so we ensure each frame contributes a
 /// non-zero duration to the resulting WebP timeline.
@@ -59,6 +60,18 @@ pub(crate) struct ReencodedAttachmentImage {
     pub(crate) webp_image: Vec<u8>,
     pub(crate) image_dimensions: (u32, u32),
     pub(crate) blurhash: String,
+}
+
+/// How much memory the re-encode of an attachment image may use.
+///
+/// The iOS share extension runs within a budget of roughly 120 MB shared
+/// with the Flutter engine, which the re-encode of a 12 MP photo only fits
+/// when libwebp trades speed for memory. The main app has no such limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ImageMemoryBudget {
+    #[default]
+    Unconstrained,
+    Constrained,
 }
 
 /// Loads an image and re-encodes it to WEBP format.
@@ -72,6 +85,7 @@ pub(crate) struct ReencodedAttachmentImage {
 ///   re-encoded as animated WebP, preserving per-frame timing.
 pub(crate) fn load_attachment_image(
     path: &Path,
+    memory_budget: ImageMemoryBudget,
 ) -> anyhow::Result<Option<ReencodedAttachmentImage>> {
     let file_size = fs::metadata(path)?.len();
 
@@ -90,7 +104,7 @@ pub(crate) fn load_attachment_image(
             if decoder.has_animation() {
                 load_animated_frames(decoder, file_size, format)?
             } else {
-                load_still_image(decoder, file_size)?
+                load_still_image(decoder, file_size, memory_budget)?
             }
         }
         ImageFormat::Png => {
@@ -99,7 +113,7 @@ pub(crate) fn load_attachment_image(
                 let apng = decoder.apng()?;
                 load_animated_frames(apng, file_size, format)?
             } else {
-                load_still_image(decoder, file_size)?
+                load_still_image(decoder, file_size, memory_budget)?
             }
         }
         _ => {
@@ -109,7 +123,7 @@ pub(crate) fn load_attachment_image(
                 Err(image::ImageError::Unsupported(_)) => return Ok(None),
                 Err(error) => return Err(error.into()),
             };
-            load_still_image(decoder, file_size)?
+            load_still_image(decoder, file_size, memory_budget)?
         }
     };
 
@@ -136,9 +150,15 @@ pub fn image_is_animated(bytes: &[u8]) -> bool {
 }
 
 /// Decodes a still image and re-encodes it as a static WebP.
+///
+/// Peak memory matters here (see [`ImageMemoryBudget`]): nothing may hold a
+/// second full-size copy of the decoded image. The pixels go to libwebp as
+/// YUV planes and the RGB buffer is dropped before encoding, since libwebp's
+/// RGB import would keep an ARGB copy alive for the whole encode.
 fn load_still_image<D: ImageDecoder>(
     mut decoder: D,
     file_size: u64,
+    memory_budget: ImageMemoryBudget,
 ) -> anyhow::Result<ReencodedAttachmentImage> {
     let orientation = decoder.orientation().ok();
 
@@ -151,18 +171,32 @@ fn load_still_image<D: ImageDecoder>(
     if let Some(orientation) = orientation {
         image.apply_orientation(orientation);
     }
+    let (width, height) = image.dimensions();
 
-    let image_rgba = image.to_rgba8();
-    let (width, height) = image_rgba.dimensions();
+    let blurhash = compute_blurhash(&image)?;
 
-    let webp_data = webpx::Encoder::new_rgba(&image_rgba, width, height)
+    // `low_memory` makes libwebp emit the bitstream as it goes instead of
+    // buffering the tokens of the whole image, at the cost of encoding speed.
+    let config = webpx::EncoderConfig::default()
         .quality(ATTACHMENT_IMAGE_QUALITY_PERCENT)
-        .encode(webpx::Unstoppable)
-        .context("WebP encode failed")?;
+        .low_memory(memory_budget == ImageMemoryBudget::Constrained);
 
-    // `blurhash::encode` can only fail if the components dimension is out of range
-    // => We should never get an error here.
-    let blurhash = blurhash::encode(4, 3, width, height, &image_rgba)?;
+    let webp_data = if image.color().has_alpha() {
+        let image_rgba = image.into_rgba8();
+        webpx::Encoder::new_rgba(&image_rgba, width, height)
+            .config(config)
+            .encode(webpx::Unstoppable)
+    } else {
+        let planes = {
+            let image_rgb = image.into_rgb8();
+            YuvPlanes::from_rgb(&image_rgb)?
+            // the RGB buffer is dropped here, before libwebp allocates
+        };
+        webpx::Encoder::new_yuv(planes.as_ref())
+            .config(config)
+            .encode(webpx::Unstoppable)
+    }
+    .context("WebP encode failed")?;
 
     info!(
         from_bytes = file_size,
@@ -280,4 +314,62 @@ fn resize(image: DynamicImage, max_width: u32, max_height: u32) -> DynamicImage 
         return image;
     }
     image.resize(max_width, max_height, image::imageops::FilterType::Lanczos3)
+}
+
+/// Computes the blurhash of an image from a small thumbnail of it.
+fn compute_blurhash(image: &DynamicImage) -> anyhow::Result<String> {
+    let thumbnail = image
+        .thumbnail(BLURHASH_THUMBNAIL_SIZE, BLURHASH_THUMBNAIL_SIZE)
+        .into_rgba8();
+    // `blurhash::encode` can only fail if the components dimension is out of range
+    // => We should never get an error here.
+    Ok(blurhash::encode(
+        4,
+        3,
+        thumbnail.width(),
+        thumbnail.height(),
+        &thumbnail,
+    )?)
+}
+
+/// An image as planar YUV 4:2:0, the layout libwebp encodes from.
+struct YuvPlanes {
+    planes: yuv::YuvPlanarImageMut<'static, u8>,
+}
+
+impl YuvPlanes {
+    /// Converts an RGB image to YUV 4:2:0.
+    ///
+    /// BT.601 limited range is what libwebp's own RGB import produces, so the
+    /// result matches what libwebp would have computed from the RGB pixels.
+    fn from_rgb(image: &image::RgbImage) -> anyhow::Result<Self> {
+        let (width, height) = image.dimensions();
+        let mut planes =
+            yuv::YuvPlanarImageMut::alloc(width, height, yuv::YuvChromaSubsampling::Yuv420);
+        yuv::rgb_to_yuv420(
+            &mut planes,
+            image.as_raw(),
+            width * 3,
+            yuv::YuvRange::Limited,
+            yuv::YuvStandardMatrix::Bt601,
+            yuv::YuvConversionMode::Balanced,
+        )
+        .context("RGB to YUV conversion failed")?;
+        Ok(Self { planes })
+    }
+
+    fn as_ref(&self) -> webpx::YuvPlanesRef<'_> {
+        webpx::YuvPlanesRef {
+            y: self.planes.y_plane.borrow(),
+            y_stride: self.planes.y_stride as usize,
+            u: self.planes.u_plane.borrow(),
+            u_stride: self.planes.u_stride as usize,
+            v: self.planes.v_plane.borrow(),
+            v_stride: self.planes.v_stride as usize,
+            a: None,
+            a_stride: 0,
+            width: self.planes.width,
+            height: self.planes.height,
+        }
+    }
 }

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -1051,7 +1051,12 @@ impl TestBackend {
         std::fs::write(&path, attachment).unwrap();
 
         let (_local_attachment_id, _progress, upload_task) = sender
-            .upload_chat_attachment(chat_id, &path, MarkChatAsRead::Yes)
+            .upload_chat_attachment(
+                chat_id,
+                &path,
+                MarkChatAsRead::Yes,
+                ImageMemoryBudget::Unconstrained,
+            )
             .await
             .expect("fatal error")?;
 


### PR DESCRIPTION
- Bring the `blurhash` size improvement from #1492 
- Convert HEIC images on the Swift side so they get uploaded as images in the app
- Avoid extra image buffer copies and convert the input to what `libwebp` expects to avoid a full-copy of the RGBA buffer.
- Switch `libwebp` to `low_memory` when in the share extension (slower)

In a full-resolution iPhone 12 image, the peak RSS went from ~113 MB down to 60, which leaves far more buffer for the rest of the app.