### PR TITLE
fix: enforce inclusion of self-remove proposals in commits

### DIFF
--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -133,6 +133,20 @@ impl DsRequestError {
         }
     }
 
+    /// The DS rejected our commit because it left a self-remove proposal
+    /// pending.
+    pub fn is_uncommitted_self_remove(&self) -> bool {
+        if let Self::Tonic(status) = self
+            && status.code() == tonic::Code::InvalidArgument
+            && let Some(details) = StatusDetails::from_status(status)
+            && let StatusDetailsCode::UncommittedSelfRemove = details.code()
+        {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns true if the error is likely due to a network issue and we can't
     /// be sure whether the server received the request.
     pub fn is_network_error(&self) -> bool {

--- a/apqmls/src/commit_builder.rs
+++ b/apqmls/src/commit_builder.rs
@@ -9,8 +9,8 @@ use openmls::{
         QueuedProposal,
     },
     prelude::{
-        InvalidExtensionError, LeafNodeIndex, LeafNodeParameters, PreSharedKeyProposal, Proposal,
-        ProposalType,
+        Extensions, GroupContext, InvalidExtensionError, LeafNodeIndex, LeafNodeParameters,
+        PreSharedKeyProposal, Proposal, ProposalType,
     },
     storage::OpenMlsProvider,
 };
@@ -118,6 +118,7 @@ struct ConfigValues {
     create_group_info: bool,
     vc_emulation_group_id: Option<GroupId>,
     derivation_epoch: bool,
+    t_group_context_extensions: Option<Extensions<GroupContext>>,
 }
 
 impl ConfigValues {
@@ -221,6 +222,15 @@ impl<'a> CommitBuilder<'a> {
             return self;
         }
         self.values.t_proposals.push(t_proposal);
+        self
+    }
+
+    /// Proposes the given group context extensions on the classical leg.
+    pub fn propose_t_group_context_extensions(
+        mut self,
+        extensions: Extensions<GroupContext>,
+    ) -> Self {
+        self.values.t_group_context_extensions = Some(extensions);
         self
     }
 
@@ -352,6 +362,11 @@ impl<'a> CommitBuilder<'a> {
             .t_group
             .commit_builder()
             .pipe(|b| self.values.apply::<true>(b));
+        // The group context extensions live on the classical leg only.
+        let t_builder = match self.values.t_group_context_extensions.clone() {
+            Some(extensions) => t_builder.propose_group_context_extensions(extensions)?,
+            None => t_builder,
+        };
         let t_builder = match &self.values.vc_emulation_group_id {
             Some(group_id) => {
                 t_builder.vc_emulation(provider.crypto(), provider.storage(), group_id)?

--- a/apqmls/tests/basic.rs
+++ b/apqmls/tests/basic.rs
@@ -8,9 +8,9 @@ use apqmls::{
 use openmls::{
     group::{GroupId, MlsGroup, MlsGroupJoinConfig},
     prelude::{
-        Capabilities, Credential, Extension, ExtensionType, Extensions, LeafNodeIndex,
-        LeafNodeParameters, MlsMessageIn, OpenMlsProvider, ProcessedMessageContent,
-        UnknownExtension,
+        Capabilities, Credential, Extension, ExtensionType, Extensions, GroupContext,
+        LeafNodeIndex, LeafNodeParameters, MlsMessageIn, OpenMlsProvider, ProcessedMessageContent,
+        RequiredCapabilitiesExtension, UnknownExtension,
     },
 };
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -298,5 +298,131 @@ fn t_only_update() {
         };
 
         update_group_helper(joined_group);
+    }
+}
+
+/// A group context extensions proposal on the classical leg only.
+///
+/// The application stores its own state in the T group context, so an APQ
+/// commit that carries it must leave the PQ context alone and both members must
+/// still converge.
+#[test]
+fn commit_with_t_group_context_extensions() {
+    const APP_EXTENSION_TYPE: u16 = 0xff01;
+
+    fn app_capabilities() -> Capabilities {
+        Capabilities::new(
+            None,
+            None,
+            Some(&[ExtensionType::Unknown(APP_EXTENSION_TYPE)]),
+            None,
+            None,
+        )
+    }
+
+    /// The group context extensions the app wants, built the way the client
+    /// builds them: from the current ones, so required capabilities survive.
+    fn app_extensions(group: &MlsGroup, data: &[u8]) -> Extensions<GroupContext> {
+        let mut extensions = group.extensions().clone();
+        extensions
+            .add_or_replace(Extension::Unknown(
+                APP_EXTENSION_TYPE,
+                UnknownExtension(data.to_vec()),
+            ))
+            .unwrap();
+        extensions
+    }
+
+    fn app_data(group: &MlsGroup) -> Option<&[u8]> {
+        group
+            .extensions()
+            .unknown(APP_EXTENSION_TYPE)
+            .map(|ext| ext.0.as_slice())
+    }
+
+    for mode in TEST_MODE {
+        let ciphersuite = mode.default_ciphersuite();
+        let alice = Client::new("Alice", ciphersuite.into(), OpenMlsRustCrypto::default());
+        let bob = Client::new("Bob", ciphersuite.into(), OpenMlsRustCrypto::default());
+
+        let mut alice_group = ApqMlsGroup::builder()
+            .with_group_ids(
+                GroupId::random(alice.provider.rand()),
+                GroupId::from_slice(b"test_pq_group"),
+            )
+            .set_mode(mode)
+            .with_capabilities(app_capabilities())
+            .with_group_context_extensions(
+                Extensions::from_vec(vec![Extension::RequiredCapabilities(
+                    RequiredCapabilitiesExtension::new(
+                        &[ExtensionType::Unknown(APP_EXTENSION_TYPE)],
+                        &[],
+                        &[],
+                    ),
+                )])
+                .unwrap(),
+                Extensions::default(),
+            )
+            .unwrap()
+            .build(
+                &alice.provider,
+                &alice.signer,
+                alice.credential_with_key.clone(),
+            )
+            .unwrap();
+
+        let key_package =
+            bob.generate_key_package_with_capabilities(ciphersuite, app_capabilities());
+        let commit_bundle = alice_group
+            .commit_builder()
+            .propose_adds([key_package])
+            .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+            .unwrap();
+        alice_group.merge_pending_commit(&alice.provider).unwrap();
+        let ratchet_tree = alice_group.export_ratchet_tree();
+        let mut bob_group = ApqMlsGroup::new_from_welcome(
+            &bob.provider,
+            &MlsGroupJoinConfig::default(),
+            commit_bundle.into_welcome().unwrap(),
+            Some(ratchet_tree.into()),
+            compare_credentials,
+        )
+        .unwrap();
+
+        assert_eq!(app_data(&alice_group.t_group), None);
+
+        // A joint self-update that also carries the application's state.
+        let extensions = app_extensions(&alice_group.t_group, b"title");
+        let commit_bundle = alice_group
+            .commit_builder()
+            .force_self_update(true)
+            .propose_t_group_context_extensions(extensions)
+            .finalize(&alice.provider, &alice.signer, |_| true, |_| true)
+            .unwrap();
+        alice_group.merge_pending_commit(&alice.provider).unwrap();
+
+        assert_eq!(app_data(&alice_group.t_group), Some(b"title".as_slice()));
+        assert_eq!(
+            app_data(alice_group.pq_group()),
+            None,
+            "the PQ context must be left alone"
+        );
+
+        // Bob converges on both legs.
+        let message_in = ApqMlsMessageIn::try_from(commit_bundle.commit).unwrap();
+        let protocol_message = message_in.into_protocol_message().unwrap();
+        let processed_message = bob_group
+            .process_message(&bob.provider, protocol_message, compare_credentials)
+            .unwrap();
+        bob_group
+            .merge_staged_commit(
+                &bob.provider,
+                processed_message.into_staged_commit().unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(app_data(&bob_group.t_group), Some(b"title".as_slice()));
+        assert_eq!(app_data(bob_group.pq_group()), None);
+        assert_groups_eq(&mut alice_group, &mut bob_group);
     }
 }

--- a/backend/src/ds/group_operation.rs
+++ b/backend/src/ds/group_operation.rs
@@ -16,7 +16,7 @@ use mls_assist::{
         group::StagedCommit,
         prelude::{
             Extension, KeyPackage, LeafNodeIndex, OpenMlsProvider, ProcessedMessage,
-            ProcessedMessageContent, Sender,
+            ProcessedMessageContent, Proposal, Sender,
         },
     },
     openmls_rust_crypto::OpenMlsRustCrypto,
@@ -124,14 +124,25 @@ impl DsGroupState {
             return Err(GroupOperationError::InvalidMessage);
         }
 
+        // A member that proposed its own removal relies on the next committer
+        // to carry the proposal, so a commit must not leave one behind.
+        let uncommitted = self
+            .uncommitted_self_removes(staged_commit)
+            .map_err(|_| GroupOperationError::ProcessingError)?;
+        if !uncommitted.is_empty() {
+            warn!(?uncommitted, "Commit leaves pending self-removes behind");
+            return Err(GroupOperationError::UncommittedSelfRemove);
+        }
+
         // A traditional commit on an APQ group can only be a PARTIAL
-        // self-update. Membership changes must go through the APQ endpoint so
-        // that both legs stay in sync. External commits are caught by the
-        // remove proposal they must carry.
+        // self-update. Membership changes (including self-removes) must go
+        // through the APQ endpoint so that both legs stay in sync. External
+        // commits are caught by the remove proposal they must carry.
         if pq_group_state.is_none()
             && self.is_apq()
             && (staged_commit.add_proposals().next().is_some()
-                || staged_commit.remove_proposals().next().is_some())
+                || staged_commit.remove_proposals().next().is_some()
+                || covers_self_remove(staged_commit))
         {
             warn!("Traditional membership change on an APQ group");
             return Err(GroupOperationError::ApqMembershipChange);
@@ -430,6 +441,14 @@ impl DsGroupState {
             if !pq_group_state.self_group_flag_unchanged(pq_staged_commit) {
                 warn!("PQ commit would toggle the self-group flag");
                 return Err(GroupOperationError::InvalidMessage);
+            }
+            // See the T leg. Self-removes need to be committed on both legs.
+            let uncommitted = pq_group_state
+                .uncommitted_self_removes(pq_staged_commit)
+                .map_err(|_| GroupOperationError::ProcessingError)?;
+            if !uncommitted.is_empty() {
+                warn!(?uncommitted, "PQ commit leaves pending self-removes behind");
+                return Err(GroupOperationError::UncommittedSelfRemove);
             }
             let pq_sender_index = match processed_assisted_message
                 .processed_message
@@ -791,6 +810,13 @@ impl DsGroupState {
         };
         Ok(response)
     }
+}
+
+/// Whether the commit covers a self-remove proposal, by reference or inline.
+fn covers_self_remove(staged_commit: &StagedCommit) -> bool {
+    staged_commit
+        .queued_proposals()
+        .any(|proposal| matches!(proposal.proposal(), Proposal::SelfRemove))
 }
 
 /// Extract the virtual client hint if present from the Safe AAD part of the message.

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -17,6 +17,7 @@ use aircommon::{
     identifiers::{QsReference, SealedClientReference},
     mls_group_config::leaf_node_is_virtual_client,
     time::TimeStamp,
+    utils::removed_clients,
 };
 use airprotos::client::component::AirComponent;
 use apqmls::extension::ApqInfo;
@@ -26,7 +27,7 @@ use mls_assist::{
     group::{Group, RetainedWelcomeInfo},
     openmls::{
         group::GroupId,
-        prelude::{GroupEpoch, LeafNodeIndex, StagedCommit},
+        prelude::{GroupEpoch, LeafNodeIndex, Proposal, Sender, StagedCommit},
     },
     provider_traits::MlsAssistProvider,
 };
@@ -297,6 +298,43 @@ impl DsGroupState {
         !self.is_self_group()
     }
 
+    /// The leaves that sent a self-remove proposal the DS has accepted but not
+    /// seen committed yet.
+    fn pending_self_remove_leaves(&self) -> Result<Vec<LeafNodeIndex>, ProposalStoreError> {
+        let proposals = self
+            .group()
+            .queued_proposals(self.provider.storage())
+            .map_err(|error| {
+                error!(%error, "Failed to read the proposal store");
+                ProposalStoreError
+            })?;
+        Ok(proposals
+            .iter()
+            .filter_map(|proposal| match (proposal.proposal(), proposal.sender()) {
+                (Proposal::SelfRemove, Sender::Member(leaf_index)) => Some(*leaf_index),
+                _ => None,
+            })
+            .collect())
+    }
+
+    /// The next commit after a self-remove proposal has to remove the proposing
+    /// leaf, otherwise a group could keep a leaving member in indefinitely by
+    /// committing around its proposal.
+    ///
+    /// Returns the leaves with a pending self-remove that `staged_commit`
+    /// leaves in the group.
+    pub(super) fn uncommitted_self_removes(
+        &self,
+        staged_commit: &StagedCommit,
+    ) -> Result<Vec<LeafNodeIndex>, ProposalStoreError> {
+        let removed = removed_clients(staged_commit);
+        Ok(self
+            .pending_self_remove_leaves()?
+            .into_iter()
+            .filter(|leaf_index| !removed.contains(leaf_index))
+            .collect())
+    }
+
     /// The self-group flag in the group context's [`AirComponent`] is fixed at
     /// group creation. Returns `true` if merging `staged_commit` keeps it
     /// unchanged.
@@ -337,6 +375,12 @@ impl DsGroupState {
             .map(|(index, profile)| (*index, profile.encrypted_user_profile_key.clone()))
     }
 }
+
+/// The proposal store could not be read, so the DS cannot tell whether a commit
+/// leaves a self-remove behind.
+#[derive(Debug, Error)]
+#[error("Failed to read the proposal store")]
+pub(super) struct ProposalStoreError;
 
 #[derive(Debug, Error)]
 pub(super) enum DsGroupStateEncryptionError {

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1630,9 +1630,11 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .collect();
                 let broadcast_to_all_client_queues = group_state.broadcast_to_all_client_queues();
 
+                // The delete commit is never merged, so the proposal store
+                // keeps whatever is parked in it. Clearing the mirror here
+                // would stop handing those proposals out while the next
+                // commit still has to carry them.
                 let group_message = group_state.delete_group(commit)?;
-
-                group_state.proposals.clear();
 
                 let timestamp = self
                     .fan_out_message_without_notifications(
@@ -1684,15 +1686,14 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
                     .other_destination_clients(t_sender_index)
                     .collect();
 
+                // See `delete_group`: the delete commit is never merged, so the
+                // mirror stays as it is.
                 let serialized_apq_message = DsGroupState::delete_apq_group(
                     t_group_state,
                     pq_group_state,
                     t_message,
                     pq_message,
                 )?;
-
-                t_group_state.proposals.clear();
-                pq_group_state.proposals.clear();
 
                 let timestamp = TimeStamp::now();
                 let apq_payload =

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -6,6 +6,7 @@ use aircommon::{
     credentials::LeafCredential,
     messages::client_ds::{AadMessage, AadPayload, JoinConnectionGroupParams},
     time::TimeStamp,
+    utils::removed_clients,
 };
 use mls_assist::{
     group::ProcessedAssistedMessage, messages::SerializedMlsMessage,
@@ -47,8 +48,10 @@ impl DsGroupState {
                 return Err(JoinConnectionGroupError::InvalidMessage);
             };
 
-        // The external commit joining the client into the group should contain only the path.
-        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+        // The external commit joining the client into the group should contain only the path,
+        // plus any self-remove proposal the joiner had to pick up. Returns the leaves that the
+        // commit removes, so their profiles can be dropped once it is accepted.
+        let removed = if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
             processed_message.content()
         {
             if staged_commit.add_proposals().count() > 0
@@ -60,6 +63,15 @@ impl DsGroupState {
             if !self.self_group_flag_unchanged(staged_commit) {
                 tracing::warn!("Commit would toggle the self-group flag");
                 return Err(JoinConnectionGroupError::InvalidMessage);
+            }
+            // The connection group info handed the joiner the pending
+            // self-remove proposals, so its commit has to carry them.
+            let uncommitted = self
+                .uncommitted_self_removes(staged_commit)
+                .map_err(|_| JoinConnectionGroupError::ProcessingError)?;
+            if !uncommitted.is_empty() {
+                tracing::warn!(?uncommitted, "Commit leaves pending self-removes behind");
+                return Err(JoinConnectionGroupError::UncommittedSelfRemove);
             }
             // A connection group is never a self-group, and its joiner's leaf must carry a user
             // credential.
@@ -76,6 +88,7 @@ impl DsGroupState {
                 tracing::warn!("Connection group joiner must carry a user credential");
                 return Err(JoinConnectionGroupError::InvalidMessage);
             }
+            removed_clients(staged_commit)
         } else {
             tracing::warn!("Invalid message: External commit contained unexpected proposals.");
             return Err(JoinConnectionGroupError::InvalidMessage);
@@ -107,6 +120,9 @@ impl DsGroupState {
             self.provider.storage(),
             processed_assisted_message_plus.processed_assisted_message,
         )?;
+
+        // A self-remove the joiner carried takes its sender's leaf with it.
+        self.remove_profiles(removed);
 
         // Let's figure out the leaf index of the new member.
         let sender = if let Some(sender) = self.group().members().find_map(|m| {

--- a/backend/src/ds/resync.rs
+++ b/backend/src/ds/resync.rs
@@ -108,6 +108,16 @@ impl DsGroupState {
             return Err(ResyncClientError::InvalidMessage);
         }
 
+        // The external commit info handed the resyncing client the pending
+        // self-remove proposals, so its commit has to carry them.
+        let uncommitted = self
+            .uncommitted_self_removes(staged_commit_message)
+            .map_err(|_| ResyncClientError::ProcessingError)?;
+        if !uncommitted.is_empty() {
+            error!(?uncommitted, "Commit leaves pending self-removes behind");
+            return Err(ResyncClientError::UncommittedSelfRemove);
+        }
+
         // Check if it's an external commit.
         if !matches!(processed_message.sender(), Sender::NewMemberCommit) {
             return Err(ResyncClientError::InvalidMessage);
@@ -242,6 +252,25 @@ impl DsGroupState {
         {
             error!("Commit would toggle the self-group flag");
             return Err(ResyncClientError::InvalidMessage);
+        }
+
+        // See the T-only variant. Both legs park their own copy of a
+        // self-remove proposal, so both have to see it committed.
+        for (leg, group_state, staged_commit) in [
+            ("T", &*t_group_state, t_staged_commit),
+            ("PQ", &*pq_group_state, pq_staged_commit),
+        ] {
+            let uncommitted = group_state
+                .uncommitted_self_removes(staged_commit)
+                .map_err(|_| ResyncClientError::ProcessingError)?;
+            if !uncommitted.is_empty() {
+                error!(
+                    leg,
+                    ?uncommitted,
+                    "Commit leaves pending self-removes behind"
+                );
+                return Err(ResyncClientError::UncommittedSelfRemove);
+            }
         }
 
         let (Sender::NewMemberCommit, Sender::NewMemberCommit) =

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use airprotos::common::v1::{
-    StatusDetails, StatusDetailsCode, WrongEpochDetail, status_details::Detail,
+    StatusDetails, StatusDetailsCode, UncommittedSelfRemoveDetail, WrongEpochDetail,
+    status_details::Detail,
 };
 use apqmls::processing::ApqProcessPublicMessageError;
 use displaydoc::Display;
@@ -129,6 +130,10 @@ pub(crate) enum GroupOperationError {
     /// Incomplete Welcome message.
     #[error("Incomplete Welcome message.")]
     IncompleteWelcome,
+    /// The commit does not remove every leaf with a pending self-remove
+    /// proposal.
+    #[error("Commit leaves a pending self-remove proposal uncommitted")]
+    UncommittedSelfRemove,
     #[error("Error merging commit")]
     MergeCommitError(#[from] MergeCommitError<group::errors::StorageError<CborMlsAssistStorage>>),
 }
@@ -188,6 +193,7 @@ impl From<GroupOperationError> for Status {
                 Status::invalid_argument(msg)
             }
             GroupOperationError::ApqMembershipChange => Status::failed_precondition(msg),
+            GroupOperationError::UncommittedSelfRemove => uncommitted_self_remove_status(msg),
             GroupOperationError::MergeCommitError(merge_commit_error) => {
                 error!(%merge_commit_error, "failed merging commit");
                 Status::internal(msg)
@@ -209,6 +215,10 @@ pub(crate) enum JoinConnectionGroupError {
     /// Not a connection group.
     #[error("Not a connection group")]
     NotAConnectionGroup,
+    /// The commit does not remove every leaf with a pending self-remove
+    /// proposal.
+    #[error("Commit leaves a pending self-remove proposal uncommitted")]
+    UncommittedSelfRemove,
     #[error("Error merging commit")]
     MergeCommitError(#[from] MergeCommitError<group::errors::StorageError<CborMlsAssistStorage>>),
 }
@@ -220,6 +230,7 @@ impl From<JoinConnectionGroupError> for Status {
             JoinConnectionGroupError::InvalidMessage
             | JoinConnectionGroupError::NotAConnectionGroup => Status::invalid_argument(msg),
             JoinConnectionGroupError::ProcessingError => Status::internal(msg),
+            JoinConnectionGroupError::UncommittedSelfRemove => uncommitted_self_remove_status(msg),
             JoinConnectionGroupError::MergeCommitError(merge_commit_error) => {
                 error!(%merge_commit_error, "failed merging commit");
                 Status::internal(msg)
@@ -303,6 +314,28 @@ fn wrong_epoch_status(msg: String) -> Status {
     )
 }
 
+/// The commit was rejected for leaving a self-remove proposal uncommitted.
+///
+/// The detail tells the committer that its view is stale rather than its
+/// message malformed, so it can drop the commit, process its queue and commit
+/// again. Which leaves are affected is logged where the rejection is raised:
+/// the committer cannot act on leaf indices, it needs the proposal messages
+/// waiting in its queue.
+fn uncommitted_self_remove_status(msg: String) -> Status {
+    Status::with_details(
+        Code::InvalidArgument,
+        msg,
+        StatusDetails {
+            code: StatusDetailsCode::UncommittedSelfRemove.into(),
+            detail: Some(Detail::UncommittedSelfRemove(
+                UncommittedSelfRemoveDetail {},
+            )),
+        }
+        .encode_to_vec()
+        .into(),
+    )
+}
+
 impl From<ClientSelfRemovalError> for Status {
     fn from(e: ClientSelfRemovalError) -> Self {
         let msg = e.to_string();
@@ -327,6 +360,10 @@ pub(crate) enum ResyncClientError {
     /// Error processing message.
     #[error("Error processing message")]
     ProcessingError,
+    /// The commit does not remove every leaf with a pending self-remove
+    /// proposal.
+    #[error("Commit leaves a pending self-remove proposal uncommitted")]
+    UncommittedSelfRemove,
     #[error("Error merging commit")]
     MergeCommitError(#[from] MergeCommitError<group::errors::StorageError<CborMlsAssistStorage>>),
 }
@@ -337,6 +374,7 @@ impl From<ResyncClientError> for Status {
         match e {
             ResyncClientError::InvalidMessage => Status::invalid_argument(msg),
             ResyncClientError::ProcessingError => Status::internal(msg),
+            ResyncClientError::UncommittedSelfRemove => uncommitted_self_remove_status(msg),
             ResyncClientError::MergeCommitError(merge_commit_error) => {
                 error!(%merge_commit_error, "failed merging commit");
                 Status::internal(msg)

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -446,6 +446,18 @@ impl Group {
     /// pending commit. Used by clean loaders to refuse to hand out a
     /// `Group` whose MLS state has an in-flight commit, since further
     /// staging on top of one is a logic error.
+    /// Whether either leg holds a proposal that has not been committed yet.
+    ///
+    /// A pending proposal has to be carried by the next commit, so on an APQ
+    /// group it forces the commit onto the joint path.
+    pub(crate) fn has_pending_proposals(&self) -> bool {
+        self.mls_group.pending_proposals().next().is_some()
+            || self
+                .pq
+                .as_ref()
+                .is_some_and(|pq| pq.mls_group.pending_proposals().next().is_some())
+    }
+
     pub(crate) fn ensure_clean(&self) -> Result<()> {
         ensure!(
             self.mls_group.pending_commit().is_none(),
@@ -2241,6 +2253,7 @@ impl Group {
         &mut self,
         txn: &mut WriteDbTransaction<'_>,
         signer: &LeafSigningKey,
+        new_group_data: Option<GroupDataBytes>,
         derivation_epoch: DerivationEpoch,
     ) -> anyhow::Result<ApqGroupOperationParamsOut> {
         let aad = AadMessage::from(AadPayload::GroupOperation(GroupOperationParamsAad {
@@ -2248,6 +2261,16 @@ impl Group {
         }))
         .tls_serialize_detached()?;
         self.mls_group.set_aad(aad);
+
+        let group_context_extensions = new_group_data
+            .map(|gd| -> Result<_> {
+                let group_data_extension =
+                    Extension::Unknown(GROUP_DATA_EXTENSION_TYPE, UnknownExtension(gd.bytes));
+                let mut exts = self.mls_group().extensions().clone();
+                exts.add_or_replace(group_data_extension)?;
+                Ok(exts)
+            })
+            .transpose()?;
 
         let t_own_leaf_node = self.mls_group.own_leaf_node().context("No own leaf node")?;
         let t_leaf_node_parameters = Self::update_leaf_node_extensions(
@@ -2277,6 +2300,9 @@ impl Group {
                 .create_group_info(true);
         if let Some(group_id) = vc_group_id {
             builder = builder.vc_emulation(group_id);
+        }
+        if let Some(extensions) = group_context_extensions {
+            builder = builder.propose_t_group_context_extensions(extensions);
         }
         let bundle = builder.finalize(&provider, signer, |_| true, |_| true)?;
 

--- a/coreclient/src/job/mod.rs
+++ b/coreclient/src/job/mod.rs
@@ -153,6 +153,8 @@ pub(crate) enum JobError<E> {
     Blocked,
     #[error("Not found")]
     NotFound,
+    #[error("Stale commit: {0}")]
+    Stale(anyhow::Error),
     #[error(transparent)]
     Fatal(#[from] anyhow::Error),
 }

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -296,6 +296,26 @@ impl Job for PendingChatOperation {
                     .ok();
                 fatal_error
             }
+            stale_error @ Err(JobError::Stale(_)) => {
+                // Same cleanup as a fatal error, but the we still want to do
+                // the commit.
+                context
+                    .db
+                    .write()
+                    .await?
+                    .with_transaction(async |txn| -> anyhow::Result<()> {
+                        let group = self.group.group_mut();
+                        group.discard_pending_commit(&mut *txn).await?;
+                        Self::delete(txn, self.group.group_id()).await?;
+                        Ok(())
+                    })
+                    .await
+                    .inspect_err(|error| {
+                        error!(%error, "Failed to delete stale pending chat operation");
+                    })
+                    .ok();
+                stale_error
+            }
             res => res,
         }
     }
@@ -699,6 +719,17 @@ impl PendingChatOperation {
             }
 
             Err(JobError::Blocked)
+        } else if error.is_uncommitted_self_remove() {
+            // A member proposed its own removal and the DS requires the next
+            // commit to carry it. Our commit was staged before we saw the
+            // proposal, so we can't just re-send it.
+            info!(
+                group_id = ?self.group.group_id(),
+                "DS rejected the commit for leaving a self-remove proposal uncommitted"
+            );
+            Ok(JobError::Stale(anyhow!(
+                "DS rejected the commit: it left a pending self-remove uncommitted"
+            )))
         } else if error.is_network_error() && self.number_of_attempts < MAX_RETRIES {
             // If we get a network error (which means we don't know whether the request has been
             // processed by the DS), we want to try again until we've either succeeded or reached a
@@ -813,7 +844,7 @@ impl PendingChatOperation {
         let signer = OwnClientInfo::signer_for_group(&mut *txn, group.group_id(), signer).await?;
         let params = group
             .group_mut()
-            .apq_update(txn, &signer, derivation_epoch)
+            .apq_update(txn, &signer, None, derivation_epoch)
             .await?;
         let job = Self::new(group, OperationType::apq_other(params));
         job.store(txn).await?;
@@ -996,15 +1027,23 @@ impl PendingChatOperation {
             .with_context(|| format!("Can't find group with chat id {chat_id}"))?;
 
         let signer = OwnClientInfo::signer_for_group(&mut *txn, group.group_id(), signer).await?;
-        let params = group
-            .group_mut()
-            .update(&mut *txn, &signer, group_data_bytes, derivation_epoch)
-            .await?;
 
-        let job = Self::new(
-            group,
-            OperationType::other_with_picture(params, new_chat_picture),
-        );
+        // If there is a pending proposal, we have to do a full APQ update.
+        let operation_type = if group.is_apq() && group.group().has_pending_proposals() {
+            let params = group
+                .group_mut()
+                .apq_update(&mut *txn, &signer, group_data_bytes, derivation_epoch)
+                .await?;
+            OperationType::apq_other_with_picture(params, new_chat_picture)
+        } else {
+            let params = group
+                .group_mut()
+                .update(&mut *txn, &signer, group_data_bytes, derivation_epoch)
+                .await?;
+            OperationType::other_with_picture(params, new_chat_picture)
+        };
+
+        let job = Self::new(group, operation_type);
         job.store(txn).await?;
 
         Ok(job)
@@ -1761,14 +1800,20 @@ mod tests {
     };
     use airprotos::{
         client::component::AirComponent,
-        common::v1::{StatusDetails, StatusDetailsCode, WrongEpochDetail, status_details::Detail},
+        common::v1::{
+            StatusDetails, StatusDetailsCode, UncommittedSelfRemoveDetail, WrongEpochDetail,
+            status_details::Detail,
+        },
     };
     use chrono::{Duration, Utc};
     use uuid::Uuid;
 
     use crate::{
-        ChatAttributes, clients::own_client_info::OwnClientInfo, db::access::DbAccess,
-        groups::GroupDataBytes, utils::persistence::open_db_in_memory,
+        ChatAttributes,
+        clients::{own_client_info::OwnClientInfo, user_settings::ReadReceiptsSetting},
+        db::access::DbAccess,
+        groups::GroupDataBytes,
+        utils::persistence::open_db_in_memory,
     };
 
     use super::*;
@@ -1780,6 +1825,20 @@ mod tests {
             detail: Some(Detail::WrongEpoch(WrongEpochDetail {})),
         };
         DsRequestError::Tonic(details.to_status(tonic::Code::InvalidArgument, "wrong epoch"))
+    }
+
+    /// A DS error that reports a commit which left a self-remove proposal
+    /// uncommitted.
+    fn uncommitted_self_remove_error() -> DsRequestError {
+        let details = StatusDetails {
+            code: StatusDetailsCode::UncommittedSelfRemove.into(),
+            detail: Some(Detail::UncommittedSelfRemove(
+                UncommittedSelfRemoveDetail {},
+            )),
+        };
+        DsRequestError::Tonic(
+            details.to_status(tonic::Code::InvalidArgument, "uncommitted self remove"),
+        )
     }
 
     /// Builds a single-member APQ self-group with a pending settings-update
@@ -1879,6 +1938,51 @@ mod tests {
             reloaded.status,
             PendingChatOperationStatus::WaitingForQueueResponse
         ));
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn uncommitted_self_remove_keeps_the_settings_intent() -> anyhow::Result<()> {
+        let (pool, mut pending, _signing_key) = setup_self_group_settings_op().await?;
+
+        // Record the local change the staged commit is carrying, so there is an
+        // intent a rollback could destroy.
+        pool.write()
+            .await?
+            .with_transaction(async |txn| {
+                SettingChanges::record(txn, &ReadReceiptsSetting(true)).await
+            })
+            .await?;
+        assert!(
+            SettingChanges::load(pool.read().await?).await?.is_some(),
+            "test setup should leave a pending setting change"
+        );
+
+        let result = pending
+            .handle_error(pool.write().await?, uncommitted_self_remove_error())
+            .await;
+
+        assert_matches!(result, Ok(JobError::Stale(_)));
+
+        let group_id = pending.group.group_id().clone();
+        let reloaded = PendingChatOperation::load_by_group_id(pool.read().await?, &group_id)
+            .await?
+            .expect("operation is only deleted by the caller's cleanup");
+        assert!(matches!(
+            reloaded.status,
+            PendingChatOperationStatus::ReadyToRetry
+        ));
+
+        assert!(SettingChanges::load(pool.read().await?).await?.is_some());
+        pool.write()
+            .await?
+            .with_transaction(async |txn| pending.roll_back_self_group_intent(txn).await)
+            .await?;
+        assert!(
+            SettingChanges::load(pool.read().await?).await?.is_none(),
+            "the fatal path would have dropped the setting change"
+        );
 
         Ok(())
     }

--- a/coreclient/src/outbound_service/chat_messages.rs
+++ b/coreclient/src/outbound_service/chat_messages.rs
@@ -418,7 +418,7 @@ impl OutboundServiceContext {
             Err(JobError::NotFound) => Err(OutboundServiceError::fatal(anyhow!(
                 "Chat not found while committing pending proposals"
             ))),
-            Err(error @ (JobError::Domain(_) | JobError::Fatal(_))) => {
+            Err(error @ (JobError::Domain(_) | JobError::Fatal(_) | JobError::Stale(_))) => {
                 Err(OutboundServiceError::fatal(error))
             }
         }

--- a/coreclient/src/outbound_service/profile.rs
+++ b/coreclient/src/outbound_service/profile.rs
@@ -119,6 +119,7 @@ impl OutboundServiceContext {
             Err(
                 error @ (JobError::Blocked
                 | JobError::Fatal(_)
+                | JobError::Stale(_)
                 | JobError::NotFound
                 | JobError::Domain(_)),
             ) => {

--- a/coreclient/src/outbound_service/retry_pending_chat_operations.rs
+++ b/coreclient/src/outbound_service/retry_pending_chat_operations.rs
@@ -68,7 +68,7 @@ impl OutboundServiceContext {
                     // If we're getting a network error, error out of the loop and wait for the next run.
                     return Err(OutboundServiceRunError::NetworkError);
                 }
-                Err(error @ (JobError::Fatal(_) | JobError::Domain(_))) => {
+                Err(error @ (JobError::Fatal(_) | JobError::Domain(_) | JobError::Stale(_))) => {
                     error!(%error, ?group_id, "Failed to execute pending chat operation");
                     // This job has a fatal error. Continue with the next one.
                     continue;

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -561,7 +561,7 @@ impl OutboundServiceContext {
             // The operation is no longer applicable to this chat, so we skip
             // it.
             Err(JobError::NotFound | JobError::Blocked) => Ok(SelfUpdateOutcome::Skipped),
-            Err(error @ (JobError::Domain(_) | JobError::Fatal(_))) => {
+            Err(error @ (JobError::Domain(_) | JobError::Fatal(_) | JobError::Stale(_))) => {
                 Err(OutboundServiceError::fatal(error))
             }
         }

--- a/mls-assist/src/group/mod.rs
+++ b/mls-assist/src/group/mod.rs
@@ -11,7 +11,7 @@ use errors::StorageError;
 use openmls::{
     error::LibraryError,
     framing::PrivateMessageIn,
-    group::{GroupId, MergeCommitError},
+    group::{GroupId, MergeCommitError, QueuedProposal},
     prelude::{
         ConfirmationTag, CreationFromExternalError, GroupEpoch, LeafNodeIndex, Member,
         OpenMlsSignaturePublicKey, ProcessedMessage, ProcessedMessageContent, ProposalStore,
@@ -222,6 +222,19 @@ impl Group {
         staged_commit: &StagedCommit,
     ) -> Result<LeafNodeIndex, LibraryError> {
         self.public_group.ext_commit_sender_index(staged_commit)
+    }
+
+    /// The proposals that were accepted into the proposal store but have not
+    /// been committed yet.
+    pub fn queued_proposals<StorageProvider: MlsAssistStorageProvider>(
+        &self,
+        provider: &StorageProvider,
+    ) -> Result<Vec<QueuedProposal>, StorageError<StorageProvider>> {
+        let proposals = self.public_group.queued_proposals(provider)?;
+        Ok(proposals
+            .into_iter()
+            .map(|(_, proposal)| proposal)
+            .collect())
     }
 }
 

--- a/protos/api/common/v1/common.proto
+++ b/protos/api/common/v1/common.proto
@@ -91,6 +91,7 @@ message StatusDetails {
     WrongEpochDetail wrong_epoch = 4;
     TokenQuotaExceededDetail token_quota_exceeded = 5;
     GenerationCollisionDetail generation_collision = 6;
+    UncommittedSelfRemoveDetail uncommitted_self_remove = 7;
   }
 }
 
@@ -106,6 +107,8 @@ enum StatusDetailsCode {
   STATUS_DETAILS_CODE_TOKEN_QUOTA_EXCEEDED = 5;
   // Another previous message was already sent in this generation
   STATUS_DETAILS_CODE_GENERATION_COLLISION = 6;
+  // The commit left a self-remove proposal pending on the DS uncommitted
+  STATUS_DETAILS_CODE_UNCOMMITTED_SELF_REMOVE = 7;
 }
 
 message VersionUnsupportedDetail {
@@ -124,6 +127,8 @@ message TokenQuotaExceededDetail {
 }
 
 message WrongEpochDetail {}
+
+message UncommittedSelfRemoveDetail {}
 
 message GenerationCollisionDetail {
   repeated sfixed64 tags = 1;

--- a/server/tests/tests/jobs.rs
+++ b/server/tests/tests/jobs.rs
@@ -226,6 +226,55 @@ async fn setup_apq_group_with_charlie_member() -> (TestBackend, UserId, UserId, 
     (setup, alice, bob, charlie, chat_id)
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn apq_self_remove_is_committed_on_both_legs() {
+    let (setup, alice, bob, charlie, chat_id) = setup_apq_group_with_charlie_member().await;
+    let bob_user = &setup.get_user(&bob).user;
+
+    let charlie_user = &setup.get_user(&charlie).user;
+    charlie_user.leave_chat(chat_id).await.unwrap();
+
+    let qs_messages = bob_user.qs_fetch_messages().await.unwrap();
+    let result = bob_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Bob should process Charlie's self-remove proposal without errors: {:?}",
+        result.errors
+    );
+
+    let before = bob_user.chat_debug_info(chat_id).await.unwrap();
+    let pq_before = before.pq.clone().expect("APQ group must have a PQ group");
+    assert_eq!(
+        before.pending_proposals, 1,
+        "T leg should hold Charlie's self-remove"
+    );
+    assert_eq!(
+        pq_before.pending_proposals, 1,
+        "PQ leg should hold Charlie's self-remove"
+    );
+
+    bob_user.update_key(chat_id).await.unwrap();
+
+    let after = bob_user.chat_debug_info(chat_id).await.unwrap();
+    let pq_after = after.pq.clone().expect("APQ group must have a PQ group");
+    assert_eq!(after.pending_proposals, 0, "T self-remove not committed");
+    assert_eq!(
+        pq_after.pending_proposals, 0,
+        "PQ self-remove not committed"
+    );
+    // A T-only update would have left the PQ epoch where it was.
+    assert!(
+        pq_after.epoch > pq_before.epoch,
+        "PQ leg must advance with the self-remove, got {} -> {}",
+        pq_before.epoch,
+        pq_after.epoch
+    );
+
+    let participants = bob_user.chat_participants(chat_id).await.unwrap();
+    assert!(!participants.contains(&charlie));
+    assert!(participants.contains(&alice));
+}
+
 // Make sure that the rosters of T and PQ groups in an APQ group remain
 // identical in the context of pending commits.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -452,4 +501,43 @@ async fn pending_leave_is_deleted_when_another_member_commits_self_remove() {
         pending_after.is_none(),
         "pending leave should be deleted once another member commits our self-remove"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn commit_that_ignores_a_pending_self_remove_is_rejected() {
+    let (setup, alice, bob, _charlie, chat_id) = setup_group_with_contacts().await;
+    let alice_user = &setup.get_user(&alice).user;
+    let bob_user = &setup.get_user(&bob).user;
+
+    alice_user.leave_chat(chat_id).await.unwrap();
+
+    // Bob leaves the proposal sitting in his queue, so his commit cannot carry
+    // it.
+    bob_user
+        .update_key(chat_id)
+        .await
+        .expect_err("DS should reject a commit that ignores the pending self-remove");
+
+    let pending_after = bob_user.pending_chat_operation_info(chat_id).await.unwrap();
+    assert!(
+        pending_after.is_none(),
+        "rejected operation should be cleaned up, not parked"
+    );
+
+    let qs_messages = bob_user.qs_fetch_messages().await.unwrap();
+    let result = bob_user.fully_process_qs_messages(qs_messages).await;
+    assert!(
+        result.errors.is_empty(),
+        "Bob should process Alice's self-remove proposal without errors: {:?}",
+        result.errors
+    );
+
+    bob_user
+        .update_key(chat_id)
+        .await
+        .expect("commit carrying the self-remove should be accepted");
+
+    let chat_participants = bob_user.chat_participants(chat_id).await.unwrap();
+    assert_eq!(chat_participants.len(), 1);
+    assert!(!chat_participants.contains(&alice));
 }


### PR DESCRIPTION
This PR has the DS enforce that pending self-remove proposals are actually included in the next commit. This can lead to a race where the DS rejects a commit because it doesn't contain a self-remove proposal that has arrived in the mean time, **so client logic had to be adjusted**.

Also fixes an existing bug, where T and PQ group diverged temporarily due to a self-remove proposal being committed in the T group but not the PQ group.