### PR TITLE
fix(app): handoff small images from the iOS share extension for the time being

### DIFF
--- a/app/ios/ShareExtension/ShareViewController.swift
+++ b/app/ios/ShareExtension/ShareViewController.swift
@@ -31,10 +31,10 @@ private let maxAttachmentCopyBytes: UInt64 = 32 * 1024 * 1024
 // Matches the limit the Rust side resizes images to
 // (MAX_ATTACHMENT_IMAGE_WIDTH/HEIGHT in coreclient), preventing OOM
 // issues in the share extension.
-private let maxImagePixelSize = 2048
+private let maxImagePixelSize = 1024
 
 // Matches ATTACHMENT_IMAGE_QUALITY_PERCENT of the Rust re-encode.
-private let downscaledImageQuality = 0.9
+private let reencodedImageQuality = 0.9
 
 // Cache entries older than this are leftovers of a share session that was
 // killed before its cleanup ran. They are removed on the next share.
@@ -309,7 +309,7 @@ class ShareViewController: UIViewController {
             // copy the file into storage owned by the extension.
             let name = self.fileName(for: provider, loadedFrom: url)
             if type.conforms(to: .image),
-                let target = self.downscaledImageCopy(url, named: name)
+                let target = self.reencodedImageCopy(url, named: name)
             {
                 state.addAttachment(
                     path: target.path, mimeType: "image/jpeg", at: index)
@@ -354,16 +354,21 @@ class ShareViewController: UIViewController {
         return suggested
     }
 
-    // Copies an oversized still image into the App Group caches downscaled
-    // to `maxImagePixelSize`, transcoded to JPEG. Returns nil where
-    // downscaling does not apply. If the image is small enough, animated, or
-    // not decodable, we leave the plain copy to handle the file.
+    // Copies a still image into the App Group caches, scaled to fit
+    // `maxImagePixelSize` and transcoded to JPEG. Returns nil where the
+    // re-encode does not apply: an animated or an undecodable image is left
+    // to the plain copy.
+    //
+    // Every still image takes this path, not only an oversized one. The Rust
+    // side cannot decode HEIC, which is what the Photos app hands over, and
+    // a JPEG that already fits the limit costs its pipeline far less memory
+    // than the original.
     //
     // ImageIO scales images in streaming fashion, which prevents from running
     // out of memory in the share extension.
-    private func downscaledImageCopy(_ url: URL, named name: String) -> URL? {
+    private func reencodedImageCopy(_ url: URL, named name: String) -> URL? {
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-            // A multi-frame image is an animation, which a downscale to a
+            // A multi-frame image is an animation, which a re-encode to a
             // single frame would freeze. The Rust side re-encodes it with
             // its frames intact.
             CGImageSourceGetCount(source) == 1,
@@ -371,7 +376,7 @@ class ShareViewController: UIViewController {
                 source, 0, nil) as? [CFString: Any],
             let width = properties[kCGImagePropertyPixelWidth] as? Int,
             let height = properties[kCGImagePropertyPixelHeight] as? Int,
-            max(width, height) > maxImagePixelSize
+            max(width, height) > 0
         else {
             return nil
         }
@@ -381,13 +386,16 @@ class ShareViewController: UIViewController {
             // Bakes the EXIF orientation into the pixels, since the
             // orientation tag does not survive the re-encode.
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxImagePixelSize,
+            // Capped at the image's own size, so an image that already fits
+            // is re-encoded rather than blown up.
+            kCGImageSourceThumbnailMaxPixelSize: min(
+                max(width, height), maxImagePixelSize),
         ]
         guard
             let scaled = CGImageSourceCreateThumbnailAtIndex(
                 source, 0, options as CFDictionary)
         else {
-            logger.error("Failed to downscale shared image")
+            logger.error("Failed to decode shared image")
             return nil
         }
 
@@ -418,12 +426,12 @@ class ShareViewController: UIViewController {
             return nil
         }
         let encodeOptions: [CFString: Any] = [
-            kCGImageDestinationLossyCompressionQuality: downscaledImageQuality
+            kCGImageDestinationLossyCompressionQuality: reencodedImageQuality
         ]
         CGImageDestinationAddImage(
             destination, scaled, encodeOptions as CFDictionary)
         guard CGImageDestinationFinalize(destination) else {
-            logger.error("Failed to write downscaled shared image")
+            logger.error("Failed to write re-encoded shared image")
             return nil
         }
         return target

--- a/app/ios/ShareExtension/ShareViewController.swift
+++ b/app/ios/ShareExtension/ShareViewController.swift
@@ -31,7 +31,7 @@ private let maxAttachmentCopyBytes: UInt64 = 32 * 1024 * 1024
 // Matches the limit the Rust side resizes images to
 // (MAX_ATTACHMENT_IMAGE_WIDTH/HEIGHT in coreclient), preventing OOM
 // issues in the share extension.
-private let maxImagePixelSize = 4096
+private let maxImagePixelSize = 2048
 
 // Matches ATTACHMENT_IMAGE_QUALITY_PERCENT of the Rust re-encode.
 private let downscaledImageQuality = 0.9

--- a/coreclient/src/utils/image.rs
+++ b/coreclient/src/utils/image.rs
@@ -17,6 +17,12 @@ use image::{
 };
 use tracing::info;
 
+/// Running blurhash on the full resolution picture is unnecessary (and
+/// extremely slow)
+const BLURHASH_MAX_EDGE: u32 = 64;
+const BLURHASH_COMPONENTS_X: u32 = 4;
+const BLURHASH_COMPONENTS_Y: u32 = 3;
+
 const MAX_PROFILE_IMAGE_WIDTH: u32 = 256;
 const MAX_PROFILE_IMAGE_HEIGHT: u32 = 256;
 
@@ -135,6 +141,22 @@ pub fn image_is_animated(bytes: &[u8]) -> bool {
     }
 }
 
+/// Compute the blurhash on a (very) small thumbnail, which produces a very
+/// similar result for photos and runs much faster.
+fn compute_blurhash(image: &DynamicImage) -> anyhow::Result<String> {
+    let thumbnail = image
+        .thumbnail(BLURHASH_MAX_EDGE, BLURHASH_MAX_EDGE)
+        .to_rgba8();
+    let (width, height) = thumbnail.dimensions();
+    Ok(blurhash::encode(
+        BLURHASH_COMPONENTS_X,
+        BLURHASH_COMPONENTS_Y,
+        width,
+        height,
+        &thumbnail,
+    )?)
+}
+
 /// Decodes a still image and re-encodes it as a static WebP.
 fn load_still_image<D: ImageDecoder>(
     mut decoder: D,
@@ -152,6 +174,8 @@ fn load_still_image<D: ImageDecoder>(
         image.apply_orientation(orientation);
     }
 
+    let blurhash = compute_blurhash(&image)?;
+
     let image_rgba = image.to_rgba8();
     let (width, height) = image_rgba.dimensions();
 
@@ -159,10 +183,6 @@ fn load_still_image<D: ImageDecoder>(
         .quality(ATTACHMENT_IMAGE_QUALITY_PERCENT)
         .encode(webpx::Unstoppable)
         .context("WebP encode failed")?;
-
-    // `blurhash::encode` can only fail if the components dimension is out of range
-    // => We should never get an error here.
-    let blurhash = blurhash::encode(4, 3, width, height, &image_rgba)?;
 
     info!(
         from_bytes = file_size,
@@ -197,8 +217,9 @@ fn load_animated_frames<'a, D: AnimationDecoder<'a>>(
         MAX_ATTACHMENT_IMAGE_HEIGHT,
     );
     let (width, height) = first_buffer.dimensions();
+    let first_dynamic_image = DynamicImage::ImageRgba8(first_buffer);
 
-    let blurhash = blurhash::encode(4, 3, width, height, first_buffer.as_raw())?;
+    let blurhash = compute_blurhash(&first_dynamic_image)?;
 
     let mut encoder = webpx::AnimationEncoder::with_options(width, height, true, 0)
         .context("WebP encoder init failed")?;
@@ -206,7 +227,7 @@ fn load_animated_frames<'a, D: AnimationDecoder<'a>>(
 
     let mut timestamp_ms: i32 = 0;
     encoder
-        .add_frame_rgba(first_buffer.as_raw(), timestamp_ms)
+        .add_frame_rgba(first_dynamic_image.as_bytes(), timestamp_ms)
         .context("WebP add_frame failed")?;
     timestamp_ms = timestamp_ms.saturating_add(delay_to_ms(first_delay));
 


### PR DESCRIPTION
and calculate the `blurhash` on a tiny thumbnail (produces extremely similar results for a fraction of the cost).