### PR TITLE
feat: robust connection request accepts

### DIFF
--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -564,6 +564,9 @@ impl ApiClient {
         group_info: MlsMessageOut,
         qs_client_reference: QsReference,
         group_state_ear_key: &GroupStateEarKey,
+        // A `GroupBootstrapBlob` (CBOR, defined in `airprotos`) encrypted for
+        // the joiner's sibling clients.
+        group_bootstrap: Option<Vec<u8>>,
     ) -> Result<TimeStamp, DsRequestError> {
         let external_commit = AssistedMessageOut::new(commit, Some(group_info));
         let request = JoinConnectionGroupRequest {
@@ -571,7 +574,7 @@ impl ApiClient {
             group_state_ear_key: Some(group_state_ear_key.ref_into()),
             external_commit: Some(external_commit.try_ref_into()?),
             qs_client_reference: Some(qs_client_reference.into()),
-            group_bootstrap: None,
+            group_bootstrap,
         };
         let response = self
             .ds_grpc_client()

--- a/apiclient/src/ds_api.rs
+++ b/apiclient/src/ds_api.rs
@@ -159,6 +159,21 @@ impl DsRequestError {
             false
         }
     }
+
+    /// Returns true if the server understood the request and rejected it.
+    pub fn is_definitive_rejection(&self) -> bool {
+        if let Self::Tonic(status) = self {
+            matches!(
+                status.code(),
+                Code::InvalidArgument
+                    | Code::FailedPrecondition
+                    | Code::NotFound
+                    | Code::PermissionDenied
+            )
+        } else {
+            false
+        }
+    }
 }
 
 pub enum DsAttachmentTarget<'a> {

--- a/app/lib/core/api/chat_details_cubit.dart
+++ b/app/lib/core/api/chat_details_cubit.dart
@@ -27,7 +27,11 @@ part 'chat_details_cubit.freezed.dart';
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChatDetailsCubitBase>>
 abstract class ChatDetailsCubitBase implements RustOpaqueInterface {
-  Future<AcceptContactRequestError?> acceptContactRequest();
+  /// Queues accepting the contact request behind this chat.
+  ///
+  /// The accept runs in the background and retries until it goes through.
+  /// Its progress is reported via [`UiChatDetails::connection_accept`].
+  Future<void> acceptContactRequest();
 
   Future<GroupDebugInfo> chatDebugInfo();
 
@@ -129,15 +133,6 @@ abstract class ChatDetailsCubitBase implements RustOpaqueInterface {
   Future<UploadAttachmentError?> uploadAttachment({required String path});
 }
 
-@freezed
-sealed class AcceptContactRequestError with _$AcceptContactRequestError {
-  const AcceptContactRequestError._();
-
-  const factory AcceptContactRequestError.incompatibleClient({
-    required String reason,
-  }) = AcceptContactRequestError_IncompatibleClient;
-}
-
 class AppDataDebugInfo {
   final List<String> components;
   final AirComponent? airComponent;
@@ -170,6 +165,16 @@ sealed class ChatDetailsState with _$ChatDetailsState {
   }) = _ChatDetailsState;
   static Future<ChatDetailsState> default_() =>
       RustLib.instance.api.crateApiChatDetailsCubitChatDetailsStateDefault();
+}
+
+@freezed
+sealed class ConnectionAcceptStatus with _$ConnectionAcceptStatus {
+  const ConnectionAcceptStatus._();
+
+  const factory ConnectionAcceptStatus.pending() =
+      ConnectionAcceptStatus_Pending;
+  const factory ConnectionAcceptStatus.failed({required String reason}) =
+      ConnectionAcceptStatus_Failed;
 }
 
 class DebugCapabilities {

--- a/app/lib/core/api/chat_details_cubit.freezed.dart
+++ b/app/lib/core/api/chat_details_cubit.freezed.dart
@@ -12,134 +12,6 @@ part of 'chat_details_cubit.dart';
 // dart format off
 T _$identity<T>(T value) => value;
 /// @nodoc
-mixin _$AcceptContactRequestError {
-
- String get reason;
-/// Create a copy of AcceptContactRequestError
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$AcceptContactRequestErrorCopyWith<AcceptContactRequestError> get copyWith => _$AcceptContactRequestErrorCopyWithImpl<AcceptContactRequestError>(this as AcceptContactRequestError, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcceptContactRequestError&&(identical(other.reason, reason) || other.reason == reason));
-}
-
-
-@override
-int get hashCode => Object.hash(runtimeType,reason);
-
-@override
-String toString() {
-  return 'AcceptContactRequestError(reason: $reason)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $AcceptContactRequestErrorCopyWith<$Res>  {
-  factory $AcceptContactRequestErrorCopyWith(AcceptContactRequestError value, $Res Function(AcceptContactRequestError) _then) = _$AcceptContactRequestErrorCopyWithImpl;
-@useResult
-$Res call({
- String reason
-});
-
-
-
-
-}
-/// @nodoc
-class _$AcceptContactRequestErrorCopyWithImpl<$Res>
-    implements $AcceptContactRequestErrorCopyWith<$Res> {
-  _$AcceptContactRequestErrorCopyWithImpl(this._self, this._then);
-
-  final AcceptContactRequestError _self;
-  final $Res Function(AcceptContactRequestError) _then;
-
-/// Create a copy of AcceptContactRequestError
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? reason = null,}) {
-  return _then(_self.copyWith(
-reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
-}
-
-
-
-/// @nodoc
-
-
-class AcceptContactRequestError_IncompatibleClient extends AcceptContactRequestError {
-  const AcceptContactRequestError_IncompatibleClient({required this.reason}): super._();
-  
-
-@override final  String reason;
-
-/// Create a copy of AcceptContactRequestError
-/// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$AcceptContactRequestError_IncompatibleClientCopyWith<AcceptContactRequestError_IncompatibleClient> get copyWith => _$AcceptContactRequestError_IncompatibleClientCopyWithImpl<AcceptContactRequestError_IncompatibleClient>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AcceptContactRequestError_IncompatibleClient&&(identical(other.reason, reason) || other.reason == reason));
-}
-
-
-@override
-int get hashCode => Object.hash(runtimeType,reason);
-
-@override
-String toString() {
-  return 'AcceptContactRequestError.incompatibleClient(reason: $reason)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $AcceptContactRequestError_IncompatibleClientCopyWith<$Res> implements $AcceptContactRequestErrorCopyWith<$Res> {
-  factory $AcceptContactRequestError_IncompatibleClientCopyWith(AcceptContactRequestError_IncompatibleClient value, $Res Function(AcceptContactRequestError_IncompatibleClient) _then) = _$AcceptContactRequestError_IncompatibleClientCopyWithImpl;
-@override @useResult
-$Res call({
- String reason
-});
-
-
-
-
-}
-/// @nodoc
-class _$AcceptContactRequestError_IncompatibleClientCopyWithImpl<$Res>
-    implements $AcceptContactRequestError_IncompatibleClientCopyWith<$Res> {
-  _$AcceptContactRequestError_IncompatibleClientCopyWithImpl(this._self, this._then);
-
-  final AcceptContactRequestError_IncompatibleClient _self;
-  final $Res Function(AcceptContactRequestError_IncompatibleClient) _then;
-
-/// Create a copy of AcceptContactRequestError
-/// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
-  return _then(AcceptContactRequestError_IncompatibleClient(
-reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
-
-}
-
-/// @nodoc
 mixin _$ChatDetailsState {
 
  UiChatDetails? get chat; List<UiUserId> get members;
@@ -270,6 +142,135 @@ class __$ChatDetailsStateCopyWithImpl<$Res>
 chat: freezed == chat ? _self.chat : chat // ignore: cast_nullable_to_non_nullable
 as UiChatDetails?,members: null == members ? _self._members : members // ignore: cast_nullable_to_non_nullable
 as List<UiUserId>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$ConnectionAcceptStatus {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConnectionAcceptStatus);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ConnectionAcceptStatus()';
+}
+
+
+}
+
+/// @nodoc
+class $ConnectionAcceptStatusCopyWith<$Res>  {
+$ConnectionAcceptStatusCopyWith(ConnectionAcceptStatus _, $Res Function(ConnectionAcceptStatus) __);
+}
+
+
+
+/// @nodoc
+
+
+class ConnectionAcceptStatus_Pending extends ConnectionAcceptStatus {
+  const ConnectionAcceptStatus_Pending(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConnectionAcceptStatus_Pending);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ConnectionAcceptStatus.pending()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class ConnectionAcceptStatus_Failed extends ConnectionAcceptStatus {
+  const ConnectionAcceptStatus_Failed({required this.reason}): super._();
+  
+
+ final  String reason;
+
+/// Create a copy of ConnectionAcceptStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ConnectionAcceptStatus_FailedCopyWith<ConnectionAcceptStatus_Failed> get copyWith => _$ConnectionAcceptStatus_FailedCopyWithImpl<ConnectionAcceptStatus_Failed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ConnectionAcceptStatus_Failed&&(identical(other.reason, reason) || other.reason == reason));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,reason);
+
+@override
+String toString() {
+  return 'ConnectionAcceptStatus.failed(reason: $reason)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ConnectionAcceptStatus_FailedCopyWith<$Res> implements $ConnectionAcceptStatusCopyWith<$Res> {
+  factory $ConnectionAcceptStatus_FailedCopyWith(ConnectionAcceptStatus_Failed value, $Res Function(ConnectionAcceptStatus_Failed) _then) = _$ConnectionAcceptStatus_FailedCopyWithImpl;
+@useResult
+$Res call({
+ String reason
+});
+
+
+
+
+}
+/// @nodoc
+class _$ConnectionAcceptStatus_FailedCopyWithImpl<$Res>
+    implements $ConnectionAcceptStatus_FailedCopyWith<$Res> {
+  _$ConnectionAcceptStatus_FailedCopyWithImpl(this._self, this._then);
+
+  final ConnectionAcceptStatus_Failed _self;
+  final $Res Function(ConnectionAcceptStatus_Failed) _then;
+
+/// Create a copy of ConnectionAcceptStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? reason = null,}) {
+  return _then(ConnectionAcceptStatus_Failed(
+reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,
   ));
 }
 

--- a/app/lib/core/api/chats_data_source.dart
+++ b/app/lib/core/api/chats_data_source.dart
@@ -8,6 +8,7 @@ import 'package:convert/convert.dart';
 
 import '../frb_generated.dart';
 import '../lib.dart';
+import 'chat_details_cubit.dart';
 import 'markdown.dart';
 import 'message_content.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';

--- a/app/lib/core/api/share_cubit.dart
+++ b/app/lib/core/api/share_cubit.dart
@@ -8,6 +8,7 @@ import 'package:convert/convert.dart';
 
 import '../frb_generated.dart';
 import '../lib.dart';
+import 'chat_details_cubit.dart';
 import 'markdown.dart';
 import 'message_content.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';

--- a/app/lib/core/api/types.dart
+++ b/app/lib/core/api/types.dart
@@ -8,6 +8,7 @@ import 'package:convert/convert.dart';
 
 import '../frb_generated.dart';
 import '../lib.dart';
+import 'chat_details_cubit.dart';
 import 'markdown.dart';
 import 'message_content.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
@@ -151,6 +152,9 @@ class UiChatDetails {
   final UiChatMuted? mutedUntil;
   final bool pendingCommitFailed;
 
+  /// State of the queued accept of this chat's connection request, if any.
+  final ConnectionAcceptStatus? connectionAccept;
+
   const UiChatDetails({
     required this.id,
     required this.status,
@@ -163,6 +167,7 @@ class UiChatDetails {
     required this.isApq,
     this.mutedUntil,
     required this.pendingCommitFailed,
+    this.connectionAccept,
   });
 
   @override
@@ -177,7 +182,8 @@ class UiChatDetails {
       draft.hashCode ^
       isApq.hashCode ^
       mutedUntil.hashCode ^
-      pendingCommitFailed.hashCode;
+      pendingCommitFailed.hashCode ^
+      connectionAccept.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -194,7 +200,8 @@ class UiChatDetails {
           draft == other.draft &&
           isApq == other.isApq &&
           mutedUntil == other.mutedUntil &&
-          pendingCommitFailed == other.pendingCommitFailed;
+          pendingCommitFailed == other.pendingCommitFailed &&
+          connectionAccept == other.connectionAccept;
 }
 
 /// A message in a chat

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -141,7 +141,7 @@ abstract class RustLibApi extends BaseApi {
     required AttachmentId attachmentId,
   });
 
-  Future<AcceptContactRequestError?>
+  Future<void>
   crateApiChatDetailsCubitChatDetailsCubitBaseAcceptContactRequest({
     required ChatDetailsCubitBase that,
   });
@@ -1368,7 +1368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<AcceptContactRequestError?>
+  Future<void>
   crateApiChatDetailsCubitChatDetailsCubitBaseAcceptContactRequest({
     required ChatDetailsCubitBase that,
   }) {
@@ -1388,8 +1388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
         },
         codec: SseCodec(
-          decodeSuccessData:
-              sse_decode_opt_box_autoadd_accept_contact_request_error,
+          decodeSuccessData: sse_decode_unit,
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta:
@@ -9113,21 +9112,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError dco_decode_accept_contact_request_error(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    switch (raw[0]) {
-      case 0:
-        return AcceptContactRequestError_IncompatibleClient(
-          reason: dco_decode_String(raw[1]),
-        );
-      default:
-        throw Exception("unreachable");
-    }
-  }
-
-  @protected
   AddUsernameContactError dco_decode_add_username_contact_error(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AddUsernameContactError.values[raw as int];
@@ -9284,14 +9268,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError dco_decode_box_autoadd_accept_contact_request_error(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return dco_decode_accept_contact_request_error(raw);
-  }
-
-  @protected
   AddUsernameContactError dco_decode_box_autoadd_add_username_contact_error(
     dynamic raw,
   ) {
@@ -9339,6 +9315,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ChatId dco_decode_box_autoadd_chat_id(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_chat_id(raw);
+  }
+
+  @protected
+  ConnectionAcceptStatus dco_decode_box_autoadd_connection_accept_status(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_connection_accept_status(raw);
   }
 
   @protected
@@ -9648,6 +9632,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       order: dco_decode_opt_list_chat_id(arr[2]),
       members: dco_decode_Map_chat_id_list_ui_user_id_None(arr[3]),
     );
+  }
+
+  @protected
+  ConnectionAcceptStatus dco_decode_connection_accept_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return ConnectionAcceptStatus_Pending();
+      case 1:
+        return ConnectionAcceptStatus_Failed(reason: dco_decode_String(raw[1]));
+      default:
+        throw Exception("unreachable");
+    }
   }
 
   @protected
@@ -10449,15 +10446,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError?
-  dco_decode_opt_box_autoadd_accept_contact_request_error(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw == null
-        ? null
-        : dco_decode_box_autoadd_accept_contact_request_error(raw);
-  }
-
-  @protected
   AddUsernameContactError?
   dco_decode_opt_box_autoadd_add_username_contact_error(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -10496,6 +10484,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ChatId? dco_decode_opt_box_autoadd_chat_id(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_chat_id(raw);
+  }
+
+  @protected
+  ConnectionAcceptStatus? dco_decode_opt_box_autoadd_connection_accept_status(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null
+        ? null
+        : dco_decode_box_autoadd_connection_accept_status(raw);
   }
 
   @protected
@@ -11009,8 +11007,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   UiChatDetails dco_decode_ui_chat_details(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 11)
-      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+    if (arr.length != 12)
+      throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
     return UiChatDetails(
       id: dco_decode_chat_id(arr[0]),
       status: dco_decode_ui_chat_status(arr[1]),
@@ -11023,6 +11021,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       isApq: dco_decode_bool(arr[8]),
       mutedUntil: dco_decode_opt_box_autoadd_ui_chat_muted(arr[9]),
       pendingCommitFailed: dco_decode_bool(arr[10]),
+      connectionAccept: dco_decode_opt_box_autoadd_connection_accept_status(
+        arr[11],
+      ),
     );
   }
 
@@ -12563,22 +12564,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError sse_decode_accept_contact_request_error(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    var tag_ = sse_decode_i_32(deserializer);
-    switch (tag_) {
-      case 0:
-        var var_reason = sse_decode_String(deserializer);
-        return AcceptContactRequestError_IncompatibleClient(reason: var_reason);
-      default:
-        throw UnimplementedError('');
-    }
-  }
-
-  @protected
   AddUsernameContactError sse_decode_add_username_contact_error(
     SseDeserializer deserializer,
   ) {
@@ -12736,14 +12721,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError sse_decode_box_autoadd_accept_contact_request_error(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return (sse_decode_accept_contact_request_error(deserializer));
-  }
-
-  @protected
   AddUsernameContactError sse_decode_box_autoadd_add_username_contact_error(
     SseDeserializer deserializer,
   ) {
@@ -12801,6 +12778,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ChatId sse_decode_box_autoadd_chat_id(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_chat_id(deserializer));
+  }
+
+  @protected
+  ConnectionAcceptStatus sse_decode_box_autoadd_connection_accept_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_connection_accept_status(deserializer));
   }
 
   @protected
@@ -13164,6 +13149,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       order: var_order,
       members: var_members,
     );
+  }
+
+  @protected
+  ConnectionAcceptStatus sse_decode_connection_accept_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return ConnectionAcceptStatus_Pending();
+      case 1:
+        var var_reason = sse_decode_String(deserializer);
+        return ConnectionAcceptStatus_Failed(reason: var_reason);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -14251,22 +14254,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  AcceptContactRequestError?
-  sse_decode_opt_box_autoadd_accept_contact_request_error(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    if (sse_decode_bool(deserializer)) {
-      return (sse_decode_box_autoadd_accept_contact_request_error(
-        deserializer,
-      ));
-    } else {
-      return null;
-    }
-  }
-
-  @protected
   AddUsernameContactError?
   sse_decode_opt_box_autoadd_add_username_contact_error(
     SseDeserializer deserializer,
@@ -14336,6 +14323,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_chat_id(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  ConnectionAcceptStatus? sse_decode_opt_box_autoadd_connection_accept_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_connection_accept_status(deserializer));
     } else {
       return null;
     }
@@ -15057,6 +15057,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_isApq = sse_decode_bool(deserializer);
     var var_mutedUntil = sse_decode_opt_box_autoadd_ui_chat_muted(deserializer);
     var var_pendingCommitFailed = sse_decode_bool(deserializer);
+    var var_connectionAccept =
+        sse_decode_opt_box_autoadd_connection_accept_status(deserializer);
     return UiChatDetails(
       id: var_id,
       status: var_status,
@@ -15069,6 +15071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       isApq: var_isApq,
       mutedUntil: var_mutedUntil,
       pendingCommitFailed: var_pendingCommitFailed,
+      connectionAccept: var_connectionAccept,
     );
   }
 
@@ -16941,19 +16944,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_accept_contact_request_error(
-    AcceptContactRequestError self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    switch (self) {
-      case AcceptContactRequestError_IncompatibleClient(reason: final reason):
-        sse_encode_i_32(0, serializer);
-        sse_encode_String(reason, serializer);
-    }
-  }
-
-  @protected
   void sse_encode_add_username_contact_error(
     AddUsernameContactError self,
     SseSerializer serializer,
@@ -17099,15 +17089,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_box_autoadd_accept_contact_request_error(
-    AcceptContactRequestError self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_accept_contact_request_error(self, serializer);
-  }
-
-  @protected
   void sse_encode_box_autoadd_add_username_contact_error(
     AddUsernameContactError self,
     SseSerializer serializer,
@@ -17171,6 +17152,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_box_autoadd_chat_id(ChatId self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_chat_id(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_connection_accept_status(
+    ConnectionAcceptStatus self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_connection_accept_status(self, serializer);
   }
 
   @protected
@@ -17574,6 +17564,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_Set_chat_id_None(self.removed, serializer);
     sse_encode_opt_list_chat_id(self.order, serializer);
     sse_encode_Map_chat_id_list_ui_user_id_None(self.members, serializer);
+  }
+
+  @protected
+  void sse_encode_connection_accept_status(
+    ConnectionAcceptStatus self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case ConnectionAcceptStatus_Pending():
+        sse_encode_i_32(0, serializer);
+      case ConnectionAcceptStatus_Failed(reason: final reason):
+        sse_encode_i_32(1, serializer);
+        sse_encode_String(reason, serializer);
+    }
   }
 
   @protected
@@ -18521,19 +18526,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_opt_box_autoadd_accept_contact_request_error(
-    AcceptContactRequestError? self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    sse_encode_bool(self != null, serializer);
-    if (self != null) {
-      sse_encode_box_autoadd_accept_contact_request_error(self, serializer);
-    }
-  }
-
-  @protected
   void sse_encode_opt_box_autoadd_add_username_contact_error(
     AddUsernameContactError? self,
     SseSerializer serializer,
@@ -18605,6 +18597,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_chat_id(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_connection_accept_status(
+    ConnectionAcceptStatus? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_connection_accept_status(self, serializer);
     }
   }
 
@@ -19276,6 +19281,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.isApq, serializer);
     sse_encode_opt_box_autoadd_ui_chat_muted(self.mutedUntil, serializer);
     sse_encode_bool(self.pendingCommitFailed, serializer);
+    sse_encode_opt_box_autoadd_connection_accept_status(
+      self.connectionAccept,
+      serializer,
+    );
   }
 
   @protected
@@ -19874,9 +19883,11 @@ class ChatDetailsCubitBaseImpl extends RustOpaque
         .rust_arc_decrement_strong_count_ChatDetailsCubitBasePtr,
   );
 
-  Future<AcceptContactRequestError?> acceptContactRequest() => RustLib
-      .instance
-      .api
+  /// Queues accepting the contact request behind this chat.
+  ///
+  /// The accept runs in the background and retries until it goes through.
+  /// Its progress is reported via [`UiChatDetails::connection_accept`].
+  Future<void> acceptContactRequest() => RustLib.instance.api
       .crateApiChatDetailsCubitChatDetailsCubitBaseAcceptContactRequest(
         that: this,
       );

--- a/app/lib/core/frb_generated.io.dart
+++ b/app/lib/core/frb_generated.io.dart
@@ -659,11 +659,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   UuidValue dco_decode_Uuid(dynamic raw);
 
   @protected
-  AcceptContactRequestError dco_decode_accept_contact_request_error(
-    dynamic raw,
-  );
-
-  @protected
   AddUsernameContactError dco_decode_add_username_contact_error(dynamic raw);
 
   @protected
@@ -712,11 +707,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DateTime dco_decode_box_autoadd_Chrono_Utc(dynamic raw);
 
   @protected
-  AcceptContactRequestError dco_decode_box_autoadd_accept_contact_request_error(
-    dynamic raw,
-  );
-
-  @protected
   AddUsernameContactError dco_decode_box_autoadd_add_username_contact_error(
     dynamic raw,
   );
@@ -741,6 +731,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatId dco_decode_box_autoadd_chat_id(dynamic raw);
+
+  @protected
+  ConnectionAcceptStatus dco_decode_box_autoadd_connection_accept_status(
+    dynamic raw,
+  );
 
   @protected
   ConversationNotification dco_decode_box_autoadd_conversation_notification(
@@ -893,6 +888,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatsDelta dco_decode_chats_delta(dynamic raw);
+
+  @protected
+  ConnectionAcceptStatus dco_decode_connection_accept_status(dynamic raw);
 
   @protected
   ConversationMessage dco_decode_conversation_message(dynamic raw);
@@ -1149,10 +1147,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DateTime? dco_decode_opt_box_autoadd_Chrono_Utc(dynamic raw);
 
   @protected
-  AcceptContactRequestError?
-  dco_decode_opt_box_autoadd_accept_contact_request_error(dynamic raw);
-
-  @protected
   AddUsernameContactError?
   dco_decode_opt_box_autoadd_add_username_contact_error(dynamic raw);
 
@@ -1170,6 +1164,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatId? dco_decode_opt_box_autoadd_chat_id(dynamic raw);
+
+  @protected
+  ConnectionAcceptStatus? dco_decode_opt_box_autoadd_connection_accept_status(
+    dynamic raw,
+  );
 
   @protected
   ConversationNotification?
@@ -1986,11 +1985,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   UuidValue sse_decode_Uuid(SseDeserializer deserializer);
 
   @protected
-  AcceptContactRequestError sse_decode_accept_contact_request_error(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   AddUsernameContactError sse_decode_add_username_contact_error(
     SseDeserializer deserializer,
   );
@@ -2041,11 +2035,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DateTime sse_decode_box_autoadd_Chrono_Utc(SseDeserializer deserializer);
 
   @protected
-  AcceptContactRequestError sse_decode_box_autoadd_accept_contact_request_error(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   AddUsernameContactError sse_decode_box_autoadd_add_username_contact_error(
     SseDeserializer deserializer,
   );
@@ -2078,6 +2067,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatId sse_decode_box_autoadd_chat_id(SseDeserializer deserializer);
+
+  @protected
+  ConnectionAcceptStatus sse_decode_box_autoadd_connection_accept_status(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ConversationNotification sse_decode_box_autoadd_conversation_notification(
@@ -2290,6 +2284,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatsDelta sse_decode_chats_delta(SseDeserializer deserializer);
+
+  @protected
+  ConnectionAcceptStatus sse_decode_connection_accept_status(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ConversationMessage sse_decode_conversation_message(
@@ -2612,12 +2611,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DateTime? sse_decode_opt_box_autoadd_Chrono_Utc(SseDeserializer deserializer);
 
   @protected
-  AcceptContactRequestError?
-  sse_decode_opt_box_autoadd_accept_contact_request_error(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   AddUsernameContactError?
   sse_decode_opt_box_autoadd_add_username_contact_error(
     SseDeserializer deserializer,
@@ -2643,6 +2636,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ChatId? sse_decode_opt_box_autoadd_chat_id(SseDeserializer deserializer);
+
+  @protected
+  ConnectionAcceptStatus? sse_decode_opt_box_autoadd_connection_accept_status(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ConversationNotification?
@@ -3634,12 +3632,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_Uuid(UuidValue self, SseSerializer serializer);
 
   @protected
-  void sse_encode_accept_contact_request_error(
-    AcceptContactRequestError self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_add_username_contact_error(
     AddUsernameContactError self,
     SseSerializer serializer,
@@ -3703,12 +3695,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_accept_contact_request_error(
-    AcceptContactRequestError self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_box_autoadd_add_username_contact_error(
     AddUsernameContactError self,
     SseSerializer serializer,
@@ -3749,6 +3735,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_chat_id(ChatId self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_connection_accept_status(
+    ConnectionAcceptStatus self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_box_autoadd_conversation_notification(
@@ -4010,6 +4002,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_chats_delta(ChatsDelta self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_connection_accept_status(
+    ConnectionAcceptStatus self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_conversation_message(
@@ -4423,12 +4421,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_opt_box_autoadd_accept_contact_request_error(
-    AcceptContactRequestError? self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_opt_box_autoadd_add_username_contact_error(
     AddUsernameContactError? self,
     SseSerializer serializer,
@@ -4458,6 +4450,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_chat_id(
     ChatId? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_connection_accept_status(
+    ConnectionAcceptStatus? self,
     SseSerializer serializer,
   );
 

--- a/app/lib/features/chat/chat_details_cubit.dart
+++ b/app/lib/features/chat/chat_details_cubit.dart
@@ -102,9 +102,7 @@ class ChatDetailsCubit extends StateStreamableSource<ChatDetailsState> {
   Future<void> replyToMessage({required MessageId messageId}) =>
       _impl.replyToMessage(messageId: messageId);
 
-  @useResult
-  Future<AcceptContactRequestError?> acceptContactRequest() =>
-      _impl.acceptContactRequest();
+  Future<void> acceptContactRequest() => _impl.acceptContactRequest();
 
   Future<void> muteChat({UiChatMuted? mutedUntil}) =>
       _impl.muteChat(mutedUntil: mutedUntil);

--- a/app/lib/features/message_list/contact_request_dialog.dart
+++ b/app/lib/features/message_list/contact_request_dialog.dart
@@ -57,7 +57,39 @@ class ContactRequestDialog extends HookWidget {
     final loc = AppLocalizations.of(context);
     final tokens = ContactRequestCardTokens.current;
 
-    final isAccepting = useState(false);
+    // The accept runs as a persistent background job. The button stays
+    // disabled as long as the job is pending. A permanently failed job
+    // re-enables it: accepting again re-arms the job.
+    final acceptStatus = context.select(
+      (ChatDetailsCubit c) => c.state.chat?.connectionAccept,
+    );
+    final tapped = useState(false);
+    final isAccepting =
+        tapped.value || acceptStatus is ConnectionAcceptStatus_Pending;
+
+    final failedReason = switch (acceptStatus) {
+      ConnectionAcceptStatus_Failed(:final reason) => reason,
+      _ => null,
+    };
+    useEffect(() {
+      if (acceptStatus != null) {
+        // The job state took over from the local tap feedback.
+        tapped.value = false;
+      }
+      if (failedReason != null) {
+        // The effect runs during build, but showing a banner rebuilds the
+        // messenger, so defer it to after the frame.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          Logger.detached(
+            "ContactRequestDialog",
+          ).severe("Failed to accept contact request: $failedReason");
+          showErrorBannerStandalone(
+            (loc) => loc.contactRequestDialog_error_fatal,
+          );
+        });
+      }
+      return null;
+    }, [acceptStatus]);
 
     final subtitle = switch (source) {
       _TargetedMessageContactRequest(:final originChatTitle) =>
@@ -86,9 +118,9 @@ class ContactRequestDialog extends HookWidget {
       pictureRevealLabel: loc.contactRequestDialog_avatarHint,
       acceptLabel: loc.contactRequestDialog_confirm,
       dismissLabel: loc.contactRequestDialog_cancel,
-      onAccept: () => _accept(context, isAccepting),
+      onAccept: () => _accept(context, tapped),
       onDismiss: () => context.read<NavigationCubit>().closeChat(),
-      isAccepting: isAccepting.value,
+      isAccepting: isAccepting,
     );
   }
 
@@ -108,30 +140,18 @@ class ContactRequestDialog extends HookWidget {
     );
   }
 
-  void _accept(BuildContext context, ValueNotifier<bool> isAccepting) async {
-    isAccepting.value = true;
+  void _accept(BuildContext context, ValueNotifier<bool> tapped) async {
+    tapped.value = true;
 
     final chatDetailsCubit = context.read<ChatDetailsCubit>();
     try {
-      switch (await chatDetailsCubit.acceptContactRequest()) {
-        case null:
-          break; // No error
-        case AcceptContactRequestError_IncompatibleClient(:final reason):
-          Logger.detached("ContactRequestDialog").severe(
-            "Failed to accept contact request due to incompatible client: $reason",
-          );
-          showErrorBannerStandalone(
-            (loc) => loc.contactRequestDialog_error_incompatibleClient,
-          );
-          break;
-      }
+      await chatDetailsCubit.acceptContactRequest();
     } catch (e, stackTrace) {
       Logger.detached(
         "ContactRequestDialog",
       ).severe("Failed to accept contact request: $e", e, stackTrace);
       showErrorBannerStandalone((loc) => loc.contactRequestDialog_error_fatal);
-    } finally {
-      isAccepting.value = false;
+      tapped.value = false;
     }
   }
 }

--- a/applogic/src/api/chat_details_cubit.rs
+++ b/applogic/src/api/chat_details_cubit.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use aircommon::{OpenMlsRand, RustCrypto, identifiers::UserId};
 pub use aircoreclient::{
-    AcceptContactRequestError, AppDataDebugInfo, DebugCapabilities, EncryptedGroupTitleDebugInfo,
+    AppDataDebugInfo, ConnectionAcceptStatus, DebugCapabilities, EncryptedGroupTitleDebugInfo,
     ExternalGroupProfileDebugInfo, GroupDataDebugInfo, GroupDebugInfo, PqGroupDebugInfo,
     RequiredDebugCapabilities,
 };
@@ -665,16 +665,13 @@ impl ChatDetailsCubitBase {
         Ok(())
     }
 
-    pub async fn accept_contact_request(
-        &self,
-    ) -> anyhow::Result<Option<AcceptContactRequestError>> {
+    /// Queues accepting the contact request behind this chat.
+    ///
+    /// The accept runs in the background and retries until it goes through.
+    /// Its progress is reported via [`UiChatDetails::connection_accept`].
+    pub async fn accept_contact_request(&self) -> anyhow::Result<()> {
         let chat_id = self.context.chat_id;
-        Ok(self
-            .context
-            .core_user
-            .accept_contact_request(chat_id)
-            .await?
-            .err())
+        self.context.core_user.accept_contact_request(chat_id).await
     }
 
     /// Mute notifications for this chat until the given datetime.
@@ -867,6 +864,11 @@ pub(super) async fn load_chat_details(core_user: &CoreUser, chat: Chat) -> UiCha
 
     let pending_commit_failed = core_user.chat_is_pending(&group_id).await.unwrap_or(false);
 
+    let connection_accept = core_user
+        .connection_accept_status(chat.id)
+        .await
+        .unwrap_or_default();
+
     UiChatDetails {
         id: chat.id,
         status: chat.status.into(),
@@ -881,6 +883,7 @@ pub(super) async fn load_chat_details(core_user: &CoreUser, chat: Chat) -> UiCha
         is_apq,
         muted_until: chat.muted_until.map(Into::into),
         pending_commit_failed,
+        connection_accept,
     }
 }
 
@@ -915,9 +918,10 @@ pub enum UploadAttachmentError {
     },
 }
 
-#[frb(mirror(AcceptContactRequestError))]
-pub enum _AcceptContactRequestError {
-    IncompatibleClient { reason: String },
+#[frb(mirror(ConnectionAcceptStatus))]
+pub enum _ConnectionAcceptStatus {
+    Pending,
+    Failed { reason: String },
 }
 
 #[frb(mirror(GroupDebugInfo))]

--- a/applogic/src/api/types.rs
+++ b/applogic/src/api/types.rs
@@ -16,9 +16,10 @@ pub(crate) use airprotos::client::component::{AirComponent, AirFeatures};
 
 use aircommon::identifiers::UserId;
 use aircoreclient::{
-    Asset, AttachmentId, ChatAttributes, ChatMessage, ChatMuted, ChatStatus, ChatType, Contact,
-    ContentMessage, DisplayName, ErrorMessage, EventMessage, InactiveChat, LastReaction, Message,
-    MessageDraft, SystemMessage, TargetedMessageContact, UserProfile, clients::CoreUser,
+    Asset, AttachmentId, ChatAttributes, ChatMessage, ChatMuted, ChatStatus, ChatType,
+    ConnectionAcceptStatus, Contact, ContentMessage, DisplayName, ErrorMessage, EventMessage,
+    InactiveChat, LastReaction, Message, MessageDraft, SystemMessage, TargetedMessageContact,
+    UserProfile, clients::CoreUser,
 };
 use chrono::{DateTime, Local, Utc};
 use flutter_rust_bridge::frb;
@@ -104,6 +105,8 @@ pub struct UiChatDetails {
     pub is_apq: bool,
     pub muted_until: Option<UiChatMuted>,
     pub pending_commit_failed: bool,
+    /// State of the queued accept of this chat's connection request, if any.
+    pub connection_accept: Option<ConnectionAcceptStatus>,
 }
 
 impl UiChatDetails {

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -9110,13 +9110,6 @@ fn wire__crate__api__username_suggestions__username_from_display_impl(
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 const _: fn() = || {
-    match None::<crate::api::chat_details_cubit::AcceptContactRequestError>.unwrap() {
-        crate::api::chat_details_cubit::AcceptContactRequestError::IncompatibleClient {
-            reason,
-        } => {
-            let _: String = reason;
-        }
-    }
     {
         let AdmissionSession = None::<crate::api::registration::AdmissionSession>.unwrap();
         let _: uuid::Uuid = AdmissionSession.session_id;
@@ -9145,6 +9138,12 @@ const _: fn() = || {
     {
         let ChatId = None::<crate::api::types::ChatId>.unwrap();
         let _: uuid::Uuid = ChatId.uuid;
+    }
+    match None::<crate::api::chat_details_cubit::ConnectionAcceptStatus>.unwrap() {
+        crate::api::chat_details_cubit::ConnectionAcceptStatus::Pending => {}
+        crate::api::chat_details_cubit::ConnectionAcceptStatus::Failed { reason } => {
+            let _: String = reason;
+        }
     }
     {
         let DebugCapabilities = None::<crate::api::chat_details_cubit::DebugCapabilities>.unwrap();
@@ -10233,22 +10232,6 @@ impl SseDecode for uuid::Uuid {
     }
 }
 
-impl SseDecode for crate::api::chat_details_cubit::AcceptContactRequestError {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut tag_ = <i32>::sse_decode(deserializer);
-        match tag_ {
-            0 => {
-                let mut var_reason = <String>::sse_decode(deserializer);
-                return crate::api::chat_details_cubit::AcceptContactRequestError::IncompatibleClient{reason: var_reason};
-            }
-            _ => {
-                unimplemented!("");
-            }
-        }
-    }
-}
-
 impl SseDecode for crate::api::types::AddUsernameContactError {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -10461,6 +10444,27 @@ impl SseDecode for crate::api::chats_data_source::ChatsDelta {
             order: var_order,
             members: var_members,
         };
+    }
+}
+
+impl SseDecode for crate::api::chat_details_cubit::ConnectionAcceptStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::chat_details_cubit::ConnectionAcceptStatus::Pending;
+            }
+            1 => {
+                let mut var_reason = <String>::sse_decode(deserializer);
+                return crate::api::chat_details_cubit::ConnectionAcceptStatus::Failed {
+                    reason: var_reason,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -11619,21 +11623,6 @@ impl SseDecode for Option<chrono::DateTime<chrono::Utc>> {
     }
 }
 
-impl SseDecode for Option<crate::api::chat_details_cubit::AcceptContactRequestError> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        if (<bool>::sse_decode(deserializer)) {
-            return Some(
-                <crate::api::chat_details_cubit::AcceptContactRequestError>::sse_decode(
-                    deserializer,
-                ),
-            );
-        } else {
-            return None;
-        }
-    }
-}
-
 impl SseDecode for Option<crate::api::types::AddUsernameContactError> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -11698,6 +11687,19 @@ impl SseDecode for Option<crate::api::types::ChatId> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<crate::api::types::ChatId>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<crate::api::chat_details_cubit::ConnectionAcceptStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(
+                <crate::api::chat_details_cubit::ConnectionAcceptStatus>::sse_decode(deserializer),
+            );
         } else {
             return None;
         }
@@ -12441,6 +12443,9 @@ impl SseDecode for crate::api::types::UiChatDetails {
         let mut var_isApq = <bool>::sse_decode(deserializer);
         let mut var_mutedUntil = <Option<crate::api::types::UiChatMuted>>::sse_decode(deserializer);
         let mut var_pendingCommitFailed = <bool>::sse_decode(deserializer);
+        let mut var_connectionAccept = <Option<
+            crate::api::chat_details_cubit::ConnectionAcceptStatus,
+        >>::sse_decode(deserializer);
         return crate::api::types::UiChatDetails {
             id: var_id,
             status: var_status,
@@ -12453,6 +12458,7 @@ impl SseDecode for crate::api::types::UiChatDetails {
             is_apq: var_isApq,
             muted_until: var_mutedUntil,
             pending_commit_failed: var_pendingCommitFailed,
+            connection_accept: var_connectionAccept,
         };
     }
 }
@@ -13898,36 +13904,6 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<UsersState>> for UsersState {
 }
 
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart
-    for FrbWrapper<crate::api::chat_details_cubit::AcceptContactRequestError>
-{
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        match self.0 {
-            crate::api::chat_details_cubit::AcceptContactRequestError::IncompatibleClient {
-                reason,
-            } => [0.into_dart(), reason.into_into_dart().into_dart()].into_dart(),
-            _ => {
-                unimplemented!("");
-            }
-        }
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<crate::api::chat_details_cubit::AcceptContactRequestError>
-{
-}
-impl
-    flutter_rust_bridge::IntoIntoDart<
-        FrbWrapper<crate::api::chat_details_cubit::AcceptContactRequestError>,
-    > for crate::api::chat_details_cubit::AcceptContactRequestError
-{
-    fn into_into_dart(
-        self,
-    ) -> FrbWrapper<crate::api::chat_details_cubit::AcceptContactRequestError> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<crate::api::types::AddUsernameContactError> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self.0 {
@@ -14210,6 +14186,37 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::chats_data_source::ChatsDelta
 {
     fn into_into_dart(self) -> crate::api::chats_data_source::ChatsDelta {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart
+    for FrbWrapper<crate::api::chat_details_cubit::ConnectionAcceptStatus>
+{
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self.0 {
+            crate::api::chat_details_cubit::ConnectionAcceptStatus::Pending => {
+                [0.into_dart()].into_dart()
+            }
+            crate::api::chat_details_cubit::ConnectionAcceptStatus::Failed { reason } => {
+                [1.into_dart(), reason.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<crate::api::chat_details_cubit::ConnectionAcceptStatus>
+{
+}
+impl
+    flutter_rust_bridge::IntoIntoDart<
+        FrbWrapper<crate::api::chat_details_cubit::ConnectionAcceptStatus>,
+    > for crate::api::chat_details_cubit::ConnectionAcceptStatus
+{
+    fn into_into_dart(self) -> FrbWrapper<crate::api::chat_details_cubit::ConnectionAcceptStatus> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -15503,6 +15510,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::types::UiChatDetails {
             self.is_apq.into_into_dart().into_dart(),
             self.muted_until.into_into_dart().into_dart(),
             self.pending_commit_failed.into_into_dart().into_dart(),
+            self.connection_accept.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -17104,23 +17112,6 @@ impl SseEncode for uuid::Uuid {
     }
 }
 
-impl SseEncode for crate::api::chat_details_cubit::AcceptContactRequestError {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        match self {
-            crate::api::chat_details_cubit::AcceptContactRequestError::IncompatibleClient {
-                reason,
-            } => {
-                <i32>::sse_encode(0, serializer);
-                <String>::sse_encode(reason, serializer);
-            }
-            _ => {
-                unimplemented!("");
-            }
-        }
-    }
-}
-
 impl SseEncode for crate::api::types::AddUsernameContactError {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -17304,6 +17295,24 @@ impl SseEncode for crate::api::chats_data_source::ChatsDelta {
         );
         <Option<Vec<crate::api::types::ChatId>>>::sse_encode(self.order, serializer);
         <std::collections::HashMap<crate::api::types::ChatId, Vec<crate::api::types::UiUserId>>>::sse_encode(self.members, serializer);
+    }
+}
+
+impl SseEncode for crate::api::chat_details_cubit::ConnectionAcceptStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::chat_details_cubit::ConnectionAcceptStatus::Pending => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::chat_details_cubit::ConnectionAcceptStatus::Failed { reason } => {
+                <i32>::sse_encode(1, serializer);
+                <String>::sse_encode(reason, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -18225,18 +18234,6 @@ impl SseEncode for Option<chrono::DateTime<chrono::Utc>> {
     }
 }
 
-impl SseEncode for Option<crate::api::chat_details_cubit::AcceptContactRequestError> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <bool>::sse_encode(self.is_some(), serializer);
-        if let Some(value) = self {
-            <crate::api::chat_details_cubit::AcceptContactRequestError>::sse_encode(
-                value, serializer,
-            );
-        }
-    }
-}
-
 impl SseEncode for Option<crate::api::types::AddUsernameContactError> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -18293,6 +18290,16 @@ impl SseEncode for Option<crate::api::types::ChatId> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <crate::api::types::ChatId>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::chat_details_cubit::ConnectionAcceptStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::chat_details_cubit::ConnectionAcceptStatus>::sse_encode(value, serializer);
         }
     }
 }
@@ -18899,6 +18906,10 @@ impl SseEncode for crate::api::types::UiChatDetails {
         <bool>::sse_encode(self.is_apq, serializer);
         <Option<crate::api::types::UiChatMuted>>::sse_encode(self.muted_until, serializer);
         <bool>::sse_encode(self.pending_commit_failed, serializer);
+        <Option<crate::api::chat_details_cubit::ConnectionAcceptStatus>>::sse_encode(
+            self.connection_accept,
+            serializer,
+        );
     }
 }
 

--- a/backend/src/ds/grpc.rs
+++ b/backend/src/ds/grpc.rs
@@ -1456,21 +1456,20 @@ impl<Qep: QsConnector, As: AsConnector> DeliveryService for GrpcDs<Qep, As> {
 
                     group_state.proposals.clear();
 
-                    if let Some((group_bootstrap, epoch)) =
-                        group_bootstrap.zip(outcome.snapshot_epoch)
-                    {
-                        let echo = QsQueueMessagePayload::group_join_echo(GroupBootstrapEcho {
-                            group_id: qgid.clone().into(),
-                            // APQ joins are rejected on this path.
-                            pq_group_id: None,
-                            epoch,
-                            timestamp: TimeStamp::now(),
-                            group_bootstrap,
-                        })
-                        .tls_failed("group join echo")?;
-                        self.dispatch_group_bootstrap_echo(echo, qs_client_reference)
-                            .await;
-                    }
+                    // In addition to bootstrapping siblings, the echo confirms
+                    // the accepted join to the acting client when the response
+                    // below is lost.
+                    let echo = QsQueueMessagePayload::group_join_echo(GroupBootstrapEcho {
+                        group_id: qgid.clone().into(),
+                        // APQ joins are rejected on this path.
+                        pq_group_id: None,
+                        epoch: outcome.pre_commit_epoch,
+                        timestamp: TimeStamp::now(),
+                        group_bootstrap: group_bootstrap.unwrap_or_default(),
+                    })
+                    .tls_failed("group join echo")?;
+                    self.dispatch_group_bootstrap_echo(echo, qs_client_reference)
+                        .await;
 
                     let timestamp = self
                         .fan_out_message_without_notifications(

--- a/backend/src/ds/join_connection_group.rs
+++ b/backend/src/ds/join_connection_group.rs
@@ -64,17 +64,18 @@ fn validate_join_proposals(staged_commit: &StagedCommit) -> Result<(), JoinConne
 
 pub(super) struct JoinConnectionGroupOutcome {
     pub(super) message: SerializedMlsMessage,
-    /// The epoch of the staged snapshot, present iff the join carried a group
-    /// bootstrap.
-    pub(super) snapshot_epoch: Option<GroupEpoch>,
+    /// The epoch the group was at before the commit. A snapshot is staged at
+    /// this epoch iff the join carried a group bootstrap.
+    pub(super) pre_commit_epoch: GroupEpoch,
 }
 
 impl DsGroupState {
     /// Accept an external commit joining a connection group.
     ///
-    /// With `bootstrap_requested`, the joiner's sibling emulator clients get an
-    /// echo of the operation, so the joining leaf must be a virtual-client leaf
-    /// and the pre-commit state is staged as an epoch snapshot for them.
+    /// With `bootstrap_requested`, the echo of the operation carries a group
+    /// bootstrap for the joiner's sibling emulator clients, so the joining
+    /// leaf must be a virtual-client leaf and the pre-commit state is staged
+    /// as an epoch snapshot for them.
     pub(super) fn join_connection_group(
         &mut self,
         params: JoinConnectionGroupParams,
@@ -163,8 +164,8 @@ impl DsGroupState {
 
         // The siblings apply the commit on top of the state the joiner used, so
         // capture it before the commit is accepted.
-        let staged_snapshot =
-            bootstrap_requested.then(|| (self.group().epoch(), self.epoch_snapshot()));
+        let pre_commit_epoch = self.group().epoch();
+        let staged_snapshot = bootstrap_requested.then(|| self.epoch_snapshot());
 
         // Finalize processing.
         let retained_welcome_info = self.group.accept_processed_message(
@@ -200,14 +201,13 @@ impl DsGroupState {
         // Finally, we create the message for distribution.
         let message = processed_assisted_message_plus.serialized_mls_message;
 
-        let snapshot_epoch = staged_snapshot.map(|(epoch, snapshot)| {
-            self.stage_epoch_snapshot(epoch, snapshot.with_join_commit(&message));
-            epoch
-        });
+        if let Some(snapshot) = staged_snapshot {
+            self.stage_epoch_snapshot(pre_commit_epoch, snapshot.with_join_commit(&message));
+        }
 
         Ok(JoinConnectionGroupOutcome {
             message,
-            snapshot_epoch,
+            pre_commit_epoch,
         })
     }
 }

--- a/common/src/messages/client_ds.rs
+++ b/common/src/messages/client_ds.rs
@@ -162,13 +162,15 @@ pub struct DsCommitResponse {
     pub key_package_batch: Option<KeyPackageBatchId>,
 }
 
-/// Announces a group a virtual client created or externally joined. Meant to
-/// be put into the QS queues of all of the acting user's clients. The message
-/// type distinguishes creation from join.
+/// Announces a group a client created or externally joined. Meant to be put
+/// into the QS queues of all of the acting user's clients. The message type
+/// distinguishes creation from join.
 ///
 /// The DS sends it when it accepts the operation, before any other traffic of
 /// that group reaches those queues. A sibling client uses it to join the group
-/// itself.
+/// itself. The acting client uses its own join echo as the durable
+/// confirmation that the join was accepted, in case the direct response to
+/// the join request was lost.
 #[derive(Debug, TlsSerialize, TlsDeserializeBytes, TlsSize, Clone)]
 pub struct GroupBootstrapEcho {
     pub group_id: GroupId,
@@ -179,7 +181,8 @@ pub struct GroupBootstrapEcho {
     pub epoch: GroupEpoch,
     pub timestamp: TimeStamp,
     /// A `GroupBootstrapBlob` (CBOR, defined in `airprotos`), encrypted for the
-    /// acting client's siblings. The DS echoes it unread.
+    /// acting client's siblings. The DS echoes it unread. Empty when the
+    /// acting client requested no bootstrap.
     pub group_bootstrap: Vec<u8>,
 }
 

--- a/coreclient/.sqlx/query-08e31bcf92e6d2f2ccbc2835bd19b9977171a70f5747b3fc9d4a370569846903.json
+++ b/coreclient/.sqlx/query-08e31bcf92e6d2f2ccbc2835bd19b9977171a70f5747b3fc9d4a370569846903.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE connection_accept_queue\n                SET locked_by = ?1\n                WHERE chat_id = (\n                    SELECT chat_id\n                    FROM connection_accept_queue\n                    WHERE failed_reason IS NULL\n                        AND (locked_by IS NULL OR locked_by != ?1)\n                    LIMIT 1\n                )\n                RETURNING chat_id AS \"chat_id: ChatId\"",
+  "describe": {
+    "columns": [
+      {
+        "name": "chat_id: ChatId",
+        "ordinal": 0,
+        "type_info": "Blob",
+        "origin": {
+          "Table": {
+            "table": "connection_accept_queue",
+            "name": "chat_id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "08e31bcf92e6d2f2ccbc2835bd19b9977171a70f5747b3fc9d4a370569846903"
+}

--- a/coreclient/.sqlx/query-54cd7ba17de43c0afe7e270fd7dd55122f6eee0691b655ea64d6a6b8531cd2f6.json
+++ b/coreclient/.sqlx/query-54cd7ba17de43c0afe7e270fd7dd55122f6eee0691b655ea64d6a6b8531cd2f6.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE connection_accept_queue SET failed_reason = ?2 WHERE chat_id = ?1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "54cd7ba17de43c0afe7e270fd7dd55122f6eee0691b655ea64d6a6b8531cd2f6"
+}

--- a/coreclient/.sqlx/query-82e54f21767af8feaf9ab1e488b56a37e63cc7ae7decd348cf8cf45dfdfbb758.json
+++ b/coreclient/.sqlx/query-82e54f21767af8feaf9ab1e488b56a37e63cc7ae7decd348cf8cf45dfdfbb758.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO connection_accept_queue (chat_id) VALUES (?1)\n                ON CONFLICT (chat_id) DO UPDATE SET failed_reason = NULL",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "82e54f21767af8feaf9ab1e488b56a37e63cc7ae7decd348cf8cf45dfdfbb758"
+}

--- a/coreclient/.sqlx/query-ac6e068c613fa4299d379ab4965bca0e53f8162293b993725db5b395721a94a2.json
+++ b/coreclient/.sqlx/query-ac6e068c613fa4299d379ab4965bca0e53f8162293b993725db5b395721a94a2.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT failed_reason FROM connection_accept_queue WHERE chat_id = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "failed_reason",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "connection_accept_queue",
+            "name": "failed_reason"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "ac6e068c613fa4299d379ab4965bca0e53f8162293b993725db5b395721a94a2"
+}

--- a/coreclient/.sqlx/query-b8d50b1cf57b729859c9c9a2bacbcf620e3ff02cbb61532cec9864e920241ddb.json
+++ b/coreclient/.sqlx/query-b8d50b1cf57b729859c9c9a2bacbcf620e3ff02cbb61532cec9864e920241ddb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM connection_accept_queue WHERE chat_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "b8d50b1cf57b729859c9c9a2bacbcf620e3ff02cbb61532cec9864e920241ddb"
+}

--- a/coreclient/migrations/20260901120000_connection_accept_queue.sql
+++ b/coreclient/migrations/20260901120000_connection_accept_queue.sql
@@ -1,0 +1,14 @@
+-- SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+-- Connection accept scheduled for being performed by the outbound service.
+-- The row persists until the join lands or the chat is deleted. A permanent
+-- failure is recorded in failed_reason and pauses the retries.
+CREATE TABLE IF NOT EXISTS connection_accept_queue (
+    chat_id BLOB NOT NULL,
+    locked_by BLOB,
+    failed_reason TEXT,
+    PRIMARY KEY (chat_id),
+    FOREIGN KEY (chat_id) REFERENCES chat (chat_id) ON DELETE CASCADE
+);

--- a/coreclient/src/chats/pending.rs
+++ b/coreclient/src/chats/pending.rs
@@ -12,6 +12,7 @@ use aircommon::{
     },
     time::TimeStamp,
 };
+use airprotos::client::group_bootstrap::{AcceptContext, ConnectionContext, GroupBootstrapCarrier};
 use anyhow::{Context, bail, ensure};
 use mimi_room_policy::RoleIndex;
 use openmls::treesync::errors::LeafNodeValidationError;
@@ -27,7 +28,7 @@ use crate::{
     },
     contacts::UsernameContact,
     db::access::WriteConnection,
-    groups::Group,
+    groups::{Group, group_bootstrap::secret_bytes, self_group::SelfGroup},
     key_stores::indexed_keys::StorableIndexedKey,
     usernames::connection_packages::StorableConnectionPackage,
 };
@@ -127,6 +128,9 @@ impl CoreUser {
                     }
                 }
 
+                let self_group = SelfGroup::load(&mut *txn).await?;
+                let vc_group_id = self_group.as_ref().map(|group| group.group_id().clone());
+
                 // Join group
                 let res = Group::join_group_externally(
                     txn,
@@ -139,9 +143,7 @@ impl CoreUser {
                         .clone(),
                     aad,
                     connection_offer_hash,
-                    // TODO(gabriel): joining a connection group is currently never a virtual-client
-                    // onboarding: we are not a member of the group yet.
-                    None,
+                    vc_group_id,
                 )
                 .await?;
                 let (mut group, commit, group_info, mut member_profile_info) = match res {
@@ -203,13 +205,35 @@ impl CoreUser {
                     }
                 }
 
-                Ok(Ok((commit, group_info)))
+                let group_bootstrap = match &self_group {
+                    Some(self_group) => {
+                        let friendship_package = &connection_info.friendship_package;
+                        let connection = ConnectionContext::Accept(AcceptContext {
+                            user_id: Some(sender_user_id.clone().into()),
+                            friendship_token: Some(friendship_package.friendship_token.clone()),
+                            wai_ear_key: Some(secret_bytes(&friendship_package.wai_ear_key)),
+                            user_profile_base_secret: Some(secret_bytes(
+                                &friendship_package.user_profile_base_secret,
+                            )),
+                            connection_offer_hash,
+                        });
+                        Some(self_group.seal_group_bootstrap_param(
+                            txn,
+                            &group,
+                            GroupBootstrapCarrier::JoinEcho,
+                            Some(connection),
+                        )?)
+                    }
+                    None => None,
+                };
+
+                Ok(Ok((commit, group_info, group_bootstrap)))
             },
         ))
         .await?;
 
         // Propagate the error to the caller if it is a leaf node validation error.
-        let (commit, group_info) = match result {
+        let (commit, group_info, group_bootstrap) = match result {
             Ok(value) => value,
             Err(error) => return Ok(Err(error.into())),
         };
@@ -223,6 +247,7 @@ impl CoreUser {
                 group_info,
                 qs_client_reference,
                 &connection_info.connection_group_ear_key,
+                group_bootstrap,
             )
             .await?;
 
@@ -347,7 +372,7 @@ mod persistence {
             Ok(())
         }
 
-        pub(super) async fn delete(
+        pub(crate) async fn delete(
             mut connection: impl WriteConnection,
             chat_id: ChatId,
         ) -> sqlx::Result<()> {

--- a/coreclient/src/chats/pending.rs
+++ b/coreclient/src/chats/pending.rs
@@ -4,20 +4,17 @@
 
 use aircommon::{
     crypto::{aead::AeadEncryptable, indexed_aead::keys::UserProfileKey},
-    identifiers::{QualifiedGroupId, Username},
+    identifiers::{QualifiedGroupId, UserId, Username},
     messages::{
         client_as::ConnectionOfferHash,
         client_ds::{AadMessage, AadPayload, JoinConnectionGroupParamsAad},
-        connection_package::{ConnectionPackage, ConnectionPackageHash},
+        connection_package::ConnectionPackageHash,
     },
     time::TimeStamp,
 };
-use airprotos::client::group_bootstrap::{AcceptContext, ConnectionContext, GroupBootstrapCarrier};
-use anyhow::{Context, bail, ensure};
-use mimi_room_policy::RoleIndex;
-use openmls::treesync::errors::LeafNodeValidationError;
+use anyhow::{Context, bail};
 use tls_codec::DeserializeBytes;
-use tracing::{instrument, warn};
+use tracing::instrument;
 
 use crate::{
     Chat, ChatId, ChatType, PartialContact, SystemMessage, TargetedMessageContact,
@@ -27,10 +24,10 @@ use crate::{
         connection_offer::{FriendshipPackage, payload::ConnectionInfo},
     },
     contacts::UsernameContact,
-    db::access::WriteConnection,
-    groups::{Group, group_bootstrap::secret_bytes, self_group::SelfGroup},
-    key_stores::indexed_keys::StorableIndexedKey,
-    usernames::connection_packages::StorableConnectionPackage,
+    db::access::{ReadConnection, WriteConnection, WriteDbTransaction},
+    groups::Group,
+    key_stores::MemoryUserKeyStore,
+    outbound_service::connection_accepts::ConnectionAccept,
 };
 
 pub(crate) struct PendingConnectionInfo {
@@ -43,250 +40,131 @@ pub(crate) struct PendingConnectionInfo {
 }
 
 impl CoreUser {
+    /// Queues accepting a contact request.
+    ///
+    /// The accept itself runs in the outbound service, which retries until the
+    /// join lands on the DS (see `outbound_service::connection_accepts`). The
+    /// queued job persists across restarts. Accepting a request whose earlier
+    /// accept failed permanently re-arms the job.
     #[instrument(skip(self), err)]
-    pub async fn accept_contact_request(
-        &self,
-        chat_id: ChatId,
-    ) -> anyhow::Result<Result<(), AcceptContactRequestError>> {
-        // Load needed data
-        let (chat, sender_user_id, pending_connection_info, partial_contact, own_user_profile_key) =
-            self.db()
-                .with_read_transaction(async |txn| {
-                    let chat: Chat = Chat::load(&mut *txn, &chat_id)
-                        .await?
-                        .with_context(|| format!("Can't find chat with id {chat_id}"))?;
-                    let ChatType::PendingConnection(sender_user_id) = chat.chat_type() else {
-                        bail!("Chat is not a pending connection");
-                    };
-                    let pending_connection_info = PendingConnectionInfo::load(&mut *txn, chat_id)
-                        .await?
-                        .with_context(|| {
-                            format!("No pending connection info found for chat: {chat_id}")
-                        })?;
-                    let own_user_profile_key = UserProfileKey::load_own(&mut *txn).await?;
-                    let sender_user_id = sender_user_id.clone();
-
-                    // Look up partial contact:
-                    // - UsernameContact: by chat_id since multiple senders can target the same username
-                    // - TargetedMessageContact: by user_id (its natural key)
-                    let partial_contact = if pending_connection_info.handle.is_some() {
-                        UsernameContact::load_by_chat_id(&mut *txn, chat_id)
-                            .await?
-                            .map(PartialContact::Username)
-                    } else {
-                        TargetedMessageContact::load(txn, &sender_user_id)
-                            .await?
-                            .map(PartialContact::TargetedMessage)
-                    };
-
-                    let partial_contact = partial_contact
-                        .with_context(|| format!("No partial contact found for chat: {chat_id}"))?;
-
-                    Ok((
-                        chat,
-                        sender_user_id,
-                        pending_connection_info,
-                        partial_contact,
-                        own_user_profile_key,
-                    ))
-                })
-                .await?;
-
-        let PendingConnectionInfo {
-            chat_id: _,
-            created_at: _,
-            connection_info,
-            handle,
-            connection_offer_hash,
-            connection_package_hash,
-        } = pending_connection_info;
-
-        // Prepare group
-        let (aad, qgid) = self.prepare_group(&connection_info, &own_user_profile_key)?;
-
-        // Fetch external commit info
-        let eci = self
-            .api_clients()
-            .get(qgid.owning_domain())?
-            .ds_connection_group_info(
-                connection_info.connection_group_id.clone(),
-                &connection_info.connection_group_ear_key,
-            )
-            .await?;
-
-        // Create a new group by joining it (if group already exists, it will be replaced)
-        let result = Box::pin(self.db().with_write_transaction(
-            async |txn| -> anyhow::Result<Result<_, _>> {
-                if Group::load_with_chat_id(&mut *txn, chat_id)
-                    .await?
-                    .is_some()
-                {
-                    warn!(%chat_id, "Group for pending chat already exists");
-                    Group::delete_from_db(txn, chat.group_id()).await?;
-                    if let Some(hash) = connection_offer_hash {
-                        Group::delete_connection_offer_psk(&mut *txn, hash)?;
-                    }
-                }
-
-                let self_group = SelfGroup::load(&mut *txn).await?;
-                let vc_group_id = self_group.as_ref().map(|group| group.group_id().clone());
-
-                // Join group
-                let res = Group::join_group_externally(
-                    txn,
-                    self.api_clients(),
-                    eci,
-                    self.signing_key(),
-                    connection_info.connection_group_ear_key.clone(),
-                    connection_info
-                        .connection_group_identity_link_wrapper_key
-                        .clone(),
-                    aad,
-                    connection_offer_hash,
-                    vc_group_id,
-                )
-                .await?;
-                let (mut group, commit, group_info, mut member_profile_info) = match res {
-                    Ok(value) => value,
-                    Err(error) => return Ok(Err(error)),
-                };
-
-                // Verify that the group has only one other member and that it's
-                // the sender of the CEP.
-                let members: Vec<_> = group.members().collect();
-
-                ensure!(
-                    members.len() == 2,
-                    "Connection group has more than two members: {:?}",
-                    members
-                );
-
-                ensure!(
-                    members.contains(self.user_id()) && members.contains(&sender_user_id),
-                    "Connection group has unexpected members: {:?}",
-                    members
-                );
-
-                // There should be only one user profile
-                let contact_profile_info = member_profile_info
-                    .members
-                    .pop()
-                    .context("No user profile returned when joining connection group")?;
-
-                debug_assert!(
-                    member_profile_info.members.is_empty(),
-                    "More than one user profile returned when joining connection group"
-                );
-
-                // Fetch and store user profile
-                Self::schedule_fetch_user_profile(&mut *txn, contact_profile_info).await?;
-
-                group.room_state_change_role(
-                    &sender_user_id,
-                    self.user_id(),
-                    RoleIndex::Regular,
-                )?;
-
-                let now = TimeStamp::now();
-                group.store_update(&mut *txn, Some(now), Some(now)).await?;
-
-                if let Some(hash) = connection_package_hash {
-                    // Delete the connection package if it's not last resort
-                    let is_last_resort =
-                        <ConnectionPackage as StorableConnectionPackage>::is_last_resort(
-                            &mut *txn, &hash,
-                        )
-                        .await?
-                        .unwrap_or(false);
-                    if !is_last_resort {
-                        ConnectionPackage::delete(&mut *txn, &hash)
-                            .await
-                            .context("Failed to delete connection package")?;
-                    }
-                }
-
-                let group_bootstrap = match &self_group {
-                    Some(self_group) => {
-                        let friendship_package = &connection_info.friendship_package;
-                        let connection = ConnectionContext::Accept(AcceptContext {
-                            user_id: Some(sender_user_id.clone().into()),
-                            friendship_token: Some(friendship_package.friendship_token.clone()),
-                            wai_ear_key: Some(secret_bytes(&friendship_package.wai_ear_key)),
-                            user_profile_base_secret: Some(secret_bytes(
-                                &friendship_package.user_profile_base_secret,
-                            )),
-                            connection_offer_hash,
-                        });
-                        Some(self_group.seal_group_bootstrap_param(
-                            txn,
-                            &group,
-                            GroupBootstrapCarrier::JoinEcho,
-                            Some(connection),
-                        )?)
-                    }
-                    None => None,
-                };
-
-                Ok(Ok((commit, group_info, group_bootstrap)))
-            },
-        ))
-        .await?;
-
-        // Propagate the error to the caller if it is a leaf node validation error.
-        let (commit, group_info, group_bootstrap) = match result {
-            Ok(value) => value,
-            Err(error) => return Ok(Err(error.into())),
-        };
-
-        // Send confirmation to DS
-        let qs_client_reference = self.create_own_client_reference();
-        self.api_clients()
-            .get(qgid.owning_domain())?
-            .ds_join_connection_group(
-                commit,
-                group_info,
-                qs_client_reference,
-                &connection_info.connection_group_ear_key,
-                group_bootstrap,
-            )
-            .await?;
-
-        // Mark the chat as an accepted connection and mark partial contact as complete, also
-        // remove the pending connection info.
+    pub async fn accept_contact_request(&self, chat_id: ChatId) -> anyhow::Result<()> {
         self.db()
             .with_write_transaction(async |txn| -> anyhow::Result<_> {
-                chat.set_chat_type(&mut *txn, &ChatType::Connection(sender_user_id.clone()))
-                    .await?;
+                let chat: Chat = Chat::load(&mut *txn, &chat_id)
+                    .await?
+                    .with_context(|| format!("Can't find chat with id {chat_id}"))?;
+                let ChatType::PendingConnection(sender_user_id) = chat.chat_type() else {
+                    bail!("Chat is not a pending connection");
+                };
+                let pending_connection_info = PendingConnectionInfo::load(&mut *txn, chat_id)
+                    .await?
+                    .with_context(|| {
+                        format!("No pending connection info found for chat: {chat_id}")
+                    })?;
 
-                let accepted_message = TimestampedMessage::system_message(
-                    SystemMessage::AcceptedConnectionRequest {
-                        contact: sender_user_id.clone(),
-                        user_handle: handle,
-                    },
-                    TimeStamp::now(),
-                );
-                Self::store_new_messages(&mut *txn, chat_id, vec![accepted_message]).await?;
+                // Fail early when the partial contact is gone. The accept job
+                // needs it to finalize.
+                let sender_user_id = sender_user_id.clone();
+                Self::load_partial_contact(
+                    &mut *txn,
+                    chat_id,
+                    &pending_connection_info,
+                    &sender_user_id,
+                )
+                .await?;
 
-                partial_contact
-                    .mark_as_complete(
-                        &mut *txn,
-                        sender_user_id,
-                        connection_info.friendship_package,
-                    )
-                    .await?;
-                PendingConnectionInfo::delete(&mut *txn, chat_id).await?;
-                if let Some(hash) = connection_offer_hash {
-                    Group::delete_connection_offer_psk(txn, hash)?;
-                }
+                ConnectionAccept::enqueue(txn, chat_id).await?;
                 Ok(())
             })
             .await?;
 
-        Ok(Ok(()))
+        self.outbound_service().notify_connection_accepts();
+
+        Ok(())
     }
 
-    fn prepare_group(
-        &self,
+    /// Completes an accepted connection after the DS accepted our external
+    /// join.
+    pub(crate) async fn finalize_accepted_connection(
+        txn: &mut WriteDbTransaction<'_>,
+        chat_id: ChatId,
+        timestamp: TimeStamp,
+    ) -> anyhow::Result<()> {
+        // Remove the queue row even when the pending info is already gone.
+        // The accept may have been finished by another path, e.g. the join
+        // echo, and a leftover row would keep the accept marked as pending.
+        ConnectionAccept::remove(&mut *txn, chat_id).await?;
+
+        let Some(pending_connection_info) = PendingConnectionInfo::load(&mut *txn, chat_id).await?
+        else {
+            return Ok(());
+        };
+        let chat = Chat::load(&mut *txn, &chat_id)
+            .await?
+            .with_context(|| format!("Can't find chat with id {chat_id}"))?;
+        let ChatType::PendingConnection(sender_user_id) = chat.chat_type() else {
+            bail!("Chat is not a pending connection");
+        };
+        let sender_user_id = sender_user_id.clone();
+
+        let partial_contact = Self::load_partial_contact(
+            &mut *txn,
+            chat_id,
+            &pending_connection_info,
+            &sender_user_id,
+        )
+        .await?;
+
+        chat.set_chat_type(&mut *txn, &ChatType::Connection(sender_user_id.clone()))
+            .await?;
+
+        let accepted_message = TimestampedMessage::system_message(
+            SystemMessage::AcceptedConnectionRequest {
+                contact: sender_user_id.clone(),
+                user_handle: pending_connection_info.handle,
+            },
+            timestamp,
+        );
+        Self::store_new_messages(&mut *txn, chat_id, vec![accepted_message]).await?;
+
+        partial_contact
+            .mark_as_complete(
+                &mut *txn,
+                sender_user_id,
+                pending_connection_info.connection_info.friendship_package,
+            )
+            .await?;
+        PendingConnectionInfo::delete(&mut *txn, chat_id).await?;
+        if let Some(hash) = pending_connection_info.connection_offer_hash {
+            Group::delete_connection_offer_psk(txn, hash)?;
+        }
+        Ok(())
+    }
+
+    /// Load the partial contact behind a pending connection:
+    /// - UsernameContact: by chat_id since multiple senders can target the same username
+    /// - TargetedMessageContact: by user_id
+    pub(crate) async fn load_partial_contact(
+        mut connection: impl ReadConnection,
+        chat_id: ChatId,
+        pending_connection_info: &PendingConnectionInfo,
+        sender_user_id: &UserId,
+    ) -> anyhow::Result<PartialContact> {
+        let partial_contact = if pending_connection_info.handle.is_some() {
+            UsernameContact::load_by_chat_id(&mut connection, chat_id)
+                .await?
+                .map(PartialContact::Username)
+        } else {
+            TargetedMessageContact::load(&mut connection, sender_user_id)
+                .await?
+                .map(PartialContact::TargetedMessage)
+        };
+        partial_contact.with_context(|| format!("No partial contact found for chat: {chat_id}"))
+    }
+
+    pub(crate) fn prepare_group(
+        key_store: &MemoryUserKeyStore,
+        user_id: &UserId,
         connection_info: &ConnectionInfo,
         own_user_profile_key: &UserProfileKey,
     ) -> anyhow::Result<(AadMessage, QualifiedGroupId)> {
@@ -296,12 +174,12 @@ impl CoreUser {
 
         let encrypted_user_profile_key = own_user_profile_key.encrypt(
             &connection_info.connection_group_identity_link_wrapper_key,
-            self.user_id(),
+            user_id,
         )?;
 
         let encrypted_friendship_package = FriendshipPackage {
-            friendship_token: self.key_store().friendship_token.clone(),
-            wai_ear_key: self.key_store().wai_ear_key.clone(),
+            friendship_token: key_store.friendship_token.clone(),
+            wai_ear_key: key_store.wai_ear_key.clone(),
             user_profile_base_secret: own_user_profile_key.base_secret().clone(),
         }
         .encrypt(&connection_info.friendship_package_ear_key)?;
@@ -387,17 +265,114 @@ mod persistence {
     }
 }
 
-/// Errors that can occur when accepting a contact request.
-#[derive(Debug, thiserror::Error)]
-pub enum AcceptContactRequestError {
-    #[error("Incompatible client: {reason}")]
-    IncompatibleClient { reason: String },
-}
+#[cfg(test)]
+mod tests {
+    use aircommon::{
+        crypto::{
+            aead::keys::{
+                FriendshipPackageEarKey, GroupStateEarKey, IdentityLinkWrapperKey,
+                WelcomeAttributionInfoEarKey,
+            },
+            indexed_aead::keys::UserProfileBaseSecret,
+        },
+        messages::FriendshipToken,
+    };
+    use openmls::group::GroupId;
+    use sqlx::SqlitePool;
 
-impl From<LeafNodeValidationError> for AcceptContactRequestError {
-    fn from(error: LeafNodeValidationError) -> Self {
-        Self::IncompatibleClient {
-            reason: error.to_string(),
+    use crate::{ChatMessage, Contact, chats::persistence::tests::test_chat, db::access::DbAccess};
+
+    use super::*;
+
+    fn test_connection_info() -> ConnectionInfo {
+        ConnectionInfo {
+            connection_group_id: GroupId::from_slice(&[0; 32]),
+            connection_group_ear_key: GroupStateEarKey::random().unwrap(),
+            connection_group_identity_link_wrapper_key: IdentityLinkWrapperKey::random().unwrap(),
+            friendship_package_ear_key: FriendshipPackageEarKey::random().unwrap(),
+            friendship_package: FriendshipPackage {
+                friendship_token: FriendshipToken::random().unwrap(),
+                wai_ear_key: WelcomeAttributionInfoEarKey::random().unwrap(),
+                user_profile_base_secret: UserProfileBaseSecret::random().unwrap(),
+            },
         }
+    }
+
+    #[sqlx::test]
+    async fn finalize_accepted_connection_is_idempotent(pool: SqlitePool) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let sender_user_id = UserId::random("localhost".parse().unwrap());
+        let mut chat = test_chat();
+        chat.chat_type = ChatType::PendingConnection(sender_user_id.clone());
+        chat.store(&mut txn).await?;
+
+        TargetedMessageContact::new(
+            sender_user_id.clone(),
+            chat.id(),
+            FriendshipPackageEarKey::random()?,
+        )
+        .upsert(&mut txn)
+        .await?;
+
+        PendingConnectionInfo {
+            chat_id: chat.id(),
+            created_at: TimeStamp::now(),
+            connection_info: test_connection_info(),
+            handle: None,
+            connection_offer_hash: None,
+            connection_package_hash: None,
+        }
+        .store(&mut txn)
+        .await?;
+
+        ConnectionAccept::enqueue(&mut txn, chat.id()).await?;
+
+        CoreUser::finalize_accepted_connection(&mut txn, chat.id(), TimeStamp::now()).await?;
+
+        let finalized = Chat::load(&mut txn, &chat.id()).await?.unwrap();
+        assert_eq!(
+            finalized.chat_type(),
+            &ChatType::Connection(sender_user_id.clone())
+        );
+        assert!(
+            PendingConnectionInfo::load(&mut txn, chat.id())
+                .await?
+                .is_none()
+        );
+        assert!(
+            ConnectionAccept::status(&mut txn, chat.id())
+                .await?
+                .is_none()
+        );
+        assert!(
+            TargetedMessageContact::load(&mut txn, &sender_user_id)
+                .await?
+                .is_none()
+        );
+        let contact = Contact::load(&mut txn, &sender_user_id).await?.unwrap();
+        assert_eq!(contact.chat_id, chat.id());
+        let messages = ChatMessage::load_multiple(&mut txn, chat.id(), 10).await?;
+        assert_eq!(messages.len(), 1);
+
+        // The response and echo paths race. Whoever comes second is a no-op.
+        CoreUser::finalize_accepted_connection(&mut txn, chat.id(), TimeStamp::now()).await?;
+
+        let messages = ChatMessage::load_multiple(&mut txn, chat.id(), 10).await?;
+        assert_eq!(messages.len(), 1);
+
+        // A leftover queue row is removed even when the pending info is
+        // already gone.
+        ConnectionAccept::enqueue(&mut txn, chat.id()).await?;
+        CoreUser::finalize_accepted_connection(&mut txn, chat.id(), TimeStamp::now()).await?;
+        assert!(
+            ConnectionAccept::status(&mut txn, chat.id())
+                .await?
+                .is_none()
+        );
+
+        Ok(())
     }
 }

--- a/coreclient/src/clients/add_contact.rs
+++ b/coreclient/src/clients/add_contact.rs
@@ -13,16 +13,19 @@ use aircommon::{
     },
     identifiers::{QsReference, UserId, Username, UsernameHash},
     messages::{
-        client_as::{ConnectionOfferMessage, EncryptedConnectionOffer},
+        client_as::{ConnectionOfferHash, ConnectionOfferMessage, EncryptedConnectionOffer},
         client_ds_out::{CreateGroupParamsOut, TargetedMessageParamsOut},
         connection_package::ConnectionPackage,
     },
     time::TimeStamp,
 };
 use airprotos::client::group::GroupData;
+use airprotos::client::group_bootstrap::{
+    ConnectionContext, GroupBootstrapCarrier, HandleInitiatorContext, TargetedInitiatorContext,
+};
 use anyhow::{Context, bail};
 use openmls::group::GroupId;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{
     Chat, ChatId, ChatMessage, SystemMessage,
@@ -31,9 +34,12 @@ use crate::{
         connection_offer::{FriendshipPackage, payload::ConnectionInfo},
         targeted_message::TargetedMessageContent,
     },
-    contacts::{TargetedMessageContact, UsernameContact},
+    contacts::{PartialContact, PartialContactType, TargetedMessageContact, UsernameContact},
     db::access::WriteDbTransaction,
-    groups::{Group, PartialCreateGroupParams, openmls_provider::AirOpenMlsProvider},
+    groups::{
+        Group, PartialCreateGroupParams, group_bootstrap::secret_bytes,
+        openmls_provider::AirOpenMlsProvider, self_group::SelfGroup,
+    },
     key_stores::{MemoryUserKeyStore, indexed_keys::StorableIndexedKey},
 };
 
@@ -108,38 +114,38 @@ impl CoreUser {
 
         let client_reference = self.create_own_client_reference();
 
-        Box::pin(self.db().with_write_transaction(async |txn| {
-            // Phase 4: Create a connection group
-            let local_group = connection_package
-                .create_local_connection_group(
-                    &mut *txn,
-                    &self.inner.key_store.signing_key,
-                    username.clone(),
-                )
-                .await?;
+        // Phase 4: Create the connection group locally and commit it.
+        let local_partial_contact = Box::pin(self.db().with_write_transaction(async |txn| {
+            let local_group = Box::pin(connection_package.create_local_connection_group(
+                &mut *txn,
+                &self.inner.key_store.signing_key,
+                username.clone(),
+            ))
+            .await?;
 
-            let local_partial_contact = local_group
-                .create_username_contact(
-                    txn,
-                    &self.inner.key_store,
-                    client_reference,
-                    self.user_id(),
-                    username,
-                )
-                .await?;
-
-            // Phase 5: Create the connection group on the DS and send off the connection offer
-            let chat_id = local_partial_contact
-                .create_connection_group_via_username(
-                    &client,
-                    self.signing_key(),
-                    connection_offer_responder,
-                )
-                .await?;
-
-            Ok(Ok(chat_id))
+            Box::pin(local_group.create_username_contact(
+                txn,
+                &self.inner.key_store,
+                client_reference,
+                self.user_id(),
+                username,
+            ))
+            .await
         }))
-        .await
+        .await?;
+
+        // Phase 5: Create the connection group on the DS and send off the connection offer
+        let cleanup = local_partial_contact.cleanup();
+        let result = Box::pin(local_partial_contact.create_connection_group_via_username(
+            &client,
+            self.signing_key(),
+            connection_offer_responder,
+        ))
+        .await;
+        match result {
+            Ok(chat_id) => Ok(Ok(chat_id)),
+            Err(error) => Err(self.handle_connection_group_error(cleanup, error).await),
+        }
     }
 
     /// Create a connection with a new user via an existing group chat.
@@ -182,33 +188,105 @@ impl CoreUser {
 
         let client_reference = self.create_own_client_reference();
 
-        Box::pin(self.db().with_write_transaction(async |txn| {
-            // Phase 4: Create a connection group and prepare the targeted message
+        // Phase 4: Create the connection group and the targeted message
+        // locally.
+        let local_partial_contact = Box::pin(self.db().with_write_transaction(async |txn| {
             let local_group = connection_package
                 .create_local_connection_group(&mut *txn, &self.inner.key_store.signing_key)
                 .await?;
 
-            let local_partial_contact = local_group
-                .create_targeted_message_contact(
-                    &mut *txn,
-                    &self.inner.key_store,
-                    client_reference,
-                    self.user_id(),
-                    chat_id,
-                )
-                .await?;
-
-            // Phase 5: Create the connection group on the DS and send off the connection offer
-            let chat_id = Box::pin(
-                local_partial_contact
-                    .create_connection_group_via_targeted_message(&client, self.signing_key()),
-            )
-            .await?;
-
-            Ok(chat_id)
+            Box::pin(local_group.create_targeted_message_contact(
+                txn,
+                &self.inner.key_store,
+                client_reference,
+                self.user_id(),
+                chat_id,
+            ))
+            .await
         }))
-        .await
+        .await?;
+
+        // Phase 5: Create the connection group on the DS and send off the connection offer
+        let cleanup = local_partial_contact.cleanup();
+        let result = Box::pin(
+            local_partial_contact
+                .create_connection_group_via_targeted_message(&client, self.signing_key()),
+        )
+        .await;
+        match result {
+            Ok(chat_id) => Ok(chat_id),
+            Err(error) => Err(self.handle_connection_group_error(cleanup, error).await),
+        }
     }
+
+    /// Cleans up after a failed connection group setup and returns the error
+    /// to propagate.
+    async fn handle_connection_group_error(
+        &self,
+        group: DiscardedConnectionGroup,
+        error: ConnectionGroupError,
+    ) -> anyhow::Error {
+        match error {
+            ConnectionGroupError::NotCreated(error) => {
+                self.discard_local_connection_group(group).await;
+                error
+            }
+            ConnectionGroupError::CreatedThenFailed(error) => {
+                error!(
+                    %error,
+                    chat_id = %group.chat_id,
+                    "Connection group exists on the DS and on the sibling devices, keeping it locally"
+                );
+                error
+            }
+        }
+    }
+
+    /// Removes the local state of a connection group the DS did not accept.
+    async fn discard_local_connection_group(&self, group: DiscardedConnectionGroup) {
+        let DiscardedConnectionGroup {
+            group_id,
+            chat_id,
+            contact,
+            connection_offer_hash,
+        } = group;
+        let result = self
+            .db()
+            .with_write_transaction(async |txn| -> anyhow::Result<()> {
+                Group::delete_from_db(&mut *txn, &group_id).await?;
+                Chat::delete(&mut *txn, chat_id).await?;
+                if let Some(contact) = PartialContact::load(&mut *txn, &contact).await? {
+                    contact.delete(&mut *txn).await?;
+                }
+                if let Some(hash) = connection_offer_hash {
+                    Group::delete_connection_offer_psk(txn, hash)?;
+                }
+                Ok(())
+            })
+            .await;
+        if let Err(error) = result {
+            error!(%error, "Failed to clean up the rejected connection group");
+        }
+    }
+}
+
+/// The local rows of a connection group the DS did not accept.
+struct DiscardedConnectionGroup {
+    group_id: GroupId,
+    chat_id: ChatId,
+    contact: PartialContactType,
+    connection_offer_hash: Option<ConnectionOfferHash>,
+}
+
+/// A failure while establishing a connection group on the DS.
+enum ConnectionGroupError {
+    /// The DS did not accept the create-group request, so nothing outside this
+    /// device knows about the group and the local rows can go.
+    NotCreated(anyhow::Error),
+    /// The DS accepted the group and a later send failed. The DS echoed the
+    /// creation to the sibling queues when it accepted it, so the siblings
+    /// install the group.
+    CreatedThenFailed(anyhow::Error),
 }
 
 struct VerifiedConnectionPackagesWithGroupId<Payload = ConnectionPackage> {
@@ -221,7 +299,7 @@ impl<Payload> VerifiedConnectionPackagesWithGroupId<Payload> {
         &self,
         txn: &mut WriteDbTransaction<'_>,
         signing_key: &UserSigningKey,
-    ) -> anyhow::Result<(Group, PartialCreateGroupParams)> {
+    ) -> anyhow::Result<(Group, PartialCreateGroupParams, Option<SelfGroup>)> {
         let identity_link_wrapper_key = IdentityLinkWrapperKey::random()?;
         let group_data_bytes = GroupData {
             encrypted_title: None,
@@ -231,17 +309,20 @@ impl<Payload> VerifiedConnectionPackagesWithGroupId<Payload> {
         }
         .encode()?;
 
+        let self_group = SelfGroup::load(&mut *txn).await?;
+
         let (group, partial_params) = Group::create_group(
             &mut *txn,
             signing_key,
             identity_link_wrapper_key,
             self.group_id.clone(),
             group_data_bytes,
+            self_group.as_ref().map(|group| group.group_id()),
         )?;
 
         group.store(txn).await?;
 
-        Ok((group, partial_params))
+        Ok((group, partial_params, self_group))
     }
 }
 
@@ -254,7 +335,7 @@ impl VerifiedConnectionPackagesWithGroupId<ConnectionPackage> {
     ) -> anyhow::Result<LocalGroup<ConnectionPackage>> {
         info!("Creating local connection group");
 
-        let (group, partial_params) = self
+        let (group, partial_params, self_group) = self
             .create_connection_group_internal(&mut *txn, signing_key)
             .await?;
 
@@ -276,6 +357,7 @@ impl VerifiedConnectionPackagesWithGroupId<ConnectionPackage> {
         Ok(LocalGroup {
             group,
             partial_params,
+            self_group,
             chat_id: chat.id(),
             payload: method_payload,
         })
@@ -289,7 +371,7 @@ impl VerifiedConnectionPackagesWithGroupId<UserId> {
         signing_key: &UserSigningKey,
     ) -> anyhow::Result<LocalGroup<UserId>> {
         info!("Creating local connection group");
-        let (group, partial_params) = self
+        let (group, partial_params, self_group) = self
             .create_connection_group_internal(&mut *txn, signing_key)
             .await?;
 
@@ -311,6 +393,7 @@ impl VerifiedConnectionPackagesWithGroupId<UserId> {
         Ok(LocalGroup {
             group,
             partial_params,
+            self_group,
             chat_id: chat.id(),
             payload: user_id,
         })
@@ -320,6 +403,7 @@ impl VerifiedConnectionPackagesWithGroupId<UserId> {
 struct LocalGroup<Payload = ConnectionPackage> {
     group: Group,
     partial_params: PartialCreateGroupParams,
+    self_group: Option<SelfGroup>,
     chat_id: ChatId,
     payload: Payload,
 }
@@ -336,6 +420,7 @@ impl LocalGroup<ConnectionPackage> {
         let Self {
             group,
             partial_params,
+            self_group,
             chat_id,
             payload: verified_connection_package,
         } = self;
@@ -375,9 +460,9 @@ impl LocalGroup<ConnectionPackage> {
 
         // Create and persist a new partial contact
         UsernameContact::new(
-            username,
+            username.clone(),
             chat_id,
-            friendship_package_ear_key,
+            friendship_package_ear_key.clone(),
             connection_offer_hash,
         )
         .upsert(&mut *txn)
@@ -385,12 +470,29 @@ impl LocalGroup<ConnectionPackage> {
 
         let encrypted_user_profile_key =
             own_user_profile_key.encrypt(group.identity_link_wrapper_key(), own_user_id)?;
-        let params = partial_params.into_params(own_client_reference, encrypted_user_profile_key);
+        let mut params =
+            partial_params.into_params(own_client_reference, encrypted_user_profile_key);
+
+        if let Some(self_group) = &self_group {
+            let connection = ConnectionContext::HandleInitiator(HandleInitiatorContext {
+                username: Some(username.plaintext().to_owned()),
+                friendship_package_ear_key: Some(secret_bytes(&friendship_package_ear_key)),
+                connection_offer_hash: Some(connection_offer_hash),
+            });
+            params.group_bootstrap = Some(self_group.seal_group_bootstrap_param(
+                txn,
+                &group,
+                GroupBootstrapCarrier::CreationEcho,
+                Some(connection),
+            )?);
+        }
 
         Ok(LocalUsernameContact::<UsernamePayload> {
             group,
             params,
             chat_id,
+            contact: PartialContactType::Handle(username),
+            connection_offer_hash: Some(connection_offer_hash),
             payload: UsernamePayload {
                 connection_offer,
                 verified_connection_package,
@@ -411,6 +513,7 @@ impl LocalGroup<UserId> {
         let Self {
             group,
             partial_params,
+            self_group,
             chat_id,
             payload: user_id,
         } = self;
@@ -426,13 +529,30 @@ impl LocalGroup<UserId> {
         let friendship_package_ear_key = FriendshipPackageEarKey::random()?;
 
         // Create and persist a new partial contact
-        let contact =
-            TargetedMessageContact::new(user_id, chat_id, friendship_package_ear_key.clone());
+        let contact = TargetedMessageContact::new(
+            user_id.clone(),
+            chat_id,
+            friendship_package_ear_key.clone(),
+        );
         contact.upsert(&mut *txn).await?;
 
         let encrypted_user_profile_key =
             own_user_profile_key.encrypt(group.identity_link_wrapper_key(), own_user_id)?;
-        let params = partial_params.into_params(own_client_reference, encrypted_user_profile_key);
+        let mut params =
+            partial_params.into_params(own_client_reference, encrypted_user_profile_key);
+
+        if let Some(self_group) = &self_group {
+            let connection = ConnectionContext::TargetedInitiator(TargetedInitiatorContext {
+                user_id: Some(contact.user_id.clone().into()),
+                friendship_package_ear_key: Some(secret_bytes(&friendship_package_ear_key)),
+            });
+            params.group_bootstrap = Some(self_group.seal_group_bootstrap_param(
+                txn,
+                &group,
+                GroupBootstrapCarrier::CreationEcho,
+                Some(connection),
+            )?);
+        }
 
         // Prepare targeted message
         let connection_info =
@@ -453,6 +573,8 @@ impl LocalGroup<UserId> {
             group,
             params,
             chat_id,
+            contact: PartialContactType::TargetedMessage(user_id),
+            connection_offer_hash: None,
             payload: TargetedMessagePayload {
                 targeted_message_params,
                 targeted_group_state_ear_key: targeted_message_group.group_state_ear_key().clone(),
@@ -475,16 +597,34 @@ struct LocalUsernameContact<Payload = UsernamePayload> {
     group: Group,
     params: CreateGroupParamsOut,
     chat_id: ChatId,
+    contact: PartialContactType,
+    connection_offer_hash: Option<ConnectionOfferHash>,
     payload: Payload,
 }
 
+impl<Payload> LocalUsernameContact<Payload> {
+    /// The local rows to remove if the DS does not accept the group.
+    fn cleanup(&self) -> DiscardedConnectionGroup {
+        DiscardedConnectionGroup {
+            group_id: self.group.group_id().clone(),
+            chat_id: self.chat_id,
+            contact: self.contact.clone(),
+            connection_offer_hash: self.connection_offer_hash,
+        }
+    }
+}
+
 impl LocalUsernameContact<UsernamePayload> {
+    /// Creates the group on the DS and sends off the connection offer.
+    ///
+    /// The error tells the caller whether the DS accepted the group before the
+    /// failure, which decides whether the local state may be discarded.
     async fn create_connection_group_via_username(
         self,
         client: &ApiClient,
         signer: &UserSigningKey,
         responder: AsConnectionOfferResponder,
-    ) -> anyhow::Result<ChatId> {
+    ) -> Result<ChatId, ConnectionGroupError> {
         let Self {
             group,
             params,
@@ -494,28 +634,39 @@ impl LocalUsernameContact<UsernamePayload> {
                     connection_offer,
                     verified_connection_package,
                 },
+            ..
         } = self;
 
         info!("Creating connection group on DS");
         client
             .ds_create_group(params, signer, group.group_state_ear_key())
-            .await?;
+            .await
+            .map_err(|error| ConnectionGroupError::NotCreated(error.into()))?;
 
-        // Send off the connection offer.
+        // Send off the connection offer. The group exists on the DS from here
+        // on, so a failure must not take the local state with it.
         let hash = verified_connection_package.hash();
         let message = ConnectionOfferMessage::new(hash, connection_offer);
-        responder.send(message).await?;
+        responder
+            .send(message)
+            .await
+            .map_err(|error| ConnectionGroupError::CreatedThenFailed(error.into()))?;
 
         Ok(chat_id)
     }
 }
 
 impl LocalUsernameContact<TargetedMessagePayload> {
+    /// Creates the group on the DS and sends off the targeted message carrying
+    /// the connection offer.
+    ///
+    /// The error tells the caller whether the DS accepted the group before the
+    /// failure, which decides whether the local state may be discarded.
     async fn create_connection_group_via_targeted_message(
         self,
         client: &ApiClient,
         signer: &UserSigningKey,
-    ) -> anyhow::Result<ChatId> {
+    ) -> Result<ChatId, ConnectionGroupError> {
         let Self {
             group,
             params,
@@ -525,14 +676,17 @@ impl LocalUsernameContact<TargetedMessagePayload> {
                     targeted_message_params,
                     targeted_group_state_ear_key,
                 },
+            ..
         } = self;
 
         info!("Creating connection group on DS");
         client
             .ds_create_group(params, signer, group.group_state_ear_key())
-            .await?;
+            .await
+            .map_err(|error| ConnectionGroupError::NotCreated(error.into()))?;
 
-        // Send off the targeted message.
+        // Send off the targeted message. The group exists on the DS from here
+        // on, so a failure must not take the local state with it.
         // TODO: This should be scheduled in the outbound service
         client
             .ds_targeted_message(
@@ -540,7 +694,8 @@ impl LocalUsernameContact<TargetedMessagePayload> {
                 signer,
                 &targeted_group_state_ear_key,
             )
-            .await?;
+            .await
+            .map_err(|error| ConnectionGroupError::CreatedThenFailed(error.into()))?;
 
         Ok(chat_id)
     }

--- a/coreclient/src/clients/api_clients.rs
+++ b/coreclient/src/clients/api_clients.rs
@@ -5,11 +5,22 @@
 use std::{
     collections::{HashMap, hash_map::Entry},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use airapiclient::{ApiClient, ApiClientInitError};
 use aircommon::identifiers::Fqdn;
 use url::Url;
+
+/// Delays between DS reads that follow up on a DS echo.
+///
+/// An echo may reach a client before the DS transaction that persists the
+/// echoed operation commits, so a miss on the first read is expected.
+pub(crate) const DS_ECHO_RETRY_DELAYS: [Duration; 3] = [
+    Duration::from_millis(200),
+    Duration::from_millis(500),
+    Duration::from_millis(1500),
+];
 
 #[derive(Debug, Clone)]
 pub(crate) struct ApiClients {

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -19,11 +19,10 @@ use aircommon::{
     crypto::{
         RatchetDecryptionKey,
         aead::keys::WelcomeAttributionInfoEarKey,
-        hpke::HpkeEncryptable,
         kdf::keys::RatchetSecret,
         signatures::keys::{QsClientSigningKey, QsUserSigningKey},
     },
-    identifiers::{ClientConfig, QsClientId, QsReference, QsUserId, UserId},
+    identifiers::{QsClientId, QsReference, QsUserId, UserId},
     messages::{FriendshipToken, QueueMessage, push_token::PushToken},
     registration::RegistrationChallenge,
 };
@@ -629,15 +628,9 @@ impl CoreUser {
     }
 
     pub(crate) fn create_own_client_reference(&self) -> QsReference {
-        let sealed_reference = ClientConfig {
-            client_id: self.inner.qs_client_id,
-            push_token_ear_key: Some(self.inner.key_store.push_token_ear_key.clone()),
-        }
-        .encrypt(&self.inner.key_store.qs_client_id_encryption_key, &[], &[]);
-        QsReference {
-            client_homeserver_domain: self.user_id().domain().clone(),
-            sealed_reference,
-        }
+        self.inner
+            .key_store
+            .create_own_client_reference(&self.inner.qs_client_id)
     }
 
     /// Returns None if there is no chat with the given id.

--- a/coreclient/src/clients/process/group_bootstrap_echo.rs
+++ b/coreclient/src/clients/process/group_bootstrap_echo.rs
@@ -8,8 +8,9 @@
 //! The DS echoes the group bootstrap blob of an accepted creation or join to
 //! all of the acting user's client queues. This module turns such an echo into
 //! the same local state the acting client built.
-
-use std::time::Duration;
+//!
+//! The echo of a join also reaches the acting client itself. There it serves
+//! as the durable confirmation that the DS accepted the join.
 
 use aircommon::{
     codec::PersistenceCodec,
@@ -28,9 +29,13 @@ use tokio::time::sleep;
 use tracing::{debug, warn};
 
 use crate::{
-    Chat, ChatMessage, ChatStatus, Contact, PartialContact, SystemMessage, TargetedMessageContact,
+    Chat, ChatMessage, ChatStatus, ChatType, Contact, PartialContact, SystemMessage,
+    TargetedMessageContact,
     chats::PendingConnectionInfo,
-    clients::{CoreUser, api_clients::ApiClients},
+    clients::{
+        CoreUser,
+        api_clients::{ApiClients, DS_ECHO_RETRY_DELAYS},
+    },
     contacts::UsernameContact,
     db::access::WriteDbTransaction,
     groups::{
@@ -39,17 +44,10 @@ use crate::{
         group_bootstrap::{BootstrapConnection, GroupBootstrapContents},
         self_group::SelfGroup,
     },
+    outbound_service::connection_accepts::ConnectionAccept,
 };
 
 use super::process_qs::QsMessageOutcome;
-
-/// A join echo may reach the sibling before the DS transaction that writes the
-/// snapshot commits, so a not-found on the first attempt is expected.
-const SNAPSHOT_FETCH_RETRY_DELAYS: [Duration; 3] = [
-    Duration::from_millis(200),
-    Duration::from_millis(500),
-    Duration::from_millis(1500),
-];
 
 impl CoreUser {
     pub(super) async fn handle_group_bootstrap_echo(
@@ -59,9 +57,24 @@ impl CoreUser {
         carrier: GroupBootstrapCarrier,
         ds_timestamp: TimeStamp,
     ) -> Result<QsMessageOutcome> {
-        // A duplicate echo must not reinstall the group.
+        // A group we already have means we are the acting client, or the echo
+        // is a duplicate. Either way it must not be reinstalled.
         if Group::load(&mut *txn, &echo.group_id).await?.is_some() {
-            debug!(group_id = ?echo.group_id, "Group bootstrap for a group we already have");
+            return match carrier {
+                GroupBootstrapCarrier::CreationEcho => {
+                    debug!(group_id = ?echo.group_id, "Group bootstrap for a group we already have");
+                    Ok(QsMessageOutcome::empty())
+                }
+                GroupBootstrapCarrier::JoinEcho => {
+                    Box::pin(self.confirm_own_join_echo(txn, &echo)).await
+                }
+            };
+        }
+
+        // A join without a bootstrap is still echoed as the acting client's
+        // confirmation, but carries nothing for siblings.
+        if echo.group_bootstrap.is_empty() {
+            debug!(group_id = ?echo.group_id, "Group bootstrap echo without a bootstrap");
             return Ok(QsMessageOutcome::empty());
         }
 
@@ -125,6 +138,29 @@ impl CoreUser {
                 .await?
             }
         }
+
+        Ok(QsMessageOutcome::empty())
+    }
+
+    /// Handles our own join echo.
+    async fn confirm_own_join_echo(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        echo: &GroupBootstrapEcho,
+    ) -> Result<QsMessageOutcome> {
+        let Some(chat) = Chat::load_by_group_id(&mut *txn, &echo.group_id).await? else {
+            debug!(group_id = ?echo.group_id, "Join echo for a group without a chat");
+            return Ok(QsMessageOutcome::empty());
+        };
+        let ChatType::PendingConnection(_) = chat.chat_type() else {
+            // The connection was already established and this is a duplicate
+            // confirmation.
+            debug!(group_id = ?echo.group_id, "Join echo for an already confirmed join");
+            return Ok(QsMessageOutcome::empty());
+        };
+
+        ConnectionAccept::enqueue(&mut *txn, chat.id()).await?;
+        self.outbound_service().notify_connection_accepts();
 
         Ok(QsMessageOutcome::empty())
     }
@@ -361,7 +397,7 @@ async fn fetch_epoch_snapshot(
         match result {
             Ok(snapshot) => return Ok(snapshot),
             Err(error) => {
-                let Some(delay) = SNAPSHOT_FETCH_RETRY_DELAYS.get(attempt) else {
+                let Some(delay) = DS_ECHO_RETRY_DELAYS.get(attempt) else {
                     return Err(error).context("failed to fetch the epoch snapshot");
                 };
                 warn!(%error, "Failed to fetch the epoch snapshot; retrying");

--- a/coreclient/src/clients/process/group_bootstrap_echo.rs
+++ b/coreclient/src/clients/process/group_bootstrap_echo.rs
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Following a sibling emulator client into a group it created or externally
+//! joined.
+//!
+//! The DS echoes the group bootstrap blob of an accepted creation or join to
+//! all of the acting user's client queues. This module turns such an echo into
+//! the same local state the acting client built.
+
+use std::time::Duration;
+
+use aircommon::{
+    codec::PersistenceCodec,
+    crypto::indexed_aead::keys::UserProfileKey,
+    identifiers::{QualifiedGroupId, UserId},
+    messages::{
+        client_as::ConnectionOfferHash, client_ds::GroupBootstrapEcho,
+        client_ds_out::EpochSnapshotIn,
+    },
+    time::TimeStamp,
+};
+use airprotos::client::group_bootstrap::{GroupBootstrapBlob, GroupBootstrapCarrier};
+use anyhow::{Context, Result, bail, ensure};
+use mimi_room_policy::RoleIndex;
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+use crate::{
+    Chat, ChatMessage, ChatStatus, Contact, PartialContact, SystemMessage, TargetedMessageContact,
+    chats::PendingConnectionInfo,
+    clients::{CoreUser, api_clients::ApiClients},
+    contacts::UsernameContact,
+    db::access::WriteDbTransaction,
+    groups::{
+        Group,
+        client_auth_info::StorableUserCredential,
+        group_bootstrap::{BootstrapConnection, GroupBootstrapContents},
+        self_group::SelfGroup,
+    },
+};
+
+use super::process_qs::QsMessageOutcome;
+
+/// A join echo may reach the sibling before the DS transaction that writes the
+/// snapshot commits, so a not-found on the first attempt is expected.
+const SNAPSHOT_FETCH_RETRY_DELAYS: [Duration; 3] = [
+    Duration::from_millis(200),
+    Duration::from_millis(500),
+    Duration::from_millis(1500),
+];
+
+impl CoreUser {
+    pub(super) async fn handle_group_bootstrap_echo(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        echo: GroupBootstrapEcho,
+        carrier: GroupBootstrapCarrier,
+        ds_timestamp: TimeStamp,
+    ) -> Result<QsMessageOutcome> {
+        // A duplicate echo must not reinstall the group.
+        if Group::load(&mut *txn, &echo.group_id).await?.is_some() {
+            debug!(group_id = ?echo.group_id, "Group bootstrap for a group we already have");
+            return Ok(QsMessageOutcome::empty());
+        }
+
+        let self_group = SelfGroup::load(&mut *txn)
+            .await?
+            .context("no self group to open the group bootstrap with")?;
+
+        let blob: GroupBootstrapBlob = PersistenceCodec::from_slice(&echo.group_bootstrap)
+            .context("failed to decode the group bootstrap blob")?;
+        let (bootstrap, epoch_id) =
+            self_group
+                .group()
+                .open_group_bootstrap(txn, &blob, carrier, &echo.group_id)?;
+        let contents = GroupBootstrapContents::try_from(bootstrap)?;
+        ensure!(
+            contents.group_id == echo.group_id && contents.pq_group_id == echo.pq_group_id,
+            "group bootstrap and echo disagree on the group ids"
+        );
+
+        let connection_offer_hash = connection_offer_psk_for(carrier, &contents)?;
+        let snapshot = fetch_epoch_snapshot(self.api_clients(), &echo, &contents).await?;
+
+        let mut group = match carrier {
+            GroupBootstrapCarrier::CreationEcho => {
+                Box::pin(Group::vc_join_at_creation(
+                    txn,
+                    self.api_clients(),
+                    snapshot,
+                    &contents,
+                    epoch_id,
+                    self.user_id(),
+                ))
+                .await?
+            }
+            GroupBootstrapCarrier::JoinEcho => {
+                Box::pin(Group::vc_join_via_sibling_external_commit(
+                    txn,
+                    self.api_clients(),
+                    snapshot,
+                    &contents,
+                    epoch_id,
+                    self.user_id(),
+                    connection_offer_hash,
+                ))
+                .await?
+            }
+        };
+
+        match &contents.connection {
+            None => {
+                self.install_bootstrapped_group_chat(txn, &group, ds_timestamp)
+                    .await?
+            }
+            Some(connection) => {
+                Box::pin(self.install_bootstrapped_connection_chat(
+                    txn,
+                    &mut group,
+                    connection,
+                    ds_timestamp,
+                ))
+                .await?
+            }
+        }
+
+        Ok(QsMessageOutcome::empty())
+    }
+
+    /// Creates the chat of a group chat a sibling created, taking the
+    /// attributes from the group data extension the snapshot carried.
+    async fn install_bootstrapped_group_chat(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        group: &Group,
+        ds_timestamp: TimeStamp,
+    ) -> Result<()> {
+        ensure_only_member(group, self.user_id())?;
+
+        let attributes =
+            Self::chat_attributes_from_group_data(txn, group, self.user_id(), ds_timestamp).await?;
+
+        let chat = Chat::new_group_chat(group.group_id().clone(), attributes);
+        chat.store(&mut *txn).await?;
+        ChatMessage::new_system_message(
+            chat.id(),
+            ds_timestamp,
+            SystemMessage::CreateGroup(self.user_id().clone()),
+        )
+        .store(&mut *txn)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Creates the chat and contact rows of a connection chat a sibling
+    /// created or accepted.
+    async fn install_bootstrapped_connection_chat(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        group: &mut Group,
+        connection: &BootstrapConnection,
+        ds_timestamp: TimeStamp,
+    ) -> Result<()> {
+        match connection {
+            BootstrapConnection::HandleInitiator {
+                username,
+                friendship_package_ear_key,
+                connection_offer_hash,
+            } => {
+                ensure_only_member(group, self.user_id())?;
+
+                let chat = Chat::new_handle_chat(group.group_id().clone(), username.clone());
+                chat.store(&mut *txn).await?;
+                ChatMessage::new_system_message(
+                    chat.id(),
+                    ds_timestamp,
+                    SystemMessage::NewHandleConnectionChat(username.clone()),
+                )
+                .store(&mut *txn)
+                .await?;
+
+                UsernameContact::new(
+                    username.clone(),
+                    chat.id(),
+                    friendship_package_ear_key.clone(),
+                    *connection_offer_hash,
+                )
+                .upsert(&mut *txn)
+                .await?;
+                // The peer's external commit will reference this PSK.
+                group.store_connection_offer_psk(&mut *txn, *connection_offer_hash)?;
+            }
+
+            BootstrapConnection::TargetedInitiator {
+                user_id,
+                friendship_package_ear_key,
+            } => {
+                ensure_only_member(group, self.user_id())?;
+
+                let chat =
+                    Chat::new_targeted_message_chat(group.group_id().clone(), user_id.clone());
+                chat.store(&mut *txn).await?;
+                ChatMessage::new_system_message(
+                    chat.id(),
+                    ds_timestamp,
+                    SystemMessage::NewDirectConnectionChat(user_id.clone()),
+                )
+                .store(&mut *txn)
+                .await?;
+
+                TargetedMessageContact::new(
+                    user_id.clone(),
+                    chat.id(),
+                    friendship_package_ear_key.clone(),
+                )
+                .upsert(&mut *txn)
+                .await?;
+            }
+
+            BootstrapConnection::Accept {
+                user_id,
+                friendship_package,
+                connection_offer_hash,
+            } => {
+                let members: Vec<_> = group.members().collect();
+                ensure!(
+                    members.len() == 2
+                        && members.contains(self.user_id())
+                        && members.contains(user_id),
+                    "connection group has unexpected members: {members:?}"
+                );
+
+                let user_profile_key = UserProfileKey::from_base_secret(
+                    friendship_package.user_profile_base_secret.clone(),
+                    user_id,
+                )?;
+                let credential = StorableUserCredential::load_by_user_id(&mut *txn, user_id)
+                    .await?
+                    .with_context(|| format!("no verified credential for {user_id:?}"))?;
+                Self::schedule_fetch_user_profile(&mut *txn, (credential.into(), user_profile_key))
+                    .await?;
+
+                // Replay the role change the accepting sibling applied: the DS
+                // does not add external joiners of connection groups to the
+                // room state it serves.
+                group.room_state_change_role(user_id, self.user_id(), RoleIndex::Regular)?;
+                let now = TimeStamp::now();
+                group.store_update(&mut *txn, Some(now), Some(now)).await?;
+
+                let chat =
+                    Chat::new_onboarding_connection_chat(group.group_id().clone(), user_id.clone());
+
+                // A connection offer that arrived as a targeted message
+                // reaches every sibling, so this client may already hold the
+                // pending chat the acting client just replaced. The handle of
+                // a username offer is only in that pending state.
+                let pending = PendingConnectionInfo::load(&mut *txn, chat.id()).await?;
+                let user_handle = pending.and_then(|pending| pending.handle);
+                let partial_contact =
+                    match UsernameContact::load_by_chat_id(&mut *txn, chat.id()).await? {
+                        Some(contact) => Some(PartialContact::Username(contact)),
+                        None => TargetedMessageContact::load(&mut *txn, user_id)
+                            .await?
+                            .map(PartialContact::TargetedMessage),
+                    };
+                if let Some(partial_contact) = partial_contact {
+                    partial_contact.delete(&mut *txn).await?;
+                }
+                PendingConnectionInfo::delete(&mut *txn, chat.id()).await?;
+
+                chat.store(&mut *txn).await?;
+                Chat::update_status(&mut *txn, chat.id(), &ChatStatus::Active).await?;
+                ChatMessage::new_system_message(
+                    chat.id(),
+                    ds_timestamp,
+                    SystemMessage::AcceptedConnectionRequest {
+                        contact: user_id.clone(),
+                        user_handle,
+                    },
+                )
+                .store(&mut *txn)
+                .await?;
+
+                Contact {
+                    user_id: user_id.clone(),
+                    wai_ear_key: friendship_package.wai_ear_key.clone(),
+                    friendship_token: friendship_package.friendship_token.clone(),
+                    chat_id: chat.id(),
+                    supported_features: None,
+                }
+                .upsert(&mut *txn)
+                .await?;
+
+                if let Some(hash) = connection_offer_hash {
+                    Group::delete_connection_offer_psk(txn, *hash)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Checks that the blob's connection context matches the operation the echo
+/// announces, and returns the connection-offer PSK a join has to install
+/// before it applies the commit.
+fn connection_offer_psk_for(
+    carrier: GroupBootstrapCarrier,
+    contents: &GroupBootstrapContents,
+) -> Result<Option<ConnectionOfferHash>> {
+    match (carrier, &contents.connection) {
+        (
+            GroupBootstrapCarrier::JoinEcho,
+            Some(BootstrapConnection::Accept {
+                connection_offer_hash,
+                ..
+            }),
+        ) => Ok(*connection_offer_hash),
+        (GroupBootstrapCarrier::JoinEcho, _) => {
+            bail!("a join echo must carry an accept connection context")
+        }
+        (GroupBootstrapCarrier::CreationEcho, Some(BootstrapConnection::Accept { .. })) => {
+            bail!("a creation echo must not carry an accept connection context")
+        }
+        (GroupBootstrapCarrier::CreationEcho, _) => Ok(None),
+    }
+}
+
+/// A group a sibling just created holds only the virtual client's own leaf.
+fn ensure_only_member(group: &Group, own_user_id: &UserId) -> Result<()> {
+    let members: Vec<_> = group.members().collect();
+    ensure!(
+        members.len() == 1 && members.contains(own_user_id),
+        "a freshly created group has members other than us: {members:?}"
+    );
+    Ok(())
+}
+
+/// Fetches the epoch snapshot of the echoed operation, retrying in place: the
+/// echo can outrun the DS transaction that writes the snapshot, and losing it
+/// loses the group.
+async fn fetch_epoch_snapshot(
+    api_clients: &ApiClients,
+    echo: &GroupBootstrapEcho,
+    contents: &GroupBootstrapContents,
+) -> Result<EpochSnapshotIn> {
+    let qgid = QualifiedGroupId::try_from(echo.group_id.clone())?;
+    let api_client = api_clients.get(qgid.owning_domain())?;
+    let mut attempt = 0;
+    loop {
+        let result = api_client
+            .ds_epoch_snapshot(
+                echo.group_id.clone(),
+                echo.epoch,
+                &contents.group_state_ear_key,
+            )
+            .await;
+        match result {
+            Ok(snapshot) => return Ok(snapshot),
+            Err(error) => {
+                let Some(delay) = SNAPSHOT_FETCH_RETRY_DELAYS.get(attempt) else {
+                    return Err(error).context("failed to fetch the epoch snapshot");
+                };
+                warn!(%error, "Failed to fetch the epoch snapshot; retrying");
+                sleep(*delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}

--- a/coreclient/src/clients/process/mod.rs
+++ b/coreclient/src/clients/process/mod.rs
@@ -4,6 +4,7 @@
 
 use super::{AsCredentials, Chat, ChatId, CoreUser, FriendshipPackage, TimestampedMessage, anyhow};
 
+pub mod group_bootstrap_echo;
 pub mod process_as;
 pub mod process_qs;
 pub mod qs_stream;

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -20,7 +20,10 @@ use aircommon::{
     utils::removed_client,
     virtual_client::KeyPackageBatchId,
 };
-use airprotos::client::{group::GroupData, virtual_client::extract_virtual_client_commit_data};
+use airprotos::client::{
+    group::GroupData, group_bootstrap::GroupBootstrapCarrier,
+    virtual_client::extract_virtual_client_commit_data,
+};
 use anyhow::{Context, Result, bail, ensure};
 use apqmls::messages::ApqMlsMessageIn;
 use chrono::Utc;
@@ -78,7 +81,7 @@ pub struct QsMessageOutcome {
 }
 
 impl QsMessageOutcome {
-    fn empty() -> QsMessageOutcome {
+    pub(super) fn empty() -> QsMessageOutcome {
         Self::default()
     }
 
@@ -259,18 +262,22 @@ impl CoreUser {
                 .await
                 .map(|_| QsMessageOutcome::empty()),
             ExtractedQsQueueMessagePayload::GroupCreationEcho(echo) => {
-                warn!(
-                    group_id = ?echo.group_id,
-                    "group creation echo processing not yet implemented"
-                );
-                Ok(QsMessageOutcome::empty())
+                Box::pin(self.handle_group_bootstrap_echo(
+                    txn,
+                    echo,
+                    GroupBootstrapCarrier::CreationEcho,
+                    ds_timestamp,
+                ))
+                .await
             }
             ExtractedQsQueueMessagePayload::GroupJoinEcho(echo) => {
-                warn!(
-                    group_id = ?echo.group_id,
-                    "group join echo processing not yet implemented"
-                );
-                Ok(QsMessageOutcome::empty())
+                Box::pin(self.handle_group_bootstrap_echo(
+                    txn,
+                    echo,
+                    GroupBootstrapCarrier::JoinEcho,
+                    ds_timestamp,
+                ))
+                .await
             }
         };
 
@@ -502,23 +509,9 @@ impl CoreUser {
         // members if they don't exist yet and store the group and the
         // new chat.
 
-        // Set the chat attributes according to the group's
-        // group data.
-        let group_data_bytes = group.group_data().context("No group data")?;
-        let group_data = GroupData::decode(&group_data_bytes)?;
-        let (title, group_profile_part) = group_data.into_parts(group.identity_link_wrapper_key());
-        let title = title.context("No group title")?;
-        // An external group profile is not yet available; it is fetched later.
-        let picture = Self::resolve_group_profile_part(
-            txn,
-            &group_id,
-            &sender_user_id,
-            ds_timestamp,
-            group_profile_part,
-            true,
-        )
-        .await?;
-        let attributes = ChatAttributes { title, picture };
+        let attributes =
+            Self::chat_attributes_from_group_data(txn, &group, &sender_user_id, ds_timestamp)
+                .await?;
 
         let chat = Chat::new_group_chat(group_id.clone(), attributes);
         let own_profile_key = UserProfileKey::load_own(&mut *txn).await?;
@@ -561,6 +554,33 @@ impl CoreUser {
             sender_user_id,
             vec![system_message],
         ))
+    }
+
+    /// Decodes the group data extension into the attributes of the chat a
+    /// joiner creates for `group`.
+    ///
+    /// An external group profile is not yet available, so it is scheduled for
+    /// a fetch and the picture stays empty until it arrives.
+    pub(crate) async fn chat_attributes_from_group_data(
+        txn: &mut WriteDbTransaction<'_>,
+        group: &Group,
+        sender_id: &UserId,
+        ds_timestamp: TimeStamp,
+    ) -> anyhow::Result<ChatAttributes> {
+        let group_data_bytes = group.group_data().context("No group data")?;
+        let group_data = GroupData::decode(&group_data_bytes)?;
+        let (title, group_profile_part) = group_data.into_parts(group.identity_link_wrapper_key());
+        let title = title.context("No group title")?;
+        let picture = Self::resolve_group_profile_part(
+            txn,
+            group.group_id(),
+            sender_id,
+            ds_timestamp,
+            group_profile_part,
+            true,
+        )
+        .await?;
+        Ok(ChatAttributes { title, picture })
     }
 
     /// Handles the profile part of decoded group data: schedules a fetch for
@@ -1816,6 +1836,7 @@ mod tests {
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     Some(vec![VC_COMPONENT_ID]),
                     AirComponent::default_for_self_group(),
+                    None,
                 )?;
                 group.store(&mut *txn).await?;
                 OwnClientInfo::set_self_group(&mut *txn, group.group_id(), &signing_key).await?;

--- a/coreclient/src/contacts/mod.rs
+++ b/coreclient/src/contacts/mod.rs
@@ -208,6 +208,7 @@ pub enum ContactType {
     Partial(PartialContact),
 }
 
+#[derive(Clone)]
 pub enum PartialContactType {
     Handle(Username),
     TargetedMessage(UserId),

--- a/coreclient/src/contacts/persistence.rs
+++ b/coreclient/src/contacts/persistence.rs
@@ -379,6 +379,15 @@ impl PartialContact {
         }
     }
 
+    pub(crate) async fn delete(&self, connection: impl WriteConnection) -> sqlx::Result<()> {
+        match self {
+            PartialContact::Username(username_contact) => username_contact.delete(connection).await,
+            PartialContact::TargetedMessage(targeted_message_contact) => {
+                targeted_message_contact.delete(connection).await
+            }
+        }
+    }
+
     pub(crate) async fn mark_as_complete(
         self,
         txn: &mut WriteDbTransaction<'_>,

--- a/coreclient/src/groups/apq_group.rs
+++ b/coreclient/src/groups/apq_group.rs
@@ -10,7 +10,7 @@ use aircommon::{
         APQ_CIPHERSUITE, GROUP_DATA_EXTENSION_TYPE, MAX_PAST_EPOCHS,
         default_group_context_app_data_dictionary_extension, default_group_required_extensions,
         default_leaf_node_capabilities, default_sender_ratchet_configuration,
-        self_group_leaf_node_capabilities,
+        self_group_leaf_node_capabilities, vc_leaf_node_extensions,
     },
     time::TimeStamp,
 };
@@ -50,6 +50,11 @@ impl PqGroup {
 }
 
 impl Group {
+    /// `vc_group_id` names the emulation group when the creator acts as a
+    /// virtual client. Both halves then derive their creator leaf and epoch-0
+    /// secret from that group's newest derivation epoch. It is mutually
+    /// exclusive with creating the group as an emulation group itself, which is
+    /// what the self group does.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn create_apq_group(
         mut connection: impl WriteConnection,
@@ -61,6 +66,7 @@ impl Group {
         group_data_bytes: GroupDataBytes,
         safe_aad_components: Option<Vec<ComponentId>>,
         air_component: AirComponent,
+        vc_group_id: Option<&GroupId>,
     ) -> anyhow::Result<(Self, PartialCreateGroupParams)> {
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
@@ -101,7 +107,7 @@ impl Group {
             LeafSigningKey::SelfGroup(_) => self_group_leaf_node_capabilities(),
         };
 
-        let (t_group, pq_group) = ApqMlsGroup::builder()
+        let mut builder = ApqMlsGroup::builder()
             .with_group_ids(t_group_id, pq_group_id)
             .with_ciphersuite(APQ_CIPHERSUITE)
             .with_capabilities(capabilities)
@@ -111,7 +117,16 @@ impl Group {
             // The self group is the emulation group of the virtual client, so its
             // initial epoch already has to be a derivation epoch.
             .emulation_group(matches!(signer, LeafSigningKey::SelfGroup(_)))
-            .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY);
+        if let Some(vc_group_id) = vc_group_id {
+            // Both leaves carry the virtual-client marker, as they do on the
+            // external-commit join path.
+            let leaf_extensions = vc_leaf_node_extensions::<AirComponent>();
+            builder = builder
+                .with_leaf_node_extensions(leaf_extensions.clone(), leaf_extensions)?
+                .vc_emulation(vc_group_id);
+        }
+        let (t_group, pq_group) = builder
             .build(&provider, signer, apq_credential_with_key)?
             .into_groups();
 

--- a/coreclient/src/groups/group_bootstrap.rs
+++ b/coreclient/src/groups/group_bootstrap.rs
@@ -11,19 +11,33 @@
 //! newest emulation epoch, whose coordinates travel in the clear inside the
 //! blob.
 
-use aircommon::crypto::{
-    aead::{AEAD_KEY_SIZE, keys::GroupBootstrapKey},
-    kdf::{KdfDerivable, keys::VcApplicationSecret},
+use aircommon::{
+    codec::PersistenceCodec,
+    crypto::{
+        aead::{
+            AEAD_KEY_SIZE,
+            keys::{
+                FriendshipPackageEarKey, GroupBootstrapKey, GroupStateEarKey,
+                IdentityLinkWrapperKey,
+            },
+        },
+        indexed_aead::keys::TypedSecret,
+        kdf::{KdfDerivable, keys::VcApplicationSecret},
+        secrets::Secret,
+    },
+    identifiers::{UserId, Username},
+    messages::client_as::ConnectionOfferHash,
 };
 use airprotos::client::group_bootstrap::{
-    GroupBootstrap, GroupBootstrapBlob, GroupBootstrapCarrier,
+    ConnectionContext, GroupBootstrap, GroupBootstrapBlob, GroupBootstrapCarrier,
 };
-use anyhow::{Context, Result, anyhow, ensure};
-use openmls::prelude::GroupId;
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use openmls::{components::vc_derivation_info::EpochId, prelude::GroupId};
 
 use crate::{
+    clients::connection_offer::FriendshipPackage,
     db::access::WriteDbTransaction,
-    groups::{Group, openmls_provider::AirOpenMlsProvider},
+    groups::{Group, openmls_provider::AirOpenMlsProvider, self_group::SelfGroup},
 };
 
 /// Domain separation of the application-ratchet derivation that feeds the
@@ -54,7 +68,8 @@ impl Group {
         Ok(GroupBootstrapBlob::new(&info, sealed))
     }
 
-    /// Opens a blob a sibling emulator client sealed on this self group.
+    /// Opens a blob a sibling emulator client sealed on this self group, and
+    /// returns it along with the emulation epoch the sibling derived from.
     ///
     /// Errors if called on a group that is not the self group, or if the blob
     /// names this client's own ratchet.
@@ -64,7 +79,7 @@ impl Group {
         blob: &GroupBootstrapBlob,
         carrier: GroupBootstrapCarrier,
         group_id: &GroupId,
-    ) -> Result<GroupBootstrap> {
+    ) -> Result<(GroupBootstrap, EpochId)> {
         ensure!(
             self.is_self_group(),
             "open_group_bootstrap must only be called on the self group"
@@ -81,8 +96,173 @@ impl Group {
             self.mls_group()
                 .derive_vc_application_secret(&provider, &info, OPERATION_CONTEXT)?;
         let key = bootstrap_key(secret)?;
-        Ok(GroupBootstrap::open(&key, ciphertext, carrier, group_id)?)
+        let bootstrap = GroupBootstrap::open(&key, ciphertext, carrier, group_id)?;
+        Ok((bootstrap, info.epoch_id))
     }
+}
+
+impl SelfGroup {
+    /// Builds the bootstrap blob describing `group` and encodes it for the
+    /// `group_bootstrap` request parameter of the create-group or
+    /// join-connection-group request that installs `group` on the DS.
+    pub(crate) fn seal_group_bootstrap_param(
+        &self,
+        txn: &mut WriteDbTransaction<'_>,
+        group: &Group,
+        carrier: GroupBootstrapCarrier,
+        connection: Option<ConnectionContext>,
+    ) -> Result<Vec<u8>> {
+        let bootstrap = group_bootstrap_payload(group, connection);
+        let blob = self
+            .group()
+            .seal_group_bootstrap(txn, &bootstrap, carrier, group.group_id())?;
+        Ok(PersistenceCodec::to_vec(&blob)?)
+    }
+}
+
+/// The payload a sibling needs to install `group` beyond the MLS material it
+/// fetches from the DS epoch snapshot.
+fn group_bootstrap_payload(group: &Group, connection: Option<ConnectionContext>) -> GroupBootstrap {
+    GroupBootstrap {
+        group_id: Some(group.group_id().as_slice().to_vec()),
+        pq_group_id: group.pq_group_id().map(|id| id.as_slice().to_vec()),
+        group_state_ear_key: Some(secret_bytes(group.group_state_ear_key())),
+        identity_link_wrapper_key: Some(secret_bytes(group.identity_link_wrapper_key())),
+        connection,
+    }
+}
+
+/// The raw bytes of a 32-byte secret.
+pub(crate) fn secret_bytes(secret: &impl AsRef<Secret<AEAD_KEY_SIZE>>) -> Vec<u8> {
+    secret.as_ref().secret().to_vec()
+}
+
+/// A [`GroupBootstrap`] payload whose required fields are present and of the
+/// right shape.
+#[derive(Debug)]
+pub(crate) struct GroupBootstrapContents {
+    pub(crate) group_id: GroupId,
+    pub(crate) pq_group_id: Option<GroupId>,
+    pub(crate) group_state_ear_key: GroupStateEarKey,
+    pub(crate) identity_link_wrapper_key: IdentityLinkWrapperKey,
+    /// Absent for group chats, whose attributes come from the group data
+    /// extension in the snapshot's `GroupInfo` instead.
+    pub(crate) connection: Option<BootstrapConnection>,
+}
+
+impl TryFrom<GroupBootstrap> for GroupBootstrapContents {
+    type Error = anyhow::Error;
+
+    fn try_from(bootstrap: GroupBootstrap) -> Result<Self> {
+        let GroupBootstrap {
+            group_id,
+            pq_group_id,
+            group_state_ear_key,
+            identity_link_wrapper_key,
+            connection,
+        } = bootstrap;
+        Ok(Self {
+            group_id: GroupId::from_slice(&group_id.context("group bootstrap without a group id")?),
+            pq_group_id: pq_group_id.map(|id| GroupId::from_slice(&id)),
+            group_state_ear_key: secret_field(group_state_ear_key, "group state ear key")?,
+            identity_link_wrapper_key: secret_field(
+                identity_link_wrapper_key,
+                "identity link wrapper key",
+            )?,
+            connection: connection.map(BootstrapConnection::try_from).transpose()?,
+        })
+    }
+}
+
+/// The contact context a sibling needs to mirror a connection chat.
+#[derive(Debug)]
+pub(crate) enum BootstrapConnection {
+    /// A sibling initiated the connection via a user handle.
+    HandleInitiator {
+        username: Username,
+        friendship_package_ear_key: FriendshipPackageEarKey,
+        connection_offer_hash: ConnectionOfferHash,
+    },
+    /// A sibling initiated the connection via a targeted message.
+    TargetedInitiator {
+        user_id: UserId,
+        friendship_package_ear_key: FriendshipPackageEarKey,
+    },
+    /// A sibling accepted a connection request by externally joining the
+    /// peer's connection group.
+    Accept {
+        user_id: UserId,
+        friendship_package: FriendshipPackage,
+        /// Absent when the offer arrived as a targeted message, which carries
+        /// no connection-offer PSK.
+        connection_offer_hash: Option<ConnectionOfferHash>,
+    },
+}
+
+impl TryFrom<ConnectionContext> for BootstrapConnection {
+    type Error = anyhow::Error;
+
+    fn try_from(context: ConnectionContext) -> Result<Self> {
+        match context {
+            ConnectionContext::HandleInitiator(context) => Ok(Self::HandleInitiator {
+                username: Username::new(
+                    context
+                        .username
+                        .context("handle initiator context without a username")?,
+                )?,
+                friendship_package_ear_key: secret_field(
+                    context.friendship_package_ear_key,
+                    "friendship package ear key",
+                )?,
+                connection_offer_hash: context
+                    .connection_offer_hash
+                    .context("handle initiator context without a connection offer hash")?,
+            }),
+            ConnectionContext::TargetedInitiator(context) => Ok(Self::TargetedInitiator {
+                user_id: context
+                    .user_id
+                    .context("targeted initiator context without a user id")?
+                    .try_into()?,
+                friendship_package_ear_key: secret_field(
+                    context.friendship_package_ear_key,
+                    "friendship package ear key",
+                )?,
+            }),
+            ConnectionContext::Accept(context) => Ok(Self::Accept {
+                user_id: context
+                    .user_id
+                    .context("accept context without a user id")?
+                    .try_into()?,
+                friendship_package: FriendshipPackage {
+                    friendship_token: context
+                        .friendship_token
+                        .context("accept context without a friendship token")?,
+                    wai_ear_key: secret_field(context.wai_ear_key, "wai ear key")?,
+                    user_profile_base_secret: secret_field(
+                        context.user_profile_base_secret,
+                        "user profile base secret",
+                    )?,
+                },
+                connection_offer_hash: context.connection_offer_hash,
+            }),
+            ConnectionContext::Unknown => {
+                bail!("group bootstrap carries an unknown connection context")
+            }
+        }
+    }
+}
+
+/// Turns a raw 32-byte blob field into its secret type, rejecting an absent
+/// field or a wrong length.
+fn secret_field<KT, ST, const N: usize>(
+    bytes: Option<Vec<u8>>,
+    field: &str,
+) -> Result<TypedSecret<KT, ST, N>> {
+    let bytes = bytes.with_context(|| format!("group bootstrap without a {field}"))?;
+    let bytes: [u8; N] = bytes
+        .try_into()
+        .map_err(|_| anyhow!("group bootstrap {field} has the wrong length"))?;
+    Ok(TypedSecret::from(Secret::from(bytes)))
 }
 
 fn bootstrap_key(secret: Vec<u8>) -> Result<GroupBootstrapKey> {
@@ -106,7 +286,11 @@ mod tests {
         identifiers::{QualifiedGroupId, UserId},
         mls_group_config::AppComponent,
     };
-    use airprotos::client::component::AirComponent;
+    use aircommon::{crypto::aead::AEAD_KEY_SIZE, messages::FriendshipToken};
+    use airprotos::client::{
+        component::AirComponent,
+        group_bootstrap::{AcceptContext, HandleInitiatorContext, PeerUserId},
+    };
     use uuid::Uuid;
 
     use crate::{
@@ -131,6 +315,14 @@ mod tests {
         txn: &mut WriteDbTransaction<'_>,
         is_self_group: bool,
     ) -> anyhow::Result<Group> {
+        create_group_with_vc_emulation(txn, is_self_group, None)
+    }
+
+    fn create_group_with_vc_emulation(
+        txn: &mut WriteDbTransaction<'_>,
+        is_self_group: bool,
+        vc_group_id: Option<&GroupId>,
+    ) -> anyhow::Result<Group> {
         let user_id = UserId::random("example.com".parse()?);
         let signer = if is_self_group {
             LeafSigningKey::SelfGroup(SelfGroupSigningKey::generate(Uuid::new_v4())?)
@@ -153,6 +345,7 @@ mod tests {
             GroupDataBytes::from(b"test-group-data".to_vec()),
             None,
             air_component,
+            vc_group_id,
         )?;
         Ok(group)
     }
@@ -169,6 +362,195 @@ mod tests {
             identity_link_wrapper_key: None,
             connection: None,
         }
+    }
+
+    fn peer_user_id() -> UserId {
+        UserId::new(Uuid::new_v4(), "example.com".parse().unwrap())
+    }
+
+    fn accept_context(user_id: &UserId) -> AcceptContext {
+        AcceptContext {
+            user_id: Some(user_id.clone().into()),
+            friendship_token: Some(FriendshipToken::from_bytes(vec![1; 32])),
+            wai_ear_key: Some(vec![2; AEAD_KEY_SIZE]),
+            user_profile_base_secret: Some(vec![3; AEAD_KEY_SIZE]),
+            connection_offer_hash: Some(ConnectionOfferHash::from_bytes([4u8; 32])),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn payload_round_trips_through_the_sibling_parser() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let self_group = SelfGroup::new_for_test(create_group(&mut txn, true)?);
+        let created = create_group_with_vc_emulation(&mut txn, false, Some(self_group.group_id()))?;
+
+        let peer = peer_user_id();
+        let payload = group_bootstrap_payload(
+            &created,
+            Some(ConnectionContext::Accept(accept_context(&peer))),
+        );
+        let contents = GroupBootstrapContents::try_from(payload)?;
+
+        assert_eq!(&contents.group_id, created.group_id());
+        assert_eq!(contents.pq_group_id, created.pq_group_id());
+        assert_eq!(
+            secret_bytes(&contents.group_state_ear_key),
+            secret_bytes(created.group_state_ear_key())
+        );
+        assert_eq!(
+            secret_bytes(&contents.identity_link_wrapper_key),
+            secret_bytes(created.identity_link_wrapper_key())
+        );
+        let Some(BootstrapConnection::Accept {
+            user_id,
+            friendship_package,
+            connection_offer_hash,
+        }) = contents.connection
+        else {
+            panic!("expected an accept context");
+        };
+        assert_eq!(user_id, peer);
+        assert_eq!(
+            friendship_package.friendship_token,
+            FriendshipToken::from_bytes(vec![1; 32])
+        );
+        assert_eq!(
+            secret_bytes(&friendship_package.wai_ear_key),
+            vec![2; AEAD_KEY_SIZE]
+        );
+        assert_eq!(
+            connection_offer_hash,
+            Some(ConnectionOfferHash::from_bytes([4u8; 32]))
+        );
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    fn minimal_payload() -> GroupBootstrap {
+        GroupBootstrap {
+            group_id: Some(b"t-group-id".to_vec()),
+            pq_group_id: None,
+            group_state_ear_key: Some(vec![1; AEAD_KEY_SIZE]),
+            identity_link_wrapper_key: Some(vec![2; AEAD_KEY_SIZE]),
+            connection: None,
+        }
+    }
+
+    #[test]
+    fn contents_reject_absent_or_malformed_fields() {
+        assert!(GroupBootstrapContents::try_from(minimal_payload()).is_ok());
+
+        let payload = GroupBootstrap {
+            group_id: None,
+            ..minimal_payload()
+        };
+        assert!(GroupBootstrapContents::try_from(payload).is_err());
+
+        let payload = GroupBootstrap {
+            group_state_ear_key: None,
+            ..minimal_payload()
+        };
+        assert!(GroupBootstrapContents::try_from(payload).is_err());
+
+        let payload = GroupBootstrap {
+            identity_link_wrapper_key: Some(vec![2; AEAD_KEY_SIZE - 1]),
+            ..minimal_payload()
+        };
+        assert!(GroupBootstrapContents::try_from(payload).is_err());
+    }
+
+    #[test]
+    fn contents_reject_incomplete_connection_contexts() {
+        let with_connection = |connection| {
+            GroupBootstrapContents::try_from(GroupBootstrap {
+                connection: Some(connection),
+                ..minimal_payload()
+            })
+        };
+
+        let peer = peer_user_id();
+        assert!(
+            with_connection(ConnectionContext::Accept(AcceptContext {
+                user_id: None,
+                ..accept_context(&peer)
+            }))
+            .is_err()
+        );
+        assert!(
+            with_connection(ConnectionContext::Accept(AcceptContext {
+                friendship_token: None,
+                ..accept_context(&peer)
+            }))
+            .is_err()
+        );
+        // An absent uuid must not decode into the nil user.
+        assert!(
+            with_connection(ConnectionContext::Accept(AcceptContext {
+                user_id: Some(PeerUserId {
+                    uuid: None,
+                    domain: Some("example.com".to_owned()),
+                }),
+                ..accept_context(&peer)
+            }))
+            .is_err()
+        );
+        assert!(
+            with_connection(ConnectionContext::HandleInitiator(HandleInitiatorContext {
+                username: None,
+                friendship_package_ear_key: Some(vec![5; AEAD_KEY_SIZE]),
+                connection_offer_hash: Some(ConnectionOfferHash::from_bytes([6u8; 32])),
+            }))
+            .is_err()
+        );
+        // A context kind this version does not know cannot be installed.
+        assert!(with_connection(ConnectionContext::Unknown).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn seal_param_describes_the_created_group() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let self_group = SelfGroup::new_for_test(create_group(&mut txn, true)?);
+        let created = create_group_with_vc_emulation(&mut txn, false, Some(self_group.group_id()))?;
+        assert!(created.own_leaf_is_virtual_client());
+
+        let param = self_group.seal_group_bootstrap_param(
+            &mut txn,
+            &created,
+            GroupBootstrapCarrier::CreationEcho,
+            None,
+        )?;
+        let blob: GroupBootstrapBlob = PersistenceCodec::from_slice(&param)?;
+        assert!(blob.secret_info().is_some());
+        assert!(blob.encrypted_bootstrap.is_some());
+
+        let payload = group_bootstrap_payload(&created, None);
+        assert_eq!(
+            payload.group_id.as_deref(),
+            Some(created.group_id().as_slice())
+        );
+        assert_eq!(
+            payload.pq_group_id,
+            created.pq_group_id().map(|id| id.as_slice().to_vec())
+        );
+        assert_eq!(
+            payload.group_state_ear_key,
+            Some(secret_bytes(created.group_state_ear_key()))
+        );
+        assert_eq!(
+            payload.identity_link_wrapper_key,
+            Some(secret_bytes(created.identity_link_wrapper_key()))
+        );
+        assert_eq!(payload.connection, None);
+
+        txn.commit().await?;
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -11,15 +11,13 @@ pub(crate) mod debug_info;
 #[allow(dead_code)]
 pub(crate) mod diff;
 pub(crate) mod error;
-// The acting and sibling sides of multi-client group creation land separately
-// and wire these helpers up.
-#[cfg_attr(not(test), expect(dead_code, reason = "not yet wired up"))]
 pub(crate) mod group_bootstrap;
 pub(crate) mod openmls_provider;
 pub(crate) mod persistence;
 pub(crate) mod process;
 pub(crate) mod self_group;
 pub(crate) mod self_group_message_key;
+pub(crate) mod vc_sibling_join;
 
 use apqmls::{
     authentication::{ApqCredentialWithKey, ApqSigner},
@@ -507,6 +505,7 @@ impl Group {
         identity_link_wrapper_key: IdentityLinkWrapperKey,
         group_id: GroupId,
         group_data_bytes: GroupDataBytes,
+        vc_group_id: Option<&GroupId>,
     ) -> Result<(Self, PartialCreateGroupParams)> {
         let provider = AirOpenMlsProvider::new(connection.as_mut());
         let group_state_ear_key = GroupStateEarKey::random()?;
@@ -526,14 +525,23 @@ impl Group {
             signature_key: signer.credential().verifying_key().clone().into(),
         };
 
-        let mls_group = MlsGroup::builder()
+        let leaf_node_extensions = if vc_group_id.is_some() {
+            vc_leaf_node_extensions::<AirComponent>()
+        } else {
+            default_leaf_node_extensions::<AirComponent>()
+        };
+        let mut builder = MlsGroup::builder()
             .with_group_id(group_id.clone())
             .with_capabilities(default_leaf_node_capabilities())
             .with_group_context_extensions(gc_extensions)
-            .with_leaf_node_extensions(default_leaf_node_extensions::<AirComponent>())?
+            .with_leaf_node_extensions(leaf_node_extensions)?
             .sender_ratchet_configuration(default_sender_ratchet_configuration())
             .max_past_epochs(MAX_PAST_EPOCHS)
-            .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY);
+        if let Some(vc_group_id) = vc_group_id {
+            builder = builder.vc_emulation(vc_group_id);
+        }
+        let mls_group = builder
             .build(&provider, signer, credential_with_key)
             .map_err(|e| anyhow!("Error while creating group: {:?}", e))?;
 
@@ -1138,19 +1146,16 @@ impl Group {
         let (mls_group, commit, group_info, encrypted_profile_keys_fallback) = {
             let provider = AirOpenMlsProvider::new(txn.as_mut());
             // Prepare PSK proposal if we have a connection offer hash.
-            let psk_proposal = match connection_offer_hash {
-                Some(co_hash) => {
-                    let psk_value = co_hash.into_bytes();
-                    let psk_id = PreSharedKeyId::new(
+            let psk_proposal = connection_offer_hash
+                .map(|co_hash| {
+                    store_connection_offer_psk(
+                        &provider,
                         verifiable_group_info.ciphersuite(),
-                        provider.rand(),
-                        Psk::External(ExternalPsk::new(psk_value.to_vec())),
-                    )?;
-                    psk_id.store(&provider, &psk_value)?;
-                    Some(PreSharedKeyProposal::new(psk_id))
-                }
-                None => None,
-            };
+                        co_hash,
+                    )
+                    .map(PreSharedKeyProposal::new)
+                })
+                .transpose()?;
 
             let leaf_node_extensions = if vc_group_id.is_some() {
                 vc_leaf_node_extensions::<AirComponent>()
@@ -2673,15 +2678,11 @@ impl Group {
         connection_offer_hash: ConnectionOfferHash,
     ) -> Result<()> {
         let provider = AirOpenMlsProvider::new(connection.as_mut());
-        let psk_value = connection_offer_hash.into_bytes();
-        PreSharedKeyId::new(
+        store_connection_offer_psk(
+            &provider,
             self.mls_group().ciphersuite(),
-            provider.rand(),
-            Psk::External(ExternalPsk::new(
-                connection_offer_hash.into_bytes().to_vec(),
-            )),
-        )?
-        .store(&provider, &psk_value)?;
+            connection_offer_hash,
+        )?;
         Ok(())
     }
 
@@ -2789,6 +2790,23 @@ async fn verify_member_credentials(
         verified.push(credential);
     }
     Ok(verified)
+}
+
+/// Stores the connection-offer PSK, so a commit referencing it can be created
+/// or processed. Returns the id the commit's PSK proposal must carry.
+fn store_connection_offer_psk(
+    provider: &AirOpenMlsProvider<'_>,
+    ciphersuite: openmls::prelude::Ciphersuite,
+    connection_offer_hash: ConnectionOfferHash,
+) -> Result<PreSharedKeyId> {
+    let psk_value = connection_offer_hash.into_bytes();
+    let psk_id = PreSharedKeyId::new(
+        ciphersuite,
+        provider.rand(),
+        Psk::External(ExternalPsk::new(psk_value.to_vec())),
+    )?;
+    psk_id.store(provider, &psk_value)?;
+    Ok(psk_id)
 }
 
 /// Ensure that every user of `room_sate` is a member of `mls_group`.
@@ -3227,6 +3245,7 @@ mod handle_group_not_found_tests {
             IdentityLinkWrapperKey::random()?,
             group_id.clone(),
             GroupDataBytes::from(b"test-group-data".to_vec()),
+            None,
         )?;
         group.store(&mut connection).await?;
 

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -58,6 +58,11 @@ pub struct SelfGroup {
 }
 
 impl SelfGroup {
+    #[cfg(test)]
+    pub(crate) fn new_for_test(group: Group) -> Self {
+        Self { group }
+    }
+
     pub(crate) fn group(&self) -> &Group {
         &self.group
     }
@@ -318,6 +323,9 @@ impl CoreUser {
                     group_data_bytes,
                     safe_aad_components,
                     AirComponent::default_for_self_group(),
+                    // The self group is the emulation group itself, not a
+                    // virtual client of one.
+                    None,
                 )?;
 
                 let user_profile_key = UserProfileKey::load_own(&mut *txn).await?;

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -558,6 +558,7 @@ mod derivation_tests {
             GroupDataBytes::from(b"test-group-data".to_vec()),
             None,
             air_component,
+            None,
         )?;
         Ok(group)
     }

--- a/coreclient/src/groups/vc_sibling_join.rs
+++ b/coreclient/src/groups/vc_sibling_join.rs
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Installing a group that a sibling emulator client of the same virtual
+//! client created or joined via an external commit.
+//!
+//! Both entry points reconstruct the MLS state from the DS epoch snapshot of
+//! the operation's epoch and the shared emulation epoch.
+
+use aircommon::{
+    identifiers::UserId,
+    messages::{client_as::ConnectionOfferHash, client_ds_out::EpochSnapshotIn},
+    mls_group_config::default_mls_group_join_config,
+    time::TimeStamp,
+};
+use airprotos::client::component::AirComponent;
+use anyhow::{Context, Result, bail, ensure};
+use apqmls::{
+    ApqMlsGroup,
+    messages::{ApqRatchetTreeIn, VerifiableApqGroupInfo},
+    validation::validate_apq_session_at_construction,
+};
+use mimi_room_policy::VerifiedRoomState;
+use openmls::{
+    components::vc_derivation_info::EpochId,
+    group::MlsGroup,
+    prelude::{MlsMessageBodyIn, group_info::VerifiableGroupInfo},
+};
+
+use crate::{
+    clients::{api_clients::ApiClients, own_client_info::OwnClientInfo},
+    db::access::WriteDbTransaction,
+    groups::{
+        Group, apq_group::PqGroup, group_bootstrap::GroupBootstrapContents,
+        openmls_provider::AirOpenMlsProvider, store_connection_offer_psk,
+    },
+};
+
+use super::{
+    ensure_room_state_users_are_members, verify_member_credentials, verify_pq_signature_keys,
+};
+
+impl Group {
+    /// Installs a group a sibling emulator client created.
+    ///
+    /// `snapshot` is the DS epoch snapshot of the creation epoch and
+    /// `epoch_id` the emulation epoch the creating sibling derived from.
+    pub(crate) async fn vc_join_at_creation(
+        txn: &mut WriteDbTransaction<'_>,
+        api_clients: &ApiClients,
+        snapshot: EpochSnapshotIn,
+        contents: &GroupBootstrapContents,
+        epoch_id: EpochId,
+        own_user_id: &UserId,
+    ) -> Result<Self> {
+        let EpochSnapshotIn {
+            verifiable_group_info,
+            ratchet_tree_in,
+            room_state,
+            pq,
+            join_commit,
+        } = snapshot;
+        ensure!(
+            join_commit.is_none(),
+            "creation snapshot carries an external commit"
+        );
+        ensure_snapshot_group_ids(
+            &verifiable_group_info,
+            pq.as_ref().map(|pq| &pq.verifiable_group_info),
+            contents,
+        )?;
+
+        let join_config = default_mls_group_join_config();
+        let (mls_group, pq_group) = {
+            let provider = AirOpenMlsProvider::new(txn.as_mut());
+            match pq {
+                Some(pq) => {
+                    let group_info = VerifiableApqGroupInfo::new(
+                        verifiable_group_info,
+                        pq.verifiable_group_info,
+                    );
+                    let ratchet_tree = ApqRatchetTreeIn::new(ratchet_tree_in, pq.ratchet_tree_in);
+                    let (t_group, pq_group) = ApqMlsGroup::vc_join_at_creation(
+                        &provider,
+                        &join_config,
+                        group_info,
+                        Some(ratchet_tree),
+                        epoch_id,
+                    )?
+                    .into_groups();
+                    (t_group, Some(pq_group))
+                }
+                None => (
+                    MlsGroup::vc_join_at_creation(
+                        &provider,
+                        &join_config,
+                        verifiable_group_info,
+                        Some(ratchet_tree_in),
+                        epoch_id,
+                    )?,
+                    None,
+                ),
+            }
+        };
+
+        Self::finish_sibling_join(
+            txn,
+            api_clients,
+            mls_group,
+            pq_group,
+            room_state,
+            contents,
+            own_user_id,
+        )
+        .await
+    }
+
+    /// Installs a group a sibling emulator client joined via an external
+    /// commit, by applying that commit on top of the pre-commit state in
+    /// `snapshot`.
+    ///
+    /// APQ is out of scope for now. The DS proposal allowlist of
+    /// `join_connection_group` rejects the `AppDataUpdate` proposal an APQ
+    /// external commit carries.
+    pub(crate) async fn vc_join_via_sibling_external_commit(
+        txn: &mut WriteDbTransaction<'_>,
+        api_clients: &ApiClients,
+        snapshot: EpochSnapshotIn,
+        contents: &GroupBootstrapContents,
+        epoch_id: EpochId,
+        own_user_id: &UserId,
+        connection_offer_hash: Option<ConnectionOfferHash>,
+    ) -> Result<Self> {
+        let EpochSnapshotIn {
+            verifiable_group_info,
+            ratchet_tree_in,
+            room_state,
+            pq,
+            join_commit,
+        } = snapshot;
+        ensure!(
+            pq.is_none() && contents.pq_group_id.is_none(),
+            "APQ group in a sibling external commit join"
+        );
+        ensure_snapshot_group_ids(&verifiable_group_info, None, contents)?;
+
+        let join_commit = join_commit.context("join snapshot without the accepted commit")?;
+        let MlsMessageBodyIn::PublicMessage(join_commit) = join_commit.extract() else {
+            bail!("the accepted external commit is not a public message");
+        };
+
+        let mls_group = {
+            let provider = AirOpenMlsProvider::new(txn.as_mut());
+            // Only the accepting sibling received the connection offer, so the
+            // PSK its commit references has to be installed from the blob.
+            if let Some(hash) = connection_offer_hash {
+                store_connection_offer_psk(&provider, verifiable_group_info.ciphersuite(), hash)?;
+            }
+
+            let mut staged = MlsGroup::vc_external_commit_join_builder()
+                .with_config(default_mls_group_join_config())
+                .skip_lifetime_validation()
+                .with_ratchet_tree(ratchet_tree_in)
+                .process_commit(&provider, verifiable_group_info, join_commit, epoch_id)?;
+            ensure!(
+                staged.app_data_update_proposals().next().is_none(),
+                "unexpected AppDataUpdate proposal in a connection group external commit"
+            );
+            staged.with_app_data_dictionary_updates(None);
+            staged.into_group(&provider)?
+        };
+
+        Self::finish_sibling_join(
+            txn,
+            api_clients,
+            mls_group,
+            None,
+            room_state,
+            contents,
+            own_user_id,
+        )
+        .await
+    }
+
+    /// Validates and persists the reconstructed group, mirroring what the
+    /// acting client's own join path checks.
+    async fn finish_sibling_join(
+        txn: &mut WriteDbTransaction<'_>,
+        api_clients: &ApiClients,
+        mls_group: MlsGroup,
+        pq_group: Option<MlsGroup>,
+        room_state: VerifiedRoomState,
+        contents: &GroupBootstrapContents,
+        own_user_id: &UserId,
+    ) -> Result<Self> {
+        // A bootstrap never installs the self group. The self group is the
+        // emulation group, which a sibling joins through device linking.
+        ensure!(
+            !AirComponent::is_self_group_context(mls_group.extensions())
+                && !pq_group.as_ref().is_some_and(|pq_group| {
+                    AirComponent::is_self_group_context(pq_group.extensions())
+                }),
+            "group bootstrap for a group flagged as a self group"
+        );
+        ensure!(
+            !OwnClientInfo::is_own_self_group(&mut *txn, mls_group.group_id()).await?,
+            "group bootstrap for our own self group"
+        );
+
+        if let Some(pq_group) = &pq_group {
+            validate_apq_session_at_construction(&mls_group, pq_group, |_, _| true)
+                .context("invalid APQ session")?;
+            verify_pq_signature_keys(&mls_group, pq_group)
+                .context("T and PQ membership is not bound by matching signature keys")?;
+        }
+
+        let credentials = verify_member_credentials(&mut *txn, api_clients, &mls_group, false)
+            .await
+            .context("failed to verify the member credentials")?;
+        ensure_room_state_users_are_members(&room_state, &mls_group)?;
+
+        let now = TimeStamp::now();
+        let group = Self {
+            identity_link_wrapper_key: contents.identity_link_wrapper_key.clone(),
+            group_state_ear_key: contents.group_state_ear_key.clone(),
+            mls_group,
+            room_state,
+            pending_diff: None,
+            self_updated_at: Some(now),
+            pq: pq_group.map(|mls_group| PqGroup {
+                mls_group,
+                self_updated_at: Some(now),
+            }),
+            pending_commit_failed: false,
+            send_message_collision_key: None,
+            own_user_id: own_user_id.clone(),
+        };
+
+        group.store(&mut *txn).await?;
+        for credential in &credentials {
+            credential.store(&mut *txn).await?;
+        }
+
+        Ok(group)
+    }
+}
+
+/// Binds the blob's group ids to the group infos the DS served.
+fn ensure_snapshot_group_ids(
+    group_info: &VerifiableGroupInfo,
+    pq_group_info: Option<&VerifiableGroupInfo>,
+    contents: &GroupBootstrapContents,
+) -> Result<()> {
+    ensure!(
+        group_info.group_id() == &contents.group_id,
+        "group bootstrap and snapshot disagree on the group id"
+    );
+    match (pq_group_info, &contents.pq_group_id) {
+        (Some(pq_group_info), Some(pq_group_id)) => ensure!(
+            pq_group_info.group_id() == pq_group_id,
+            "group bootstrap and snapshot disagree on the pq group id"
+        ),
+        (None, None) => (),
+        (Some(_), None) | (None, Some(_)) => {
+            bail!("group bootstrap and snapshot disagree on whether the group is an APQ group")
+        }
+    }
+    Ok(())
+}

--- a/coreclient/src/job/create_chat.rs
+++ b/coreclient/src/job/create_chat.rs
@@ -13,6 +13,7 @@ use aircommon::{
 };
 use airprotos::client::component::AirComponent;
 use airprotos::client::group::{EncryptedGroupTitle, GroupData, GroupProfile};
+use airprotos::client::group_bootstrap::GroupBootstrapCarrier;
 use anyhow::Context;
 use tracing::error;
 
@@ -20,7 +21,7 @@ use crate::{
     Chat, ChatAttributes, ChatId, ChatMessage, SystemMessage,
     chats::GroupDataExt,
     db::access::WriteConnection,
-    groups::Group,
+    groups::{Group, self_group::SelfGroup},
     job::{Job, JobContext, JobError},
     key_stores::indexed_keys::StorableIndexedKey,
 };
@@ -42,7 +43,7 @@ impl Job for CreateChat {
         self,
         context: &mut JobContext<'_, '_>,
     ) -> Result<ChatId, JobError<Self::DomainError>> {
-        self.execute_internal(context).await
+        Box::pin(self.execute_internal(context)).await
     }
 }
 
@@ -137,10 +138,13 @@ impl CreateChat {
 
         // Create the group. If the query to the DS fails later on, we just
         // clean up the group, so this is repeatable.
-        let (group, chat, partial_params, encrypted_user_profile_key) = db
+        let (group, chat, partial_params, encrypted_user_profile_key, group_bootstrap) = db
             .write()
             .await?
             .with_transaction(async |txn| -> anyhow::Result<_> {
+                let self_group = SelfGroup::load(&mut *txn).await?;
+                let vc_group_id = self_group.as_ref().map(|group| group.group_id());
+
                 let (group, partial_params) = if is_apq {
                     let disable_safe_aad = None;
                     Group::create_apq_group(
@@ -153,6 +157,7 @@ impl CreateChat {
                         group_data_bytes.clone(),
                         disable_safe_aad,
                         AirComponent::default_for_leaf_or_key_package(),
+                        vc_group_id,
                     )?
                 } else {
                     Group::create_group(
@@ -161,6 +166,7 @@ impl CreateChat {
                         identity_link_wrapper_key,
                         group_id,
                         group_data_bytes,
+                        vc_group_id,
                     )?
                 };
 
@@ -172,11 +178,32 @@ impl CreateChat {
 
                 let chat = Chat::new_group_chat(partial_params.group_id.clone(), chat_attributes);
                 chat.store(&mut *txn).await?;
-                Ok((group, chat, partial_params, encrypted_user_profile_key))
+
+                // Group chats carry no connection context. The sibling takes
+                // the chat attributes from the group data extension.
+                let connection = None;
+                let group_bootstrap = match &self_group {
+                    Some(self_group) => Some(self_group.seal_group_bootstrap_param(
+                        txn,
+                        &group,
+                        GroupBootstrapCarrier::CreationEcho,
+                        connection,
+                    )?),
+                    None => None,
+                };
+
+                Ok((
+                    group,
+                    chat,
+                    partial_params,
+                    encrypted_user_profile_key,
+                    group_bootstrap,
+                ))
             })
             .await?;
 
-        let params = partial_params.into_params(client_reference, encrypted_user_profile_key);
+        let mut params = partial_params.into_params(client_reference, encrypted_user_profile_key);
+        params.group_bootstrap = group_bootstrap;
         if let Err(e) = api_client
             .ds_create_group(params, &key_store.signing_key, group.group_state_ear_key())
             .await

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -1824,6 +1824,7 @@ mod tests {
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     None,
                     AirComponent::default_for_self_group(),
+                    None,
                 )?;
                 group.store(&mut *txn).await?;
                 let mut group = VerifiedGroup::new_for_test(group);
@@ -1974,6 +1975,7 @@ mod tests {
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     None,
                     AirComponent::default_for_self_group(),
+                    None,
                 )?;
                 group.store(&mut *txn).await?;
                 let chat =
@@ -2058,6 +2060,7 @@ mod tests {
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     Some(vec![VC_COMPONENT_ID]),
                     AirComponent::default_for_self_group(),
+                    None,
                 )?;
                 group.store(&mut *txn).await?;
 
@@ -2255,6 +2258,7 @@ mod tests {
             identity_link_wrapper_key,
             group_id.clone(),
             group_data_bytes,
+            None,
         )?;
         group.store(&mut connection).await?;
         let group = VerifiedGroup::new_for_test(group);

--- a/coreclient/src/lib.rs
+++ b/coreclient/src/lib.rs
@@ -27,7 +27,6 @@ pub use crate::{
             MessageId, SystemMessage,
         },
         notification_rebuild::ChatNotificationEntry,
-        pending::AcceptContactRequestError,
         reactions::LastReaction,
     },
     clients::{
@@ -54,6 +53,7 @@ pub use crate::{
         ExternalGroupProfileDebugInfo, GroupDataDebugInfo, GroupDebugInfo, PqGroupDebugInfo,
         RequiredDebugCapabilities,
     },
+    outbound_service::connection_accepts::ConnectionAcceptStatus,
     privacy_pass::TokenId,
     user_profiles::{Asset, DisplayName, DisplayNameError, UserProfile},
     usernames::UsernameRecord,

--- a/coreclient/src/outbound_service/connection_accepts.rs
+++ b/coreclient/src/outbound_service/connection_accepts.rs
@@ -1,0 +1,667 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Accepting a connection request as a persistent job.
+//!
+//! Accepting enqueues a row in `connection_accept_queue`. The client externally
+//! joins the connection group and finalizes the accepted state. Transient
+//! failures are retried. The row is removed when the join lands, or when the
+//! chat is deleted. A permanent failure is recorded on the row and pauses the
+//! retries until the user accepts again.
+
+use aircommon::{
+    credentials::LeafCredential,
+    crypto::indexed_aead::keys::UserProfileKey,
+    identifiers::{QualifiedGroupId, UserId},
+    messages::{
+        client_as::ConnectionOfferHash,
+        client_ds::AadMessage,
+        client_ds_out::ExternalCommitInfoIn,
+        connection_package::{ConnectionPackage, ConnectionPackageHash},
+    },
+    time::TimeStamp,
+};
+use airprotos::client::group_bootstrap::{AcceptContext, ConnectionContext, GroupBootstrapCarrier};
+use anyhow::{Context, anyhow, ensure};
+use mimi_room_policy::RoleIndex;
+use openmls::{
+    prelude::MlsMessageOut,
+    treesync::{RatchetTreeIn, errors::LeafNodeValidationError},
+};
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::{
+    Chat, ChatId, ChatType,
+    chats::PendingConnectionInfo,
+    clients::{
+        CoreUser, api_clients::DS_ECHO_RETRY_DELAYS, connection_offer::payload::ConnectionInfo,
+    },
+    groups::{Group, group_bootstrap::secret_bytes, self_group::SelfGroup},
+    key_stores::indexed_keys::StorableIndexedKey,
+    outbound_service::{
+        OutboundServiceContext,
+        error::{OutboundServiceError, classify_ds_error},
+    },
+    usernames::connection_packages::StorableConnectionPackage,
+};
+
+/// A queued connection accept.
+pub(crate) struct ConnectionAccept;
+
+/// State of a queued connection accept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionAcceptStatus {
+    /// Queued or in flight.
+    Pending,
+    /// Failed permanently. Retried only when the user accepts again.
+    Failed { reason: String },
+}
+
+impl CoreUser {
+    /// The state of the queued accept of the given chat's connection request,
+    /// or `None` when no accept is queued.
+    pub async fn connection_accept_status(
+        &self,
+        chat_id: ChatId,
+    ) -> anyhow::Result<Option<ConnectionAcceptStatus>> {
+        Ok(ConnectionAccept::status(self.db().read().await?, chat_id).await?)
+    }
+}
+
+/// The commit joining the connection group, its group info, and the sealed
+/// group bootstrap for sibling clients, if any.
+type JoinMessages = (MlsMessageOut, MlsMessageOut, Option<Vec<u8>>);
+
+/// The pending state an accept operates on.
+struct AcceptData {
+    sender_user_id: UserId,
+    pending_connection_info: PendingConnectionInfo,
+    own_user_profile_key: UserProfileKey,
+}
+
+impl OutboundServiceContext {
+    pub(super) async fn perform_queued_connection_accepts(
+        &self,
+        run_token: &CancellationToken,
+    ) -> anyhow::Result<()> {
+        // Used to identify rows locked by this task
+        let task_id = Uuid::new_v4();
+        loop {
+            if run_token.is_cancelled() {
+                return Ok(()); // the task is being stopped
+            }
+
+            let Some(chat_id) = self
+                .db
+                .with_write_transaction(async |txn| ConnectionAccept::dequeue(txn, task_id).await)
+                .await?
+            else {
+                return Ok(());
+            };
+            info!(%chat_id, "Performing queued connection accept");
+
+            match Box::pin(self.execute_connection_accept(chat_id)).await {
+                Ok(()) => {}
+                Err(OutboundServiceError::Recoverable(error)) => {
+                    info!(%error, "Connection accept did not go through; will retry later");
+                }
+                Err(OutboundServiceError::Fatal(error)) => {
+                    error!(%error, "Connection accept failed permanently");
+                    ConnectionAccept::mark_failed(
+                        self.db.write().await?,
+                        chat_id,
+                        &error.to_string(),
+                    )
+                    .await?;
+                }
+            }
+        }
+    }
+
+    /// Runs one accept attempt.
+    ///
+    /// The attempt is idempotent in case an earlier confirmation was lost and
+    /// the client is actually already a member. Recoverable errors leave the
+    /// queue row in place for a later run.
+    async fn execute_connection_accept(&self, chat_id: ChatId) -> Result<(), OutboundServiceError> {
+        let Some(accept_data) = self.load_accept_data(chat_id).await? else {
+            return Ok(());
+        };
+        let AcceptData {
+            sender_user_id,
+            pending_connection_info,
+            own_user_profile_key,
+        } = accept_data;
+        let PendingConnectionInfo {
+            chat_id: _,
+            created_at: _,
+            connection_info,
+            handle: _,
+            connection_offer_hash,
+            connection_package_hash,
+        } = pending_connection_info;
+
+        let mut eci = self.fetch_connection_group_info(&connection_info).await?;
+        let mut member = tree_contains_user(&eci.ratchet_tree_in, self.user_id());
+
+        // An earlier attempt may have landed on the DS while its confirmation
+        // was lost. The DS then already counts us as a member and would reject
+        // another external commit. A leftover local group marks such an
+        // attempt, so give the DS state a moment to show the join before the
+        // destructive rejoin below.
+        if !member && self.load_local_group(chat_id).await?.is_some() {
+            for delay in DS_ECHO_RETRY_DELAYS {
+                sleep(delay).await;
+                eci = self.fetch_connection_group_info(&connection_info).await?;
+                member = tree_contains_user(&eci.ratchet_tree_in, self.user_id());
+                if member {
+                    break;
+                }
+            }
+        }
+        if member {
+            return self.finalize_landed_join(chat_id, &eci).await;
+        }
+
+        let (aad, qgid) = CoreUser::prepare_group(
+            &self.key_store,
+            self.user_id(),
+            &connection_info,
+            &own_user_profile_key,
+        )
+        .map_err(OutboundServiceError::fatal)?;
+
+        // Join the group with an external commit. A group left over from an
+        // attempt the DS never saw is replaced.
+        let (commit, group_info, group_bootstrap) = self
+            .join_connection_group(
+                chat_id,
+                &sender_user_id,
+                &connection_info,
+                connection_offer_hash,
+                connection_package_hash,
+                aad,
+                eci,
+            )
+            .await?
+            .map_err(|error| {
+                OutboundServiceError::fatal(anyhow!("Incompatible client: {error}"))
+            })?;
+
+        // Send the join to the DS.
+        let api_client = self
+            .api_clients
+            .get(qgid.owning_domain())
+            .map_err(OutboundServiceError::fatal)?;
+        let qs_client_reference = self
+            .key_store
+            .create_own_client_reference(&self.qs_client_id);
+        let response = api_client
+            .ds_join_connection_group(
+                commit,
+                group_info,
+                qs_client_reference,
+                &connection_info.connection_group_ear_key,
+                group_bootstrap,
+            )
+            .await;
+
+        match response {
+            Ok(_) => self
+                .db
+                .with_write_transaction(async |txn| -> anyhow::Result<_> {
+                    CoreUser::finalize_accepted_connection(txn, chat_id, TimeStamp::now()).await
+                })
+                .await
+                .map_err(OutboundServiceError::fatal),
+            // The join stays committed locally. The next attempt sees the
+            // group and either finalizes (if the request landed) or rejoins.
+            Err(error) if error.is_network_error() => Err(OutboundServiceError::recoverable(error)),
+            Err(error) => {
+                // The DS rejected the commit.
+                let eci = self.fetch_connection_group_info(&connection_info).await?;
+                if tree_contains_user(&eci.ratchet_tree_in, self.user_id()) {
+                    self.finalize_landed_join(chat_id, &eci).await
+                } else if error.is_definitive_rejection() {
+                    Err(OutboundServiceError::fatal(error))
+                } else {
+                    // E.g. an internal server error. The commit may go
+                    // through on a retry.
+                    Err(OutboundServiceError::recoverable(error))
+                }
+            }
+        }
+    }
+
+    /// Loads the pending state the accept operates on.
+    ///
+    /// Returns `None` and removes the queue row when the job is orphaned.
+    async fn load_accept_data(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Option<AcceptData>, OutboundServiceError> {
+        self.db
+            .with_write_transaction(async |txn| -> anyhow::Result<_> {
+                let Some(chat) = Chat::load(&mut *txn, &chat_id).await? else {
+                    ConnectionAccept::remove(&mut *txn, chat_id).await?;
+                    return Ok(None);
+                };
+                let ChatType::PendingConnection(sender_user_id) = chat.chat_type() else {
+                    ConnectionAccept::remove(&mut *txn, chat_id).await?;
+                    return Ok(None);
+                };
+                let sender_user_id = sender_user_id.clone();
+
+                let pending_connection_info = PendingConnectionInfo::load(&mut *txn, chat_id)
+                    .await?
+                    .with_context(|| {
+                        format!("No pending connection info found for chat: {chat_id}")
+                    })?;
+
+                // The finalize at the end of the accept needs the partial
+                // contact, so a missing one fails the job up front.
+                CoreUser::load_partial_contact(
+                    &mut *txn,
+                    chat_id,
+                    &pending_connection_info,
+                    &sender_user_id,
+                )
+                .await?;
+
+                let own_user_profile_key = UserProfileKey::load_own(&mut *txn).await?;
+
+                Ok(Some(AcceptData {
+                    sender_user_id,
+                    pending_connection_info,
+                    own_user_profile_key,
+                }))
+            })
+            .await
+            .map_err(OutboundServiceError::fatal)
+    }
+
+    /// Fetches the connection group state from the DS.
+    async fn fetch_connection_group_info(
+        &self,
+        connection_info: &ConnectionInfo,
+    ) -> Result<ExternalCommitInfoIn, OutboundServiceError> {
+        let qgid: QualifiedGroupId = connection_info
+            .connection_group_id
+            .clone()
+            .try_into()
+            .map_err(OutboundServiceError::fatal)?;
+        let api_client = self
+            .api_clients
+            .get(qgid.owning_domain())
+            .map_err(OutboundServiceError::fatal)?;
+        api_client
+            .ds_connection_group_info(
+                connection_info.connection_group_id.clone(),
+                &connection_info.connection_group_ear_key,
+            )
+            .await
+            .map_err(classify_ds_error)
+    }
+
+    /// A group that resulted from an earlier join, if any.
+    async fn load_local_group(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Option<Group>, OutboundServiceError> {
+        let connection = self.db.read().await.map_err(OutboundServiceError::fatal)?;
+        Group::load_with_chat_id(connection, chat_id)
+            .await
+            .map_err(OutboundServiceError::fatal)
+    }
+
+    /// Finalizes the accept, but only when the local group matches the DS group
+    /// state.
+    async fn finalize_landed_join(
+        &self,
+        chat_id: ChatId,
+        eci: &ExternalCommitInfoIn,
+    ) -> Result<(), OutboundServiceError> {
+        let Some(group) = self.load_local_group(chat_id).await? else {
+            return Err(OutboundServiceError::fatal(anyhow!(
+                "the join landed on the DS, but there is no local group. \
+                Recovery requires a resync"
+            )));
+        };
+        let local = group.mls_group().public_group().group_context();
+        let remote = eci.verifiable_group_info.group_context();
+        if local.epoch() < remote.epoch() {
+            return Err(OutboundServiceError::recoverable(anyhow!(
+                "the local group lags behind the DS group state. \
+                Retrying after the queued messages are processed"
+            )));
+        }
+        if local.epoch() > remote.epoch()
+            || local.confirmed_transcript_hash() != remote.confirmed_transcript_hash()
+        {
+            return Err(OutboundServiceError::fatal(anyhow!(
+                "the join landed on the DS, but the local group state does not match. \
+                Recovery requires a resync"
+            )));
+        }
+
+        self.db
+            .with_write_transaction(async |txn| -> anyhow::Result<_> {
+                CoreUser::finalize_accepted_connection(txn, chat_id, TimeStamp::now()).await
+            })
+            .await
+            .map_err(OutboundServiceError::fatal)
+    }
+
+    /// Builds and locally commits the external commit joining the connection
+    /// group, replacing any group left over from an earlier attempt.
+    #[expect(clippy::too_many_arguments)]
+    async fn join_connection_group(
+        &self,
+        chat_id: ChatId,
+        sender_user_id: &UserId,
+        connection_info: &ConnectionInfo,
+        connection_offer_hash: Option<ConnectionOfferHash>,
+        connection_package_hash: Option<ConnectionPackageHash>,
+        aad: AadMessage,
+        eci: ExternalCommitInfoIn,
+    ) -> Result<Result<JoinMessages, LeafNodeValidationError>, OutboundServiceError> {
+        let user_id = self.user_id().clone();
+        Box::pin(self.db.with_write_transaction(
+            async |txn| -> anyhow::Result<Result<JoinMessages, LeafNodeValidationError>> {
+                if let Some(group) = Group::load_with_chat_id(&mut *txn, chat_id).await? {
+                    warn!(%chat_id, "Group for pending chat already exists");
+                    Group::delete_from_db(txn, group.group_id()).await?;
+                    if let Some(hash) = connection_offer_hash {
+                        Group::delete_connection_offer_psk(&mut *txn, hash)?;
+                    }
+                }
+
+                let self_group = SelfGroup::load(&mut *txn).await?;
+                let vc_group_id = self_group.as_ref().map(|group| group.group_id().clone());
+
+                // Join group
+                let res = Group::join_group_externally(
+                    txn,
+                    &self.api_clients,
+                    eci,
+                    self.signing_key(),
+                    connection_info.connection_group_ear_key.clone(),
+                    connection_info
+                        .connection_group_identity_link_wrapper_key
+                        .clone(),
+                    aad,
+                    connection_offer_hash,
+                    vc_group_id,
+                )
+                .await?;
+                let (mut group, commit, group_info, mut member_profile_info) = match res {
+                    Ok(value) => value,
+                    Err(error) => return Ok(Err(error)),
+                };
+
+                // Verify that the group has only one other member and that it's
+                // the sender of the CEP.
+                let members: Vec<_> = group.members().collect();
+
+                ensure!(
+                    members.len() == 2,
+                    "Connection group has more than two members: {:?}",
+                    members
+                );
+
+                ensure!(
+                    members.contains(&user_id) && members.contains(sender_user_id),
+                    "Connection group has unexpected members: {:?}",
+                    members
+                );
+
+                // There should be only one user profile
+                let contact_profile_info = member_profile_info
+                    .members
+                    .pop()
+                    .context("No user profile returned when joining connection group")?;
+
+                debug_assert!(
+                    member_profile_info.members.is_empty(),
+                    "More than one user profile returned when joining connection group"
+                );
+
+                // Fetch and store user profile
+                CoreUser::schedule_fetch_user_profile(&mut *txn, contact_profile_info).await?;
+
+                group.room_state_change_role(sender_user_id, &user_id, RoleIndex::Regular)?;
+
+                let now = TimeStamp::now();
+                group.store_update(&mut *txn, Some(now), Some(now)).await?;
+
+                if let Some(hash) = connection_package_hash {
+                    // Delete the connection package if it's not last resort
+                    let is_last_resort =
+                        <ConnectionPackage as StorableConnectionPackage>::is_last_resort(
+                            &mut *txn, &hash,
+                        )
+                        .await?
+                        .unwrap_or(false);
+                    if !is_last_resort {
+                        ConnectionPackage::delete(&mut *txn, &hash)
+                            .await
+                            .context("Failed to delete connection package")?;
+                    }
+                }
+
+                let group_bootstrap = match &self_group {
+                    Some(self_group) => {
+                        let friendship_package = &connection_info.friendship_package;
+                        let connection = ConnectionContext::Accept(AcceptContext {
+                            user_id: Some(sender_user_id.clone().into()),
+                            friendship_token: Some(friendship_package.friendship_token.clone()),
+                            wai_ear_key: Some(secret_bytes(&friendship_package.wai_ear_key)),
+                            user_profile_base_secret: Some(secret_bytes(
+                                &friendship_package.user_profile_base_secret,
+                            )),
+                            connection_offer_hash,
+                        });
+                        Some(self_group.seal_group_bootstrap_param(
+                            txn,
+                            &group,
+                            GroupBootstrapCarrier::JoinEcho,
+                            Some(connection),
+                        )?)
+                    }
+                    None => None,
+                };
+
+                Ok(Ok((commit, group_info, group_bootstrap)))
+            },
+        ))
+        .await
+        .map_err(OutboundServiceError::fatal)
+    }
+}
+
+/// Whether the ratchet tree contains a leaf carrying `user_id`'s credential.
+fn tree_contains_user(ratchet_tree: &RatchetTreeIn, user_id: &UserId) -> bool {
+    ratchet_tree.leaves().any(|leaf| {
+        LeafCredential::from_credential(leaf.credential())
+            .ok()
+            .and_then(LeafCredential::into_user)
+            .is_some_and(|credential| credential.user_id() == user_id)
+    })
+}
+
+mod persistence {
+    use sqlx::{query, query_scalar};
+
+    use crate::db::access::{ReadConnection, WriteConnection, WriteDbTransaction};
+
+    use super::*;
+
+    impl ConnectionAccept {
+        /// Enqueues the accept of the given chat's connection request.
+        ///
+        /// An existing accept that permanently failed in the past will be
+        /// retried.
+        pub(crate) async fn enqueue(
+            mut connection: impl WriteConnection,
+            chat_id: ChatId,
+        ) -> sqlx::Result<()> {
+            query!(
+                "INSERT INTO connection_accept_queue (chat_id) VALUES (?1)
+                ON CONFLICT (chat_id) DO UPDATE SET failed_reason = NULL",
+                chat_id,
+            )
+            .execute(connection.as_mut())
+            .await?;
+            connection.notifier().update(chat_id);
+            Ok(())
+        }
+
+        /// Dequeues an accept for processing that is not failed and has not
+        /// been locked by this task.
+        pub(super) async fn dequeue(
+            txn: &mut WriteDbTransaction<'_>,
+            task_id: Uuid,
+        ) -> sqlx::Result<Option<ChatId>> {
+            query_scalar!(
+                r#"UPDATE connection_accept_queue
+                SET locked_by = ?1
+                WHERE chat_id = (
+                    SELECT chat_id
+                    FROM connection_accept_queue
+                    WHERE failed_reason IS NULL
+                        AND (locked_by IS NULL OR locked_by != ?1)
+                    LIMIT 1
+                )
+                RETURNING chat_id AS "chat_id: ChatId""#,
+                task_id,
+            )
+            .fetch_optional(txn.as_mut())
+            .await
+        }
+
+        pub(super) async fn mark_failed(
+            mut connection: impl WriteConnection,
+            chat_id: ChatId,
+            reason: &str,
+        ) -> sqlx::Result<()> {
+            query!(
+                "UPDATE connection_accept_queue SET failed_reason = ?2 WHERE chat_id = ?1",
+                chat_id,
+                reason,
+            )
+            .execute(connection.as_mut())
+            .await?;
+            connection.notifier().update(chat_id);
+            Ok(())
+        }
+
+        pub(crate) async fn remove(
+            mut connection: impl WriteConnection,
+            chat_id: ChatId,
+        ) -> sqlx::Result<()> {
+            query!(
+                "DELETE FROM connection_accept_queue WHERE chat_id = ?",
+                chat_id
+            )
+            .execute(connection.as_mut())
+            .await?;
+            connection.notifier().update(chat_id);
+            Ok(())
+        }
+
+        pub(crate) async fn status(
+            mut connection: impl ReadConnection,
+            chat_id: ChatId,
+        ) -> sqlx::Result<Option<ConnectionAcceptStatus>> {
+            let row = query!(
+                "SELECT failed_reason FROM connection_accept_queue WHERE chat_id = ?",
+                chat_id
+            )
+            .fetch_optional(connection.as_mut())
+            .await?;
+            Ok(row.map(|row| match row.failed_reason {
+                Some(reason) => ConnectionAcceptStatus::Failed { reason },
+                None => ConnectionAcceptStatus::Pending,
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use crate::{
+        chats::persistence::tests::test_chat,
+        db::access::{DbAccess, WriteConnection},
+    };
+
+    use super::*;
+
+    #[sqlx::test]
+    async fn enqueue_dequeue_fail_rearm_remove(pool: SqlitePool) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let chat = test_chat();
+        chat.store(&mut txn).await?;
+        let chat_id = chat.id();
+
+        assert_eq!(ConnectionAccept::status(&mut txn, chat_id).await?, None);
+
+        ConnectionAccept::enqueue(&mut txn, chat_id).await?;
+        assert_eq!(
+            ConnectionAccept::status(&mut txn, chat_id).await?,
+            Some(ConnectionAcceptStatus::Pending)
+        );
+
+        // A row locked by this task is not dequeued again.
+        let task_id = Uuid::new_v4();
+        assert_eq!(
+            ConnectionAccept::dequeue(&mut txn, task_id).await?,
+            Some(chat_id)
+        );
+        assert_eq!(ConnectionAccept::dequeue(&mut txn, task_id).await?, None);
+
+        // A new task dequeues it again.
+        let other_task_id = Uuid::new_v4();
+        assert_eq!(
+            ConnectionAccept::dequeue(&mut txn, other_task_id).await?,
+            Some(chat_id)
+        );
+
+        // A failed row is not dequeued, but stays visible.
+        ConnectionAccept::mark_failed(&mut txn, chat_id, "boom").await?;
+        assert_eq!(
+            ConnectionAccept::dequeue(&mut txn, Uuid::new_v4()).await?,
+            None
+        );
+        assert_eq!(
+            ConnectionAccept::status(&mut txn, chat_id).await?,
+            Some(ConnectionAcceptStatus::Failed {
+                reason: "boom".to_owned()
+            })
+        );
+
+        // Re-accepting re-arms the job.
+        ConnectionAccept::enqueue(&mut txn, chat_id).await?;
+        assert_eq!(
+            ConnectionAccept::status(&mut txn, chat_id).await?,
+            Some(ConnectionAcceptStatus::Pending)
+        );
+        assert_eq!(
+            ConnectionAccept::dequeue(&mut txn, Uuid::new_v4()).await?,
+            Some(chat_id)
+        );
+
+        ConnectionAccept::remove(&mut txn, chat_id).await?;
+        assert_eq!(ConnectionAccept::status(&mut txn, chat_id).await?, None);
+
+        Ok(())
+    }
+}

--- a/coreclient/src/outbound_service/mod.rs
+++ b/coreclient/src/outbound_service/mod.rs
@@ -33,6 +33,7 @@ pub use timed_tasks::{APQ_KEY_PACKAGES, KEY_PACKAGES};
 mod attachment_recovery;
 pub(crate) mod chat_message_queue;
 mod chat_messages;
+pub(crate) mod connection_accepts;
 mod error;
 mod key_packages;
 mod profile;
@@ -193,6 +194,12 @@ impl<C: OutboundServiceWork> OutboundService<C> {
         self.notify_work()
     }
 
+    /// Wakes the outbound service to perform a freshly enqueued connection
+    /// accept.
+    pub(crate) fn notify_connection_accepts(&self) -> WaitForDoneFuture {
+        self.notify_work()
+    }
+
     /// Runs the background task and waits until it is done.
     ///
     /// If the background is already running, just waits until it is done.
@@ -315,6 +322,9 @@ impl OutboundServiceContext {
 
         if let Err(error) = self.perform_queued_resyncs(&run_token).await {
             error!(%error, "Failed to perform queued resyncs");
+        }
+        if let Err(error) = Box::pin(self.perform_queued_connection_accepts(&run_token)).await {
+            error!(%error, "Failed to perform queued connection accepts");
         }
         match Box::pin(self.send_pending_chat_operations(&run_token)).await {
             Err(OutboundServiceRunError::NetworkError) => {

--- a/coreclient/src/outbound_service/resync.rs
+++ b/coreclient/src/outbound_service/resync.rs
@@ -9,7 +9,6 @@ use aircommon::{
     messages::{client_ds::AadPayload, client_ds_out::ExternalCommitInfoIn},
     time::TimeStamp,
 };
-use airprotos::client::group::GroupData;
 use anyhow::{Context, Result, anyhow, bail};
 use apqmls::commit_builder::ApqCommitMessageBundle;
 use openmls::{
@@ -22,7 +21,6 @@ use uuid::Uuid;
 
 use crate::{
     Chat, ChatId, ChatMessage, ChatStatus, Contact, SystemMessage,
-    chats::{ChatAttributes, GroupDataExt},
     clients::{
         CoreUser,
         api_clients::ApiClients,
@@ -350,25 +348,11 @@ impl Resync {
         own_user_id: &UserId,
         ds_timestamp: TimeStamp,
     ) -> Result<ChatId> {
-        let group_data_bytes = group.group_data().context("No group data")?;
-        let group_data = GroupData::decode(&group_data_bytes)?;
-        let (title, group_profile_part) = group_data.into_parts(group.identity_link_wrapper_key());
-        let title = title.context("No group title")?;
+        let attributes =
+            CoreUser::chat_attributes_from_group_data(&mut *txn, group, own_user_id, ds_timestamp)
+                .await?;
 
-        let picture = CoreUser::resolve_group_profile_part(
-            &mut *txn,
-            group.group_id(),
-            own_user_id,
-            ds_timestamp,
-            group_profile_part,
-            true,
-        )
-        .await?;
-
-        let chat = Chat::new_pending_group_chat(
-            group.group_id().clone(),
-            ChatAttributes { title, picture },
-        );
+        let chat = Chat::new_pending_group_chat(group.group_id().clone(), attributes);
         chat.store(&mut *txn).await?;
 
         Ok(chat.id())

--- a/protos/src/client/group_bootstrap.rs
+++ b/protos/src/client/group_bootstrap.rs
@@ -255,7 +255,7 @@ pub enum ConnectionContext {
     TargetedInitiator(TargetedInitiatorContext),
     #[tag(3)]
     Accept(AcceptContext),
-    /// A context kind this client does not understand. Ignored on receive.
+    /// A context kind this client does not understand. Rejected on receive.
     #[unknown]
     Unknown,
 }

--- a/server/tests/tests/connection.rs
+++ b/server/tests/tests/connection.rs
@@ -75,12 +75,13 @@ async fn connect_users_via_targeted_message() {
         "Charlie should process Bob's targeted message without errors"
     );
 
-    // Charlie accepts the connection request
+    // Charlie accepts the connection request. The accept is queued and
+    // performed by the outbound service.
     charlie_user
         .accept_contact_request(bob_chat_id)
         .await
-        .unwrap()
         .unwrap();
+    charlie_user.outbound_service().run_once().await;
 
     // Charlie should have two messages in the new chat
     let charlie_chat_id = result.new_connections.pop().unwrap();

--- a/server/tests/tests/user.rs
+++ b/server/tests/tests/user.rs
@@ -549,11 +549,12 @@ async fn add_contact_and_change_profile() {
         .process_username_queue_message(alice_username_record.username, messages.pop().unwrap())
         .await
         .unwrap();
+    // The accept is queued and performed by the outbound service.
     alice_user
         .accept_contact_request(alice_bob_chat_id)
         .await
-        .unwrap()
         .unwrap();
+    alice_user.outbound_service().run_once().await;
 
     // Send message from Alice to Bob
     alice_user

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -575,12 +575,10 @@ impl TestBackend {
             responder.ack(message_id.into()).await;
         }
 
-        // Users accepts the connection request
-        user2
-            .accept_contact_request(chat.id())
-            .await
-            .unwrap()
-            .unwrap();
+        // Users accepts the connection request. The accept is queued and
+        // performed by the outbound service.
+        user2.accept_contact_request(chat.id()).await.unwrap();
+        user2.outbound_service().run_once().await;
         let mut user2_contacts_after = user2.contacts().await.unwrap();
         info!("User 2 contacts after: {:?}", user2_contacts_after);
         let user2_username_contacts_before = user2.username_contacts().await.unwrap();


### PR DESCRIPTION
This PR is based on the multi-client group creation and external join stack of PRs.

It makes accepting a connection request a persisted job and generally increases robustness. If a user taps "accept" on a conenction request, a job is spawned that deals with retries and DS errors during connection acceptance. Tapping "accept" is thus also made idempotent while that job has not hit a fatal error. If that happens, tapping "accept" re-creates the job.

When the DS receives a connection group join, it also fans out an echo into the queue of the sender, which the sender interprets as confirmation. This is to ensure that the clients are not stranded if they miss the servers HTTP response.