### PR TITLE
feat(app, server): warn clients ahead of version expiry

### DIFF
--- a/app/lib/core/api/user_cubit.dart
+++ b/app/lib/core/api/user_cubit.dart
@@ -11,13 +11,15 @@ import 'chats_data_source.dart';
 import 'notification_context.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'package:uuid/uuid.dart';
 import 'types.dart';
 import 'user.dart';
+part 'user_cubit.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `core_user`, `emit_stored_notifications`, `new`, `notification_service`, `reload_account_unlinked`, `show_notifications`, `spawn_emit_stored_notifications`, `spawn_load`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `CubitContext`, `UiUserInner`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `drop`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `drop`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 class intArray12 extends NonGrowableListView<int> {
   static const arraySize = 12;
@@ -35,11 +37,12 @@ class intArray12 extends NonGrowableListView<int> {
 abstract class UiUser implements RustOpaqueInterface {
   bool get accountUnlinked;
 
-  bool get unsupportedVersion;
-
   UiUserId get userId;
 
   List<UiUsername> get usernames;
+
+  /// Return the status of the client version communicated by the server.
+  VersionStatus get versionStatus;
 }
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserCubitBase>>
@@ -123,3 +126,18 @@ abstract class UserCubitBase implements RustOpaqueInterface {
 }
 
 enum AppState { mobileBackground, desktopBackground, foreground }
+
+@freezed
+sealed class VersionStatus with _$VersionStatus {
+  const VersionStatus._();
+
+  /// No expiration is announced by the server.
+  const factory VersionStatus.supported() = VersionStatus_Supported;
+
+  /// Server rejects this version.
+  const factory VersionStatus.unsupported() = VersionStatus_Unsupported;
+
+  /// The server announced that the version stops being accepted at this time.
+  const factory VersionStatus.expiresAt(DateTime field0) =
+      VersionStatus_ExpiresAt;
+}

--- a/app/lib/core/api/user_cubit.freezed.dart
+++ b/app/lib/core/api/user_cubit.freezed.dart
@@ -1,0 +1,175 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$VersionStatus {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VersionStatus);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'VersionStatus()';
+}
+
+
+}
+
+/// @nodoc
+class $VersionStatusCopyWith<$Res>  {
+$VersionStatusCopyWith(VersionStatus _, $Res Function(VersionStatus) __);
+}
+
+
+
+/// @nodoc
+
+
+class VersionStatus_Supported extends VersionStatus {
+  const VersionStatus_Supported(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VersionStatus_Supported);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'VersionStatus.supported()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class VersionStatus_Unsupported extends VersionStatus {
+  const VersionStatus_Unsupported(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VersionStatus_Unsupported);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'VersionStatus.unsupported()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class VersionStatus_ExpiresAt extends VersionStatus {
+  const VersionStatus_ExpiresAt(this.field0): super._();
+  
+
+ final  DateTime field0;
+
+/// Create a copy of VersionStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VersionStatus_ExpiresAtCopyWith<VersionStatus_ExpiresAt> get copyWith => _$VersionStatus_ExpiresAtCopyWithImpl<VersionStatus_ExpiresAt>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VersionStatus_ExpiresAt&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'VersionStatus.expiresAt(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VersionStatus_ExpiresAtCopyWith<$Res> implements $VersionStatusCopyWith<$Res> {
+  factory $VersionStatus_ExpiresAtCopyWith(VersionStatus_ExpiresAt value, $Res Function(VersionStatus_ExpiresAt) _then) = _$VersionStatus_ExpiresAtCopyWithImpl;
+@useResult
+$Res call({
+ DateTime field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$VersionStatus_ExpiresAtCopyWithImpl<$Res>
+    implements $VersionStatus_ExpiresAtCopyWith<$Res> {
+  _$VersionStatus_ExpiresAtCopyWithImpl(this._self, this._then);
+
+  final VersionStatus_ExpiresAt _self;
+  final $Res Function(VersionStatus_ExpiresAt) _then;
+
+/// Create a copy of VersionStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(VersionStatus_ExpiresAt(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/app/lib/core/api/user_settings_cubit.dart
+++ b/app/lib/core/api/user_settings_cubit.dart
@@ -13,8 +13,8 @@ import 'user.dart';
 part 'user_settings_cubit.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `f64_decode`, `f64_encode`, `reload_read_receipts`, `settings_listener`, `subscribe`
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DefaultEmojiSkinToneSetting`, `InterfaceScaleSetting`, `LocaleSetting`, `SendOnEnterSetting`, `SidebarWidthSetting`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `decode`, `decode`, `decode`, `decode`, `decode`, `encode`, `encode`, `encode`, `encode`, `encode`, `fmt`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DefaultEmojiSkinToneSetting`, `DismissedVersionExpirySetting`, `InterfaceScaleSetting`, `LocaleSetting`, `SendOnEnterSetting`, `SidebarWidthSetting`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `decode`, `decode`, `decode`, `decode`, `decode`, `decode`, `encode`, `encode`, `encode`, `encode`, `encode`, `encode`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `default`
 
 /// Loads the persisted user settings. Missing rows keep the defaults.
@@ -42,6 +42,8 @@ abstract class UserSettingsCubitBase implements RustOpaqueInterface {
   Future<void> setDefaultEmojiSkinTone({required int value});
 
   Future<void> setDeveloperMode({required bool value});
+
+  Future<void> setDismissedVersionExpiry({required DateTime value});
 
   Future<void> setExperimentalFeatures({required bool value});
 
@@ -71,5 +73,6 @@ sealed class UserSettings with _$UserSettings {
     @Default(false) bool developerMode,
     @Default(false) bool experimentalFeatures,
     @Default(0) int defaultEmojiSkinTone,
+    DateTime? dismissedVersionExpiry,
   }) = _UserSettings;
 }

--- a/app/lib/core/api/user_settings_cubit.freezed.dart
+++ b/app/lib/core/api/user_settings_cubit.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserSettings {
 
- String? get locale; double? get interfaceScale; double get sidebarWidth; bool get sendOnEnter; bool get readReceipts; bool get developerMode; bool get experimentalFeatures; int get defaultEmojiSkinTone;
+ String? get locale; double? get interfaceScale; double get sidebarWidth; bool get sendOnEnter; bool get readReceipts; bool get developerMode; bool get experimentalFeatures; int get defaultEmojiSkinTone; DateTime? get dismissedVersionExpiry;
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $UserSettingsCopyWith<UserSettings> get copyWith => _$UserSettingsCopyWithImpl<U
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, dismissedVersionExpiry) || other.dismissedVersionExpiry == dismissedVersionExpiry));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone);
+int get hashCode => Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone,dismissedVersionExpiry);
 
 @override
 String toString() {
-  return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone)';
+  return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone, dismissedVersionExpiry: $dismissedVersionExpiry)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $UserSettingsCopyWith<$Res>  {
   factory $UserSettingsCopyWith(UserSettings value, $Res Function(UserSettings) _then) = _$UserSettingsCopyWithImpl;
 @useResult
 $Res call({
- String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone
+ String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
 });
 
 
@@ -62,7 +62,7 @@ class _$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
   return _then(_self.copyWith(
 locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as String?,interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
@@ -72,7 +72,8 @@ as bool,readReceipts: null == readReceipts ? _self.readReceipts : readReceipts /
 as bool,developerMode: null == developerMode ? _self.developerMode : developerMode // ignore: cast_nullable_to_non_nullable
 as bool,experimentalFeatures: null == experimentalFeatures ? _self.experimentalFeatures : experimentalFeatures // ignore: cast_nullable_to_non_nullable
 as bool,defaultEmojiSkinTone: null == defaultEmojiSkinTone ? _self.defaultEmojiSkinTone : defaultEmojiSkinTone // ignore: cast_nullable_to_non_nullable
-as int,
+as int,dismissedVersionExpiry: freezed == dismissedVersionExpiry ? _self.dismissedVersionExpiry : dismissedVersionExpiry // ignore: cast_nullable_to_non_nullable
+as DateTime?,
   ));
 }
 
@@ -84,7 +85,7 @@ as int,
 
 
 class _UserSettings implements UserSettings {
-  const _UserSettings({this.locale, this.interfaceScale, this.sidebarWidth = 240.0, this.sendOnEnter = false, this.readReceipts = true, this.developerMode = false, this.experimentalFeatures = false, this.defaultEmojiSkinTone = 0});
+  const _UserSettings({this.locale, this.interfaceScale, this.sidebarWidth = 240.0, this.sendOnEnter = false, this.readReceipts = true, this.developerMode = false, this.experimentalFeatures = false, this.defaultEmojiSkinTone = 0, this.dismissedVersionExpiry});
   
 
 @override final  String? locale;
@@ -95,6 +96,7 @@ class _UserSettings implements UserSettings {
 @override@JsonKey() final  bool developerMode;
 @override@JsonKey() final  bool experimentalFeatures;
 @override@JsonKey() final  int defaultEmojiSkinTone;
+@override final  DateTime? dismissedVersionExpiry;
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
@@ -106,16 +108,16 @@ _$UserSettingsCopyWith<_UserSettings> get copyWith => __$UserSettingsCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, dismissedVersionExpiry) || other.dismissedVersionExpiry == dismissedVersionExpiry));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone);
+int get hashCode => Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone,dismissedVersionExpiry);
 
 @override
 String toString() {
-  return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone)';
+  return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone, dismissedVersionExpiry: $dismissedVersionExpiry)';
 }
 
 
@@ -126,7 +128,7 @@ abstract mixin class _$UserSettingsCopyWith<$Res> implements $UserSettingsCopyWi
   factory _$UserSettingsCopyWith(_UserSettings value, $Res Function(_UserSettings) _then) = __$UserSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone
+ String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
 });
 
 
@@ -143,7 +145,7 @@ class __$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
   return _then(_UserSettings(
 locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as String?,interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
@@ -153,7 +155,8 @@ as bool,readReceipts: null == readReceipts ? _self.readReceipts : readReceipts /
 as bool,developerMode: null == developerMode ? _self.developerMode : developerMode // ignore: cast_nullable_to_non_nullable
 as bool,experimentalFeatures: null == experimentalFeatures ? _self.experimentalFeatures : experimentalFeatures // ignore: cast_nullable_to_non_nullable
 as bool,defaultEmojiSkinTone: null == defaultEmojiSkinTone ? _self.defaultEmojiSkinTone : defaultEmojiSkinTone // ignore: cast_nullable_to_non_nullable
-as int,
+as int,dismissedVersionExpiry: freezed == dismissedVersionExpiry ? _self.dismissedVersionExpiry : dismissedVersionExpiry // ignore: cast_nullable_to_non_nullable
+as DateTime?,
   ));
 }
 

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -93,7 +93,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -137990403;
+  int get rustContentHash => 1410455381;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -537,11 +537,11 @@ abstract class RustLibApi extends BaseApi {
 
   bool crateApiUserCubitUiUserAccountUnlinked({required UiUser that});
 
-  bool crateApiUserCubitUiUserUnsupportedVersion({required UiUser that});
-
   UiUserId crateApiUserCubitUiUserUserId({required UiUser that});
 
   List<UiUsername> crateApiUserCubitUiUserUsernames({required UiUser that});
+
+  VersionStatus crateApiUserCubitUiUserVersionStatus({required UiUser that});
 
   Future<ChatId> crateApiUserCubitUserCubitBaseAddContactFromGroup({
     required UserCubitBase that,
@@ -4570,35 +4570,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  bool crateApiUserCubitUiUserUnsupportedVersion({required UiUser that}) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiUser(
-            that,
-            serializer,
-          );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_bool,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateApiUserCubitUiUserUnsupportedVersionConstMeta,
-        argValues: [that],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiUserCubitUiUserUnsupportedVersionConstMeta =>
-      const TaskConstMeta(
-        debugName: "UiUser_unsupported_version",
-        argNames: ["that"],
-      );
-
-  @override
   UiUserId crateApiUserCubitUiUserUserId({required UiUser that}) {
     return handler.executeSync(
       SyncTask(
@@ -4608,7 +4579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_ui_user_id,
@@ -4634,7 +4605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_ui_username,
@@ -4649,6 +4620,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiUserCubitUiUserUsernamesConstMeta =>
       const TaskConstMeta(debugName: "UiUser_usernames", argNames: ["that"]);
+
+  @override
+  VersionStatus crateApiUserCubitUiUserVersionStatus({required UiUser that}) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUiUser(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_version_status,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiUserCubitUiUserVersionStatusConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiUserCubitUiUserVersionStatusConstMeta =>
+      const TaskConstMeta(
+        debugName: "UiUser_version_status",
+        argNames: ["that"],
+      );
 
   @override
   Future<ChatId> crateApiUserCubitUserCubitBaseAddContactFromGroup({
@@ -11555,6 +11555,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  VersionStatus dco_decode_version_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return VersionStatus_Supported();
+      case 1:
+        return VersionStatus_Unsupported();
+      case 2:
+        return VersionStatus_ExpiresAt(dco_decode_Chrono_Utc(raw[1]));
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_String(deserializer);
@@ -15641,6 +15656,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BigInt sse_decode_usize(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getBigUint64();
+  }
+
+  @protected
+  VersionStatus sse_decode_version_status(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return VersionStatus_Supported();
+      case 1:
+        return VersionStatus_Unsupported();
+      case 2:
+        var var_field0 = sse_decode_Chrono_Utc(deserializer);
+        return VersionStatus_ExpiresAt(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -19769,6 +19802,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putBigUint64(self);
   }
+
+  @protected
+  void sse_encode_version_status(VersionStatus self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case VersionStatus_Supported():
+        sse_encode_i_32(0, serializer);
+      case VersionStatus_Unsupported():
+        sse_encode_i_32(1, serializer);
+      case VersionStatus_ExpiresAt(field0: final field0):
+        sse_encode_i_32(2, serializer);
+        sse_encode_Chrono_Utc(field0, serializer);
+    }
+  }
 }
 
 @sealed
@@ -20638,14 +20685,15 @@ class UiUserImpl extends RustOpaque implements UiUser {
   bool get accountUnlinked =>
       RustLib.instance.api.crateApiUserCubitUiUserAccountUnlinked(that: this);
 
-  bool get unsupportedVersion => RustLib.instance.api
-      .crateApiUserCubitUiUserUnsupportedVersion(that: this);
-
   UiUserId get userId =>
       RustLib.instance.api.crateApiUserCubitUiUserUserId(that: this);
 
   List<UiUsername> get usernames =>
       RustLib.instance.api.crateApiUserCubitUiUserUsernames(that: this);
+
+  /// Return the status of the client version communicated by the server.
+  VersionStatus get versionStatus =>
+      RustLib.instance.api.crateApiUserCubitUiUserVersionStatus(that: this);
 }
 
 @sealed

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -93,7 +93,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1410455381;
+  int get rustContentHash => -452056076;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -691,6 +691,12 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiUserSettingsCubitUserSettingsCubitBaseSetDeveloperMode({
     required UserSettingsCubitBase that,
     required bool value,
+  });
+
+  Future<void>
+  crateApiUserSettingsCubitUserSettingsCubitBaseSetDismissedVersionExpiry({
+    required UserSettingsCubitBase that,
+    required DateTime value,
   });
 
   Future<void>
@@ -5840,6 +5846,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   Future<void>
+  crateApiUserSettingsCubitUserSettingsCubitBaseSetDismissedVersionExpiry({
+    required UserSettingsCubitBase that,
+    required DateTime value,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUserSettingsCubitBase(
+            that,
+            serializer,
+          );
+          sse_encode_Chrono_Utc(value, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 126,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta:
+            kCrateApiUserSettingsCubitUserSettingsCubitBaseSetDismissedVersionExpiryConstMeta,
+        argValues: [that, value],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiUserSettingsCubitUserSettingsCubitBaseSetDismissedVersionExpiryConstMeta =>
+      const TaskConstMeta(
+        debugName: "UserSettingsCubitBase_set_dismissed_version_expiry",
+        argNames: ["that", "value"],
+      );
+
+  @override
+  Future<void>
   crateApiUserSettingsCubitUserSettingsCubitBaseSetExperimentalFeatures({
     required UserSettingsCubitBase that,
     required bool value,
@@ -5856,7 +5903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 127,
             port: port_,
           );
         },
@@ -5896,7 +5943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 128,
             port: port_,
           );
         },
@@ -5936,7 +5983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 129,
             port: port_,
           );
         },
@@ -5976,7 +6023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6016,7 +6063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6056,7 +6103,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6094,7 +6141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
           )!;
         },
         codec: SseCodec(
@@ -6134,7 +6181,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 133,
+              funcId: 134,
               port: port_,
             );
           },
@@ -6172,7 +6219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
           )!;
         },
         codec: SseCodec(
@@ -6205,7 +6252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
             port: port_,
           );
         },
@@ -6240,7 +6287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6273,7 +6320,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
             port: port_,
           );
         },
@@ -6304,7 +6351,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -6348,7 +6395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -6396,7 +6443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -6430,7 +6477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
           )!;
         },
         codec: SseCodec(
@@ -6467,7 +6514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -6505,7 +6552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -6539,7 +6586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
             port: port_,
           );
         },
@@ -6573,7 +6620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
           )!;
         },
         codec: SseCodec(
@@ -6605,7 +6652,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -6641,7 +6688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
           )!;
         },
         codec: SseCodec(
@@ -6676,7 +6723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -6712,7 +6759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
           )!;
         },
         codec: SseCodec(
@@ -6754,7 +6801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 150,
+              funcId: 151,
               port: port_,
             );
           },
@@ -6794,7 +6841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
           )!;
         },
         codec: SseCodec(
@@ -6831,7 +6878,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
           )!;
         },
         codec: SseCodec(
@@ -6868,7 +6915,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 154,
           )!;
         },
         codec: SseCodec(
@@ -6897,7 +6944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
             port: port_,
           );
         },
@@ -6932,7 +6979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
             port: port_,
           );
         },
@@ -6962,7 +7009,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
             port: port_,
           );
         },
@@ -6990,7 +7037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7025,7 +7072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7058,7 +7105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 159,
+              funcId: 160,
               port: port_,
             );
           },
@@ -7097,7 +7144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7128,7 +7175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7158,7 +7205,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -7189,7 +7236,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 164,
           )!;
         },
         codec: SseCodec(
@@ -7219,7 +7266,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
           )!;
         },
         codec: SseCodec(
@@ -7250,7 +7297,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -7283,7 +7330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -7311,7 +7358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
             port: port_,
           );
         },
@@ -7349,7 +7396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
             port: port_,
           );
         },
@@ -7377,7 +7424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -7412,7 +7459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },
@@ -7445,7 +7492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -7478,7 +7525,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
           )!;
         },
         codec: SseCodec(
@@ -7507,7 +7554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
             port: port_,
           );
         },
@@ -7553,7 +7600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 174,
+              funcId: 175,
               port: port_,
             );
           },
@@ -7602,7 +7649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 175,
+              funcId: 176,
               port: port_,
             );
           },
@@ -7635,7 +7682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
             port: port_,
           );
         },
@@ -7667,7 +7714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
             port: port_,
           );
         },
@@ -7695,7 +7742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 178,
+            funcId: 179,
             port: port_,
           );
         },
@@ -7725,7 +7772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 179,
+            funcId: 180,
             port: port_,
           );
         },
@@ -7752,7 +7799,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -7779,7 +7826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 182,
             port: port_,
           );
         },
@@ -7807,7 +7854,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 183,
             port: port_,
           );
         },
@@ -7834,7 +7881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 183,
+            funcId: 184,
             port: port_,
           );
         },
@@ -7867,7 +7914,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 184,
+            funcId: 185,
           )!;
         },
         codec: SseCodec(
@@ -7900,7 +7947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 185,
+            funcId: 186,
           )!;
         },
         codec: SseCodec(
@@ -11528,8 +11575,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   UserSettings dco_decode_user_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 8)
-      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return UserSettings(
       locale: dco_decode_opt_String(arr[0]),
       interfaceScale: dco_decode_opt_box_autoadd_f_64(arr[1]),
@@ -11539,6 +11586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       developerMode: dco_decode_bool(arr[5]),
       experimentalFeatures: dco_decode_bool(arr[6]),
       defaultEmojiSkinTone: dco_decode_u_8(arr[7]),
+      dismissedVersionExpiry: dco_decode_opt_box_autoadd_Chrono_Utc(arr[8]),
     );
   }
 
@@ -15631,6 +15679,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_developerMode = sse_decode_bool(deserializer);
     var var_experimentalFeatures = sse_decode_bool(deserializer);
     var var_defaultEmojiSkinTone = sse_decode_u_8(deserializer);
+    var var_dismissedVersionExpiry = sse_decode_opt_box_autoadd_Chrono_Utc(
+      deserializer,
+    );
     return UserSettings(
       locale: var_locale,
       interfaceScale: var_interfaceScale,
@@ -15640,6 +15691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       developerMode: var_developerMode,
       experimentalFeatures: var_experimentalFeatures,
       defaultEmojiSkinTone: var_defaultEmojiSkinTone,
+      dismissedVersionExpiry: var_dismissedVersionExpiry,
     );
   }
 
@@ -19786,6 +19838,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.developerMode, serializer);
     sse_encode_bool(self.experimentalFeatures, serializer);
     sse_encode_u_8(self.defaultEmojiSkinTone, serializer);
+    sse_encode_opt_box_autoadd_Chrono_Utc(
+      self.dismissedVersionExpiry,
+      serializer,
+    );
   }
 
   @protected
@@ -20956,6 +21012,14 @@ class UserSettingsCubitBaseImpl extends RustOpaque
 
   Future<void> setDeveloperMode({required bool value}) => RustLib.instance.api
       .crateApiUserSettingsCubitUserSettingsCubitBaseSetDeveloperMode(
+        that: this,
+        value: value,
+      );
+
+  Future<void> setDismissedVersionExpiry({required DateTime value}) => RustLib
+      .instance
+      .api
+      .crateApiUserSettingsCubitUserSettingsCubitBaseSetDismissedVersionExpiry(
         that: this,
         value: value,
       );

--- a/app/lib/core/frb_generated.io.dart
+++ b/app/lib/core/frb_generated.io.dart
@@ -1468,6 +1468,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_usize(dynamic raw);
 
   @protected
+  VersionStatus dco_decode_version_status(dynamic raw);
+
+  @protected
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
 
   @protected
@@ -3001,6 +3004,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt sse_decode_usize(SseDeserializer deserializer);
+
+  @protected
+  VersionStatus sse_decode_version_status(SseDeserializer deserializer);
 
   @protected
   void sse_encode_AnyhowException(
@@ -4916,6 +4922,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_usize(BigInt self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_version_status(VersionStatus self, SseSerializer serializer);
 }
 
 // Section: wire_class

--- a/app/lib/features/onboarding/update_required_screen.dart
+++ b/app/lib/features/onboarding/update_required_screen.dart
@@ -5,17 +5,22 @@
 import 'dart:io';
 
 import 'package:air/l10n/l10n.dart';
+import 'package:air/core/core.dart';
 import 'package:air/ds/components/button/button.dart';
+import 'package:air/ds/components/button_icon/button_icon.dart';
+import 'package:air/ds/components/button_icon/button_icon_tokens.dart';
 import 'package:air/ds/foundations/foundations.dart';
 import 'package:air/ds/patterns/nux/nux_pill.dart';
 import 'package:air/ds/patterns/nux/nux_scaffold.dart';
 import 'package:air/ds/patterns/nux/nux_scaffold_tokens.dart';
+import 'package:air/util/time/time_labels.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:air/features/user/user_cubit.dart';
+import 'package:air/features/user/user_settings_cubit.dart';
 
 class UpdateRequiredScreen extends StatelessWidget {
   const UpdateRequiredScreen({super.key, required this.child});
@@ -24,13 +29,104 @@ class UpdateRequiredScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isOutdated = context.select(
-      (UserCubit cubit) => cubit.state.unsupportedVersion,
+    final versionStatus = context.select(
+      (UserCubit cubit) => cubit.state.versionStatus,
     );
-    final showUpdateButton = DeviceType.isPhone;
-    return isOutdated
-        ? UpdateRequiredView(showUpdateButton: showUpdateButton)
-        : child;
+    return switch (versionStatus) {
+      VersionStatus_Supported() => child,
+      VersionStatus_ExpiresAt(field0: final expiresAt) => VersionExpiryBanner(
+        expiresAt: expiresAt,
+        child: child,
+      ),
+      VersionStatus_Unsupported() => UpdateRequiredView(
+        showUpdateButton: DeviceType.isPhone,
+      ),
+    };
+  }
+}
+
+/// Banner above the app content when the server announced that this
+/// version stops being accepted at [expiresAt]. Dismissing it is persisted
+/// per announced expiry, so a later announcement shows it again.
+class VersionExpiryBanner extends StatelessWidget {
+  const VersionExpiryBanner({
+    super.key,
+    required this.expiresAt,
+    required this.child,
+  });
+
+  final DateTime expiresAt;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final dismissedFor = context.select(
+      (UserSettingsCubit cubit) => cubit.state.dismissedVersionExpiry,
+    );
+    if (dismissedFor != null && dismissedFor.isAtSameMomentAs(expiresAt)) {
+      return child;
+    }
+
+    final palette = SemanticPalette.of(context);
+    final loc = AppLocalizations.of(context);
+    final date = TimeFormats.of(context).monthDayYear(expiresAt.toLocal());
+
+    final banner = Material(
+      color: palette.function.warning.primary,
+      child: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: S.s16,
+            vertical: S.s4,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  loc.versionExpiryBanner_message(date),
+                  style: typeScale.body.s.style(),
+                ),
+              ),
+              // Only a store has an update to send us to, so a desktop build
+              // shows no button.
+              if (DeviceType.isPhone) ...[
+                const SizedBox(width: S.s8),
+                Button(
+                  size: ButtonSize.small,
+                  onPressed: _handleUpdateNow,
+                  label: loc.appOutdatedScreen_action,
+                ),
+              ],
+              Tooltip(
+                message: loc.versionExpiryBanner_dismiss,
+                child: ButtonIcon(
+                  variant: ButtonIconVariant.plain,
+                  icon: AppIconType.x,
+                  onPressed: () => context
+                      .read<UserSettingsCubit>()
+                      .setDismissedVersionExpiry(value: expiresAt),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return Column(
+      children: [
+        banner,
+        Expanded(
+          // The banner already took the status bar inset.
+          child: MediaQuery.removePadding(
+            context: context,
+            removeTop: true,
+            child: child,
+          ),
+        ),
+      ],
+    );
   }
 }
 
@@ -90,25 +186,25 @@ class UpdateRequiredView extends StatelessWidget {
       ),
     );
   }
+}
 
-  void _handleUpdateNow() async {
-    const String iOSAppStoreUrl =
-        "https://beta.itunes.apple.com/v1/app/6749467927";
-    const String androidPlayStoreUrl =
-        "https://play.google.com/store/apps/details?id=ms.air";
+void _handleUpdateNow() async {
+  // Country-neutral, so the store resolves the user's own storefront.
+  const String iOSAppStoreUrl = "https://apps.apple.com/app/id6749467927";
+  const String androidPlayStoreUrl =
+      "https://play.google.com/store/apps/details?id=ms.air";
 
-    Uri url;
+  Uri url;
 
-    if (Platform.isIOS) {
-      url = Uri.parse(iOSAppStoreUrl);
-    } else if (Platform.isAndroid) {
-      url = Uri.parse(androidPlayStoreUrl);
-    } else {
-      return;
-    }
+  if (Platform.isIOS) {
+    url = Uri.parse(iOSAppStoreUrl);
+  } else if (Platform.isAndroid) {
+    url = Uri.parse(androidPlayStoreUrl);
+  } else {
+    return;
+  }
 
-    if (await canLaunchUrl(url)) {
-      await launchUrl(url, mode: LaunchMode.externalApplication);
-    }
+  if (await canLaunchUrl(url)) {
+    await launchUrl(url, mode: LaunchMode.externalApplication);
   }
 }

--- a/app/lib/features/onboarding/update_required_screen.dart
+++ b/app/lib/features/onboarding/update_required_screen.dart
@@ -98,15 +98,12 @@ class VersionExpiryBanner extends StatelessWidget {
                   label: loc.appOutdatedScreen_action,
                 ),
               ],
-              Tooltip(
-                message: loc.versionExpiryBanner_dismiss,
-                child: ButtonIcon(
-                  variant: ButtonIconVariant.plain,
-                  icon: AppIconType.x,
-                  onPressed: () => context
-                      .read<UserSettingsCubit>()
-                      .setDismissedVersionExpiry(value: expiresAt),
-                ),
+              ButtonIcon(
+                variant: ButtonIconVariant.plain,
+                icon: AppIconType.x,
+                onPressed: () => context
+                    .read<UserSettingsCubit>()
+                    .setDismissedVersionExpiry(value: expiresAt),
               ),
             ],
           ),

--- a/app/lib/features/user/user_settings_cubit.dart
+++ b/app/lib/features/user/user_settings_cubit.dart
@@ -112,6 +112,9 @@ class UserSettingsCubit implements StateStreamableSource<UserSettings> {
   Future<void> setSidebarWidth({required double value}) =>
       _impl!.setSidebarWidth(value: value);
 
+  Future<void> setDismissedVersionExpiry({required DateTime value}) =>
+      _impl!.setDismissedVersionExpiry(value: value);
+
   Future<void> setSendOnEnter({required bool value}) =>
       _impl!.setSendOnEnter(value: value);
 

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -369,7 +369,7 @@
   "deleteAccountScreen_deleteAccountError": "Bei uns ist ein Fehler aufgetreten. Warte einen Moment und versuche es dann erneut.",
   "appOutdatedScreen_title": "Software-Update erforderlich",
   "appOutdatedScreen_message": "Aktualisiere, um Air weiter zu nutzen",
-  "appOutdatedScreen_description": "Öffne TestFlight auf iOS oder Google Play auf Android und aktualisiere Air.",
+  "appOutdatedScreen_description": "Öffne den App Store auf iOS oder Google Play auf Android und aktualisiere Air.",
   "appOutdatedScreen_action": "Aktualisieren",
   "versionExpiryBanner_message": "Aktualisiere Air bis zum {date}, um es weiter zu nutzen",
   "versionExpiryBanner_dismiss": "Ausblenden",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -371,6 +371,8 @@
   "appOutdatedScreen_message": "Aktualisiere, um Air weiter zu nutzen",
   "appOutdatedScreen_description": "Öffne TestFlight auf iOS oder Google Play auf Android und aktualisiere Air.",
   "appOutdatedScreen_action": "Aktualisieren",
+  "versionExpiryBanner_message": "Aktualisiere Air bis zum {date}, um es weiter zu nutzen",
+  "versionExpiryBanner_dismiss": "Ausblenden",
   "contactRequestDialog_title": "Kontaktanfrage",
   "contactRequestDialog_avatarHint": "Tippe, um das Bild anzuzeigen",
   "contactRequestDialog_cancel": "Später",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -372,7 +372,6 @@
   "appOutdatedScreen_description": "Öffne den App Store auf iOS oder Google Play auf Android und aktualisiere Air.",
   "appOutdatedScreen_action": "Aktualisieren",
   "versionExpiryBanner_message": "Aktualisiere Air bis zum {date}, um es weiter zu nutzen",
-  "versionExpiryBanner_dismiss": "Ausblenden",
   "contactRequestDialog_title": "Kontaktanfrage",
   "contactRequestDialog_avatarHint": "Tippe, um das Bild anzuzeigen",
   "contactRequestDialog_cancel": "Später",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1781,6 +1781,19 @@
   "@appOutdatedScreen_action": {
     "description": "Button that opens the store so the user can update."
   },
+  "versionExpiryBanner_message": "Update Air by {date} to keep using it",
+  "@versionExpiryBanner_message": {
+    "description": "Banner above the app content when the server announced the date on which this app version stops working. The date is already formatted for the locale.",
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "versionExpiryBanner_dismiss": "Dismiss",
+  "@versionExpiryBanner_dismiss": {
+    "description": "Tooltip of the close button on the update banner. Hides the banner until the next app start."
+  },
 
   "contactRequestDialog_title": "Contact request",
   "@contactRequestDialog_title": {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1773,9 +1773,9 @@
   "@appOutdatedScreen_message": {
     "description": "Headline telling the user an update is needed to carry on."
   },
-  "appOutdatedScreen_description": "Open TestFlight on iOS or Google Play on Android, then update Air.",
+  "appOutdatedScreen_description": "Open the App Store on iOS or Google Play on Android, then update Air.",
   "@appOutdatedScreen_description": {
-    "description": "Names the store to update from on each mobile platform. TestFlight and Google Play are product names."
+    "description": "Names the store to update from on each mobile platform. App Store and Google Play are product names."
   },
   "appOutdatedScreen_action": "Update",
   "@appOutdatedScreen_action": {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1790,10 +1790,6 @@
       }
     }
   },
-  "versionExpiryBanner_dismiss": "Dismiss",
-  "@versionExpiryBanner_dismiss": {
-    "description": "Tooltip of the close button on the update banner. Hides the banner until the next app start."
-  },
 
   "contactRequestDialog_title": "Contact request",
   "@contactRequestDialog_title": {

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -370,7 +370,6 @@
   "appOutdatedScreen_description": "Abre App Store en iOS o Google Play en Android y actualiza Air.",
   "appOutdatedScreen_action": "Actualizar",
   "versionExpiryBanner_message": "Actualiza Air antes del {date} para seguir usándolo",
-  "versionExpiryBanner_dismiss": "Cerrar",
   "contactRequestDialog_title": "Solicitud de contacto",
   "contactRequestDialog_avatarHint": "Toca para ver su foto",
   "contactRequestDialog_cancel": "Más tarde",

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -369,6 +369,8 @@
   "appOutdatedScreen_message": "Actualiza para seguir usando Air",
   "appOutdatedScreen_description": "Abre TestFlight en iOS o Google Play en Android y actualiza Air.",
   "appOutdatedScreen_action": "Actualizar",
+  "versionExpiryBanner_message": "Actualiza Air antes del {date} para seguir usándolo",
+  "versionExpiryBanner_dismiss": "Cerrar",
   "contactRequestDialog_title": "Solicitud de contacto",
   "contactRequestDialog_avatarHint": "Toca para ver su foto",
   "contactRequestDialog_cancel": "Más tarde",

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -367,7 +367,7 @@
   "deleteAccountScreen_deleteAccountError": "Algo ha fallado por nuestra parte. Espera un momento y vuelve a intentarlo.",
   "appOutdatedScreen_title": "Actualización necesaria",
   "appOutdatedScreen_message": "Actualiza para seguir usando Air",
-  "appOutdatedScreen_description": "Abre TestFlight en iOS o Google Play en Android y actualiza Air.",
+  "appOutdatedScreen_description": "Abre App Store en iOS o Google Play en Android y actualiza Air.",
   "appOutdatedScreen_action": "Actualizar",
   "versionExpiryBanner_message": "Actualiza Air antes del {date} para seguir usándolo",
   "versionExpiryBanner_dismiss": "Cerrar",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -368,7 +368,7 @@
   "deleteAccountScreen_deleteAccountError": "Un problème est survenu de notre côté. Veuillez patienter un instant puis réessayer.",
   "appOutdatedScreen_title": "Mise à jour logicielle requise",
   "appOutdatedScreen_message": "Mettez à jour pour continuer à utiliser Air",
-  "appOutdatedScreen_description": "Ouvrez TestFlight sur iOS ou Google Play sur Android, puis mettez Air à jour.",
+  "appOutdatedScreen_description": "Ouvrez l'App Store sur iOS ou Google Play sur Android, puis mettez Air à jour.",
   "appOutdatedScreen_action": "Mettre à jour",
   "versionExpiryBanner_message": "Mettez Air à jour avant le {date} pour continuer à l'utiliser",
   "versionExpiryBanner_dismiss": "Fermer",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -370,6 +370,8 @@
   "appOutdatedScreen_message": "Mettez à jour pour continuer à utiliser Air",
   "appOutdatedScreen_description": "Ouvrez TestFlight sur iOS ou Google Play sur Android, puis mettez Air à jour.",
   "appOutdatedScreen_action": "Mettre à jour",
+  "versionExpiryBanner_message": "Mettez Air à jour avant le {date} pour continuer à l'utiliser",
+  "versionExpiryBanner_dismiss": "Fermer",
   "contactRequestDialog_title": "Demande de contact",
   "contactRequestDialog_avatarHint": "Touchez pour afficher sa photo",
   "contactRequestDialog_cancel": "Plus tard",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -371,7 +371,6 @@
   "appOutdatedScreen_description": "Ouvrez l'App Store sur iOS ou Google Play sur Android, puis mettez Air à jour.",
   "appOutdatedScreen_action": "Mettre à jour",
   "versionExpiryBanner_message": "Mettez Air à jour avant le {date} pour continuer à l'utiliser",
-  "versionExpiryBanner_dismiss": "Fermer",
   "contactRequestDialog_title": "Demande de contact",
   "contactRequestDialog_avatarHint": "Touchez pour afficher sa photo",
   "contactRequestDialog_cancel": "Plus tard",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2251,10 +2251,10 @@ abstract class AppLocalizations {
   /// **'Update to keep using Air'**
   String get appOutdatedScreen_message;
 
-  /// Names the store to update from on each mobile platform. TestFlight and Google Play are product names.
+  /// Names the store to update from on each mobile platform. App Store and Google Play are product names.
   ///
   /// In en, this message translates to:
-  /// **'Open TestFlight on iOS or Google Play on Android, then update Air.'**
+  /// **'Open the App Store on iOS or Google Play on Android, then update Air.'**
   String get appOutdatedScreen_description;
 
   /// Button that opens the store so the user can update.

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2263,6 +2263,18 @@ abstract class AppLocalizations {
   /// **'Update'**
   String get appOutdatedScreen_action;
 
+  /// Banner above the app content when the server announced the date on which this app version stops working. The date is already formatted for the locale.
+  ///
+  /// In en, this message translates to:
+  /// **'Update Air by {date} to keep using it'**
+  String versionExpiryBanner_message(String date);
+
+  /// Tooltip of the close button on the update banner. Hides the banner until the next app start.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get versionExpiryBanner_dismiss;
+
   /// Title of the dialog showing an incoming contact request.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2269,12 +2269,6 @@ abstract class AppLocalizations {
   /// **'Update Air by {date} to keep using it'**
   String versionExpiryBanner_message(String date);
 
-  /// Tooltip of the close button on the update banner. Hides the banner until the next app start.
-  ///
-  /// In en, this message translates to:
-  /// **'Dismiss'**
-  String get versionExpiryBanner_dismiss;
-
   /// Title of the dialog showing an incoming contact request.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1324,7 +1324,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Öffne TestFlight auf iOS oder Google Play auf Android und aktualisiere Air.';
+      'Öffne den App Store auf iOS oder Google Play auf Android und aktualisiere Air.';
 
   @override
   String get appOutdatedScreen_action => 'Aktualisieren';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1330,6 +1330,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appOutdatedScreen_action => 'Aktualisieren';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Aktualisiere Air bis zum $date, um es weiter zu nutzen';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Ausblenden';
+
+  @override
   String get contactRequestDialog_title => 'Kontaktanfrage';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1335,9 +1335,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Ausblenden';
-
-  @override
   String get contactRequestDialog_title => 'Kontaktanfrage';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1299,7 +1299,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Open TestFlight on iOS or Google Play on Android, then update Air.';
+      'Open the App Store on iOS or Google Play on Android, then update Air.';
 
   @override
   String get appOutdatedScreen_action => 'Update';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1305,6 +1305,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appOutdatedScreen_action => 'Update';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Update Air by $date to keep using it';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Dismiss';
+
+  @override
   String get contactRequestDialog_title => 'Contact request';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1310,9 +1310,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Dismiss';
-
-  @override
   String get contactRequestDialog_title => 'Contact request';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1331,6 +1331,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appOutdatedScreen_action => 'Actualizar';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Actualiza Air antes del $date para seguir usándolo';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Cerrar';
+
+  @override
   String get contactRequestDialog_title => 'Solicitud de contacto';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1336,9 +1336,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Cerrar';
-
-  @override
   String get contactRequestDialog_title => 'Solicitud de contacto';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1325,7 +1325,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Abre TestFlight en iOS o Google Play en Android y actualiza Air.';
+      'Abre App Store en iOS o Google Play en Android y actualiza Air.';
 
   @override
   String get appOutdatedScreen_action => 'Actualizar';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1341,9 +1341,6 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Fermer';
-
-  @override
   String get contactRequestDialog_title => 'Demande de contact';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1330,7 +1330,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Ouvrez TestFlight sur iOS ou Google Play sur Android, puis mettez Air à jour.';
+      'Ouvrez l\'App Store sur iOS ou Google Play sur Android, puis mettez Air à jour.';
 
   @override
   String get appOutdatedScreen_action => 'Mettre à jour';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1336,6 +1336,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appOutdatedScreen_action => 'Mettre à jour';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Mettez Air à jour avant le $date pour continuer à l\'utiliser';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Fermer';
+
+  @override
   String get contactRequestDialog_title => 'Demande de contact';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1332,6 +1332,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appOutdatedScreen_action => 'Atualizar';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Atualize o Air até $date para continuar usando';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Fechar';
+
+  @override
   String get contactRequestDialog_title => 'Solicitação de contato';
 
   @override
@@ -2805,6 +2813,14 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get appOutdatedScreen_action => 'Atualizar';
+
+  @override
+  String versionExpiryBanner_message(String date) {
+    return 'Atualiza o Air até $date para continuares a usá-lo';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Fechar';
 
   @override
   String get contactRequestDialog_title => 'Pedido de contacto';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1337,9 +1337,6 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Fechar';
-
-  @override
   String get contactRequestDialog_title => 'Solicitação de contato';
 
   @override
@@ -2818,9 +2815,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String versionExpiryBanner_message(String date) {
     return 'Atualiza o Air até $date para continuares a usá-lo';
   }
-
-  @override
-  String get versionExpiryBanner_dismiss => 'Fechar';
 
   @override
   String get contactRequestDialog_title => 'Pedido de contacto';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1326,7 +1326,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Abra o TestFlight no iOS ou o Google Play no Android e atualize o Air.';
+      'Abra a App Store no iOS ou o Google Play no Android e atualize o Air.';
 
   @override
   String get appOutdatedScreen_action => 'Atualizar';
@@ -2809,7 +2809,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get appOutdatedScreen_description =>
-      'Abre o TestFlight no iOS ou o Google Play no Android e atualiza o Air.';
+      'Abre a App Store no iOS ou o Google Play no Android e atualiza o Air.';
 
   @override
   String get appOutdatedScreen_action => 'Atualizar';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1313,7 +1313,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get appOutdatedScreen_description =>
-      'Öppna TestFlight på iOS eller Google Play på Android och uppdatera Air.';
+      'Öppna App Store på iOS eller Google Play på Android och uppdatera Air.';
 
   @override
   String get appOutdatedScreen_action => 'Uppdatera';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1324,9 +1324,6 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get versionExpiryBanner_dismiss => 'Stäng';
-
-  @override
   String get contactRequestDialog_title => 'Kontaktförfrågan';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1319,6 +1319,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appOutdatedScreen_action => 'Uppdatera';
 
   @override
+  String versionExpiryBanner_message(String date) {
+    return 'Uppdatera Air senast $date för att fortsätta använda det';
+  }
+
+  @override
+  String get versionExpiryBanner_dismiss => 'Stäng';
+
+  @override
   String get contactRequestDialog_title => 'Kontaktförfrågan';
 
   @override

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -367,7 +367,7 @@
   "deleteAccountScreen_deleteAccountError": "Algo deu errado do nosso lado. Espere um momento e tente de novo.",
   "appOutdatedScreen_title": "Atualização necessária",
   "appOutdatedScreen_message": "Atualize para continuar usando o Air",
-  "appOutdatedScreen_description": "Abra o TestFlight no iOS ou o Google Play no Android e atualize o Air.",
+  "appOutdatedScreen_description": "Abra a App Store no iOS ou o Google Play no Android e atualize o Air.",
   "appOutdatedScreen_action": "Atualizar",
   "versionExpiryBanner_message": "Atualize o Air até {date} para continuar usando",
   "versionExpiryBanner_dismiss": "Fechar",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -369,6 +369,8 @@
   "appOutdatedScreen_message": "Atualize para continuar usando o Air",
   "appOutdatedScreen_description": "Abra o TestFlight no iOS ou o Google Play no Android e atualize o Air.",
   "appOutdatedScreen_action": "Atualizar",
+  "versionExpiryBanner_message": "Atualize o Air até {date} para continuar usando",
+  "versionExpiryBanner_dismiss": "Fechar",
   "contactRequestDialog_title": "Solicitação de contato",
   "contactRequestDialog_avatarHint": "Toque para ver a foto",
   "contactRequestDialog_cancel": "Depois",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -370,7 +370,6 @@
   "appOutdatedScreen_description": "Abra a App Store no iOS ou o Google Play no Android e atualize o Air.",
   "appOutdatedScreen_action": "Atualizar",
   "versionExpiryBanner_message": "Atualize o Air até {date} para continuar usando",
-  "versionExpiryBanner_dismiss": "Fechar",
   "contactRequestDialog_title": "Solicitação de contato",
   "contactRequestDialog_avatarHint": "Toque para ver a foto",
   "contactRequestDialog_cancel": "Depois",

--- a/app/lib/l10n/app_pt_PT.arb
+++ b/app/lib/l10n/app_pt_PT.arb
@@ -369,6 +369,8 @@
   "appOutdatedScreen_message": "Atualiza para continuares a usar o Air",
   "appOutdatedScreen_description": "Abre o TestFlight no iOS ou o Google Play no Android e atualiza o Air.",
   "appOutdatedScreen_action": "Atualizar",
+  "versionExpiryBanner_message": "Atualiza o Air até {date} para continuares a usá-lo",
+  "versionExpiryBanner_dismiss": "Fechar",
   "contactRequestDialog_title": "Pedido de contacto",
   "contactRequestDialog_avatarHint": "Toca para veres a fotografia",
   "contactRequestDialog_cancel": "Mais tarde",

--- a/app/lib/l10n/app_pt_PT.arb
+++ b/app/lib/l10n/app_pt_PT.arb
@@ -367,7 +367,7 @@
   "deleteAccountScreen_deleteAccountError": "Algo correu mal do nosso lado. Espera um momento e tenta de novo.",
   "appOutdatedScreen_title": "Atualização necessária",
   "appOutdatedScreen_message": "Atualiza para continuares a usar o Air",
-  "appOutdatedScreen_description": "Abre o TestFlight no iOS ou o Google Play no Android e atualiza o Air.",
+  "appOutdatedScreen_description": "Abre a App Store no iOS ou o Google Play no Android e atualiza o Air.",
   "appOutdatedScreen_action": "Atualizar",
   "versionExpiryBanner_message": "Atualiza o Air até {date} para continuares a usá-lo",
   "versionExpiryBanner_dismiss": "Fechar",

--- a/app/lib/l10n/app_pt_PT.arb
+++ b/app/lib/l10n/app_pt_PT.arb
@@ -370,7 +370,6 @@
   "appOutdatedScreen_description": "Abre a App Store no iOS ou o Google Play no Android e atualiza o Air.",
   "appOutdatedScreen_action": "Atualizar",
   "versionExpiryBanner_message": "Atualiza o Air até {date} para continuares a usá-lo",
-  "versionExpiryBanner_dismiss": "Fechar",
   "contactRequestDialog_title": "Pedido de contacto",
   "contactRequestDialog_avatarHint": "Toca para veres a fotografia",
   "contactRequestDialog_cancel": "Mais tarde",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -370,7 +370,6 @@
   "appOutdatedScreen_description": "Öppna App Store på iOS eller Google Play på Android och uppdatera Air.",
   "appOutdatedScreen_action": "Uppdatera",
   "versionExpiryBanner_message": "Uppdatera Air senast {date} för att fortsätta använda det",
-  "versionExpiryBanner_dismiss": "Stäng",
   "contactRequestDialog_title": "Kontaktförfrågan",
   "contactRequestDialog_avatarHint": "Tryck för att visa bilden",
   "contactRequestDialog_cancel": "Senare",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -369,6 +369,8 @@
   "appOutdatedScreen_message": "Uppdatera för att fortsätta använda Air",
   "appOutdatedScreen_description": "Öppna TestFlight på iOS eller Google Play på Android och uppdatera Air.",
   "appOutdatedScreen_action": "Uppdatera",
+  "versionExpiryBanner_message": "Uppdatera Air senast {date} för att fortsätta använda det",
+  "versionExpiryBanner_dismiss": "Stäng",
   "contactRequestDialog_title": "Kontaktförfrågan",
   "contactRequestDialog_avatarHint": "Tryck för att visa bilden",
   "contactRequestDialog_cancel": "Senare",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -367,7 +367,7 @@
   "deleteAccountScreen_deleteAccountError": "Något gick fel hos oss. Vänta en stund och försök igen.",
   "appOutdatedScreen_title": "Programuppdatering krävs",
   "appOutdatedScreen_message": "Uppdatera för att fortsätta använda Air",
-  "appOutdatedScreen_description": "Öppna TestFlight på iOS eller Google Play på Android och uppdatera Air.",
+  "appOutdatedScreen_description": "Öppna App Store på iOS eller Google Play på Android och uppdatera Air.",
   "appOutdatedScreen_action": "Uppdatera",
   "versionExpiryBanner_message": "Uppdatera Air senast {date} för att fortsätta använda det",
   "versionExpiryBanner_dismiss": "Stäng",

--- a/app/test/ds/patterns/goldens/snackbar_capped_label.macos.png
+++ b/app/test/ds/patterns/goldens/snackbar_capped_label.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba71e91134d8df6ad802bff2d032375c6e19e988048bc96c74d69c47ff19e9d6
+size 14737

--- a/app/test/ds/patterns/goldens/snackbar_capped_label.windows.png
+++ b/app/test/ds/patterns/goldens/snackbar_capped_label.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06766caec781dc1fd88c7d15e0656f74aa786be8089694a771d666db899b6120
+size 10463

--- a/app/test/ds/patterns/goldens/snackbar_long_label.macos.png
+++ b/app/test/ds/patterns/goldens/snackbar_long_label.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb0db3b8945e3528b21266b3917707d6992a7153bd1f1cf71eab771614a972c7
+size 11060

--- a/app/test/ds/patterns/goldens/snackbar_long_label.windows.png
+++ b/app/test/ds/patterns/goldens/snackbar_long_label.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f5c1195a25695abf0c76c5ef633ef7b68ec6e56949ef7b3948a732e4959924
+size 7875

--- a/app/test/ds/patterns/goldens/snackbar_short_label.macos.png
+++ b/app/test/ds/patterns/goldens/snackbar_short_label.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31d2bc8654737985a00123a75cfff89ad2474e7d57542faa02b8bf00e328991d
+size 4343

--- a/app/test/ds/patterns/goldens/snackbar_short_label.windows.png
+++ b/app/test/ds/patterns/goldens/snackbar_short_label.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01c657ea2290b1d5674b5b208e003a174fe7dae520a002c9fcf0d4313f509949
+size 3639

--- a/app/test/features/onboarding/goldens/update_required_screen.linux.png
+++ b/app/test/features/onboarding/goldens/update_required_screen.linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73984728f714dd7a3bae0a992f3d76e78182c96df5071c80ba867acb1f424b4b
-size 79136
+oid sha256:1bceba9ae5bc6e0663936793de309149076edfc440e7d905ba93ace5b83fc0bf
+size 79957

--- a/app/test/features/onboarding/goldens/update_required_screen.macos.png
+++ b/app/test/features/onboarding/goldens/update_required_screen.macos.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48523b939891ba42441bfe8976d36067cea0b4c8f5b4f69214a8f33ebd8975cf
-size 78511
+oid sha256:ceba02ac4730f47122a916f1b4753d61506a9e6f4762604e9f09dede83622ac8
+size 80646

--- a/app/test/features/onboarding/goldens/update_required_screen.windows.png
+++ b/app/test/features/onboarding/goldens/update_required_screen.windows.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92e4be543b7e63dcf40908473b407ea0c3c70d26447e3b45b6a602774e5c9ba2
-size 61163
+oid sha256:55c0af52069ba4c0be0ff24293a8279aa2c8ad3c516dd5ce5c0c915342ee1413
+size 61705

--- a/app/test/features/onboarding/goldens/version_expiry_banner.linux.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner.linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19add280288801c65931aacd1f08e3e5739e6e35a5578b5c23cf1ee82a4d9aae
+size 11118

--- a/app/test/features/onboarding/goldens/version_expiry_banner.macos.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb842e03f6cf51f13b843140c52d8c4487020d99bc225f23c531e354bf8b460
+size 12410

--- a/app/test/features/onboarding/goldens/version_expiry_banner.windows.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d33edb4ae5cb4635396c8e002db0b4dce81a8fe91ea970a678ec5eaf400941c2
+size 9360

--- a/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.linux.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75218b54141062b41a985731d13d101ebe02f67755bab0564c10b637fa980b62
+size 11490

--- a/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.macos.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:846c90364c679721c04e55deb0ecfab7f499a0ea0347e8b3bd4fc819e49f4fb6
+size 12890

--- a/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.windows.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_dark_mode.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c0829185b43a912f716371ab7dd110a403ea94ff75a5a1d49933dd1f8726cb3
+size 9515

--- a/app/test/features/onboarding/goldens/version_expiry_banner_desktop.linux.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_desktop.linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d067be9e7e9453485f3466923c5ade2d8a095af7f242f9fccfec6a34c0c9e017
+size 11578

--- a/app/test/features/onboarding/goldens/version_expiry_banner_desktop.macos.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_desktop.macos.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2c2d55c14ffd6af0c4261c1ac1b9fb9d7a2a6f684b9a888f574700af0407adf
+size 12580

--- a/app/test/features/onboarding/goldens/version_expiry_banner_desktop.windows.png
+++ b/app/test/features/onboarding/goldens/version_expiry_banner_desktop.windows.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f708508d7af642c6e3d5f9920f73a7e3be75f9dc99d07aa898e40c6a4262c966
+size 10612

--- a/app/test/features/onboarding/version_expiry_banner_test.dart
+++ b/app/test/features/onboarding/version_expiry_banner_test.dart
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:air/core/core.dart';
+import 'package:air/ds/components/button_icon/button_icon.dart';
+import 'package:air/features/onboarding/update_required_screen.dart';
+import 'package:air/features/user/user_cubit.dart';
+import 'package:air/features/user/user_settings_cubit.dart';
+import 'package:air/l10n/l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers.dart';
+import '../../mocks.dart';
+
+void main() {
+  group('UpdateRequiredScreen', () {
+    late MockUserCubit userCubit;
+    late MockUserSettingsCubit userSettingsCubit;
+
+    Widget buildSubject({Widget child = const Text('content')}) => Builder(
+      builder: (context) {
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: testThemeData(MediaQuery.platformBrightnessOf(context)),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<UserCubit>.value(value: userCubit),
+              BlocProvider<UserSettingsCubit>.value(value: userSettingsCubit),
+            ],
+            child: UpdateRequiredScreen(child: child),
+          ),
+        );
+      },
+    );
+
+    final expiresAt = DateTime.utc(2026, 8, 1, 12);
+
+    void announceExpiry() {
+      when(() => userCubit.state).thenReturn(
+        MockUiUser(id: 1, versionStatus: VersionStatus.expiresAt(expiresAt)),
+      );
+    }
+
+    /// Stands in for the app content under the banner.
+    const content = Scaffold(body: Center(child: Text('content')));
+
+    setUp(() {
+      userCubit = MockUserCubit();
+      userSettingsCubit = MockUserSettingsCubit();
+      when(() => userSettingsCubit.state).thenReturn(const UserSettings());
+      when(
+        () => userSettingsCubit.setDismissedVersionExpiry(
+          value: any(named: 'value'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    testWidgets('shows only the content when the version is supported', (
+      tester,
+    ) async {
+      when(() => userCubit.state).thenReturn(MockUiUser(id: 1));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('content'), findsOneWidget);
+      expect(find.textContaining('Update Air by'), findsNothing);
+    });
+
+    testWidgets('shows the banner when the version expires and dismisses it', (
+      tester,
+    ) async {
+      announceExpiry();
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('content'), findsOneWidget);
+      expect(find.textContaining('Update Air by'), findsOneWidget);
+
+      await tester.tap(find.byType(ButtonIcon));
+      await tester.pump();
+
+      verify(
+        () => userSettingsCubit.setDismissedVersionExpiry(value: expiresAt),
+      ).called(1);
+    });
+
+    testWidgets('hides the banner dismissed for the announced expiry', (
+      tester,
+    ) async {
+      announceExpiry();
+      when(
+        () => userSettingsCubit.state,
+      ).thenReturn(UserSettings(dismissedVersionExpiry: expiresAt));
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('content'), findsOneWidget);
+      expect(find.textContaining('Update Air by'), findsNothing);
+    });
+
+    testWidgets('shows the banner dismissed for an earlier expiry', (
+      tester,
+    ) async {
+      announceExpiry();
+      when(() => userSettingsCubit.state).thenReturn(
+        UserSettings(
+          dismissedVersionExpiry: expiresAt.subtract(const Duration(days: 7)),
+        ),
+      );
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.textContaining('Update Air by'), findsOneWidget);
+    });
+
+    testWidgets('replaces the content when the version is unsupported', (
+      tester,
+    ) async {
+      when(() => userCubit.state).thenReturn(
+        MockUiUser(id: 1, versionStatus: const VersionStatus.unsupported()),
+      );
+
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('content'), findsNothing);
+      expect(find.text('Software update required'), findsOneWidget);
+    });
+
+    testWidgets('banner renders correctly', (tester) async {
+      sizeView(tester, phoneViewSize);
+      announceExpiry();
+
+      await tester.pumpWidget(buildSubject(child: content));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('goldens/version_expiry_banner.png'),
+      );
+    });
+
+    testWidgets('banner renders correctly (dark mode)', (tester) async {
+      sizeView(tester, phoneViewSize);
+      tester.platformDispatcher.platformBrightnessTestValue = .dark;
+      addTearDown(() {
+        tester.platformDispatcher.clearPlatformBrightnessTestValue();
+      });
+      announceExpiry();
+
+      await tester.pumpWidget(buildSubject(child: content));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('goldens/version_expiry_banner_dark_mode.png'),
+      );
+    });
+
+    testWidgets('banner renders correctly (desktop)', (tester) async {
+      sizeView(tester, desktopViewSize);
+      announceExpiry();
+
+      await tester.pumpWidget(buildSubject(child: content));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('goldens/version_expiry_banner_desktop.png'),
+      );
+    }, variant: desktopPlatform);
+  });
+}

--- a/app/test/mocks.dart
+++ b/app/test/mocks.dart
@@ -39,6 +39,7 @@ class MockUiUser implements UiUser {
     required int id,
     this.accountUnlinked = false,
     this.usernames = const [],
+    this.versionStatus = const VersionStatus.supported(),
   }) : _userId = id.userId();
 
   final UiUserId _userId;
@@ -56,7 +57,7 @@ class MockUiUser implements UiUser {
   final List<UiUsername> usernames;
 
   @override
-  bool get unsupportedVersion => false;
+  final VersionStatus versionStatus;
 
   @override
   final bool accountUnlinked;

--- a/applogic/src/api/user_cubit/mod.rs
+++ b/applogic/src/api/user_cubit/mod.rs
@@ -11,6 +11,7 @@ use aircommon::identifiers::{UserId, Username};
 use aircoreclient::clients::StorageObjectType;
 use aircoreclient::{Asset, ChatId, ContactType, PartialContact, clients::CoreUser};
 use anyhow::ensure;
+use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use qs::QueueContext;
 use tokio::sync::watch;
@@ -62,9 +63,21 @@ pub struct UiUser {
 struct UiUserInner {
     user_id: UserId,
     usernames: Vec<Username>,
-    unsupported_version: bool,
+    /// Status of the version of the client communicated by the server.
+    version_status: VersionStatus,
     /// Another device of this user removed this one from the self group.
     account_unlinked: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[frb(dart_metadata = ("freezed"))]
+pub enum VersionStatus {
+    /// No expiration is announced by the server.
+    Supported,
+    /// Server rejects this version.
+    Unsupported,
+    /// The server announced that the version stops being accepted at this time.
+    ExpiresAt(DateTime<Utc>),
 }
 
 impl UiUser {
@@ -129,9 +142,10 @@ impl UiUser {
             .collect()
     }
 
+    /// Return the status of the client version communicated by the server.
     #[frb(getter, sync)]
-    pub fn unsupported_version(&self) -> bool {
-        self.inner.unsupported_version
+    pub fn version_status(&self) -> VersionStatus {
+        self.inner.version_status
     }
 
     #[frb(getter, sync)]
@@ -174,7 +188,7 @@ impl UserCubitBase {
         let core = CubitCore::with_initial_state(UiUser::new(Arc::new(UiUserInner {
             user_id: user.user.user_id().clone(),
             usernames: Vec::new(),
-            unsupported_version: false,
+            version_status: VersionStatus::Supported,
             account_unlinked: false,
         })));
 

--- a/applogic/src/api/user_cubit/qs.rs
+++ b/applogic/src/api/user_cubit/qs.rs
@@ -4,13 +4,12 @@
 
 use std::sync::Arc;
 
-use aircommon::time::TimeStamp;
 use aircoreclient::clients::{
     ListenResponse, listen_response,
     process::{process_qs::ProcessedQsMessages, qs_stream::QsProcessEventResult},
 };
 use airprotos::queue_service;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
@@ -127,11 +126,13 @@ impl BackgroundStreamContext<ListenResponse> for QueueContext {
                 })),
         } = &event
         {
-            let expires_at = expires_at.map(|t| TimeStamp::from(t).into());
+            // Whole seconds: the dismissed expiry is persisted as such and has to compare equal to
+            // the announced one afterwards.
+            let expires_at = expires_at.and_then(|t| DateTime::from_timestamp(t.seconds, 0));
             self.cubit_context.state_tx.send_modify(|state| {
                 let inner = Arc::make_mut(&mut state.inner);
                 inner.version_status = match expires_at {
-                    Some(expires_at) if expires_at < Utc::now() => {
+                    Some(expires_at) if Utc::now() < expires_at => {
                         VersionStatus::ExpiresAt(expires_at)
                     }
                     Some(_) => VersionStatus::Unsupported,

--- a/applogic/src/api/user_cubit/qs.rs
+++ b/applogic/src/api/user_cubit/qs.rs
@@ -4,10 +4,13 @@
 
 use std::sync::Arc;
 
+use aircommon::time::TimeStamp;
 use aircoreclient::clients::{
-    ListenResponse,
+    ListenResponse, listen_response,
     process::{process_qs::ProcessedQsMessages, qs_stream::QsProcessEventResult},
 };
+use airprotos::queue_service;
+use chrono::Utc;
 use flutter_rust_bridge::frb;
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
@@ -15,7 +18,7 @@ use tonic::Code;
 use tracing::{error, warn};
 
 use crate::{
-    api::user::User,
+    api::{user::User, user_cubit::VersionStatus},
     util::{BackgroundStreamContext, BackgroundStreamTask},
 };
 
@@ -71,22 +74,22 @@ impl BackgroundStreamContext<ListenResponse> for QueueContext {
         let (stream, responder) = match self.cubit_context.core_user.listen_queue().await {
             Ok(stream) => {
                 self.cubit_context.state_tx.send_if_modified(|state| {
-                    if !state.inner.unsupported_version {
+                    if let VersionStatus::Supported = state.inner.version_status {
                         return false;
                     }
                     let inner = Arc::make_mut(&mut state.inner);
-                    inner.unsupported_version = false;
+                    inner.version_status = VersionStatus::Supported;
                     true
                 });
                 stream
             }
             Err(error) if error.is_unsupported_version() => {
                 self.cubit_context.state_tx.send_if_modified(|state| {
-                    if state.inner.unsupported_version {
+                    if let VersionStatus::Unsupported = state.inner.version_status {
                         return false;
                     }
                     let inner = Arc::make_mut(&mut state.inner);
-                    inner.unsupported_version = true;
+                    inner.version_status = VersionStatus::Unsupported;
                     true
                 });
                 return Err(error.into());
@@ -115,6 +118,28 @@ impl BackgroundStreamContext<ListenResponse> for QueueContext {
     }
 
     async fn handle_event(&mut self, event: ListenResponse) -> bool {
+        // Update the version status communicated by the server. Note that the server can also clear
+        // the state.
+        if let ListenResponse {
+            event:
+                Some(listen_response::Event::VersionStatus(queue_service::v1::VersionStatus {
+                    expires_at,
+                })),
+        } = &event
+        {
+            let expires_at = expires_at.map(|t| TimeStamp::from(t).into());
+            self.cubit_context.state_tx.send_modify(|state| {
+                let inner = Arc::make_mut(&mut state.inner);
+                inner.version_status = match expires_at {
+                    Some(expires_at) if expires_at < Utc::now() => {
+                        VersionStatus::ExpiresAt(expires_at)
+                    }
+                    Some(_) => VersionStatus::Unsupported,
+                    None => VersionStatus::Supported,
+                };
+            });
+        }
+
         let result = match self.cubit_context.core_user.process_qs_event(event).await {
             Ok(result) => result,
             Err(error) => {

--- a/applogic/src/api/user_cubit/qs.rs
+++ b/applogic/src/api/user_cubit/qs.rs
@@ -14,7 +14,7 @@ use flutter_rust_bridge::frb;
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tonic::Code;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     api::{user::User, user_cubit::VersionStatus},
@@ -126,6 +126,7 @@ impl BackgroundStreamContext<ListenResponse> for QueueContext {
                 })),
         } = &event
         {
+            debug!(expires_at = ?expires_at, "Received version status");
             // Whole seconds: the dismissed expiry is persisted as such and has to compare equal to
             // the announced one afterwards.
             let expires_at = expires_at.and_then(|t| DateTime::from_timestamp(t.seconds, 0));

--- a/applogic/src/api/user_cubit/qs.rs
+++ b/applogic/src/api/user_cubit/qs.rs
@@ -118,7 +118,7 @@ impl BackgroundStreamContext<ListenResponse> for QueueContext {
 
     async fn handle_event(&mut self, event: ListenResponse) -> bool {
         // Update the version status communicated by the server. Note that the server can also clear
-        // the state.
+        // the status.
         if let ListenResponse {
             event:
                 Some(listen_response::Event::VersionStatus(queue_service::v1::VersionStatus {

--- a/applogic/src/api/user_cubit/username.rs
+++ b/applogic/src/api/user_cubit/username.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::{
-    api::user::User,
+    api::{user::User, user_cubit::VersionStatus},
     util::{BackgroundStreamContext, BackgroundStreamTask, spawn_from_sync},
 };
 
@@ -136,22 +136,22 @@ impl BackgroundStreamContext<UsernameQueueMessage> for UsernameContext {
         {
             Ok(stream) => {
                 self.cubit_context.state_tx.send_if_modified(|state| {
-                    if !state.inner.unsupported_version {
+                    if let VersionStatus::Supported = state.inner.version_status {
                         return false;
                     }
                     let inner = Arc::make_mut(&mut state.inner);
-                    inner.unsupported_version = false;
+                    inner.version_status = VersionStatus::Supported;
                     true
                 });
                 stream
             }
             Err(error) if error.is_unsupported_version() => {
                 self.cubit_context.state_tx.send_if_modified(|state| {
-                    if state.inner.unsupported_version {
+                    if let VersionStatus::Unsupported = state.inner.version_status {
                         return false;
                     }
                     let inner = Arc::make_mut(&mut state.inner);
-                    inner.unsupported_version = true;
+                    inner.version_status = VersionStatus::Unsupported;
                     true
                 });
                 return Err(error.into());

--- a/applogic/src/api/user_settings_cubit.rs
+++ b/applogic/src/api/user_settings_cubit.rs
@@ -10,6 +10,7 @@ use aircoreclient::{
     db::notification::{DbEntityId, DbNotification},
 };
 use anyhow::{anyhow, bail};
+use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use tokio::sync::watch;
 use tokio_stream::{Stream, StreamExt};
@@ -43,6 +44,9 @@ pub struct UserSettings {
     /// Index into the client `EmojiSkinTone` enum (0 = default/none).
     #[frb(default = 0)]
     pub default_emoji_skin_tone: u8,
+    /// The version expiry announced by the server that the user dismissed the
+    /// update banner for. A different announced expiry shows the banner again.
+    pub dismissed_version_expiry: Option<DateTime<Utc>>,
 }
 
 impl Default for UserSettings {
@@ -57,6 +61,7 @@ impl Default for UserSettings {
             developer_mode: false,
             experimental_features: false,
             default_emoji_skin_tone: 0,
+            dismissed_version_expiry: None,
         }
     }
 }
@@ -73,6 +78,7 @@ pub async fn load_user_settings(user: &User) -> UserSettings {
     let developer_mode = core_user.user_setting().await;
     let experimental_features = core_user.user_setting().await;
     let default_emoji_skin_tone = core_user.user_setting().await;
+    let dismissed_version_expiry = core_user.user_setting().await;
 
     let defaults = UserSettings::default();
     UserSettings {
@@ -94,6 +100,8 @@ pub async fn load_user_settings(user: &User) -> UserSettings {
             defaults.default_emoji_skin_tone,
             |DefaultEmojiSkinToneSetting(value)| value,
         ),
+        dismissed_version_expiry: dismissed_version_expiry
+            .map(|DismissedVersionExpirySetting(value)| value),
     }
 }
 
@@ -256,6 +264,19 @@ impl UserSettingsCubitBase {
         Ok(())
     }
 
+    pub async fn set_dismissed_version_expiry(&self, value: DateTime<Utc>) -> anyhow::Result<()> {
+        if self.core.state_tx().borrow().dismissed_version_expiry == Some(value) {
+            return Ok(());
+        }
+        self.core_user
+            .set_user_setting(&DismissedVersionExpirySetting(value))
+            .await?;
+        self.core
+            .state_tx()
+            .send_modify(|state| state.dismissed_version_expiry = Some(value));
+        Ok(())
+    }
+
     pub(crate) fn subscribe(&self) -> watch::Receiver<UserSettings> {
         self.core.state_tx().subscribe()
     }
@@ -332,6 +353,28 @@ impl UserSetting for DefaultEmojiSkinToneSetting {
             [byte] => Ok(Self(*byte)),
             _ => bail!("invalid default_emoji_skin_tone bytes"),
         }
+    }
+}
+
+/// Device-local, since the banner is dismissed on the device in hand.
+///
+/// Stored in whole seconds, like the announced expiry it is compared against.
+struct DismissedVersionExpirySetting(DateTime<Utc>);
+
+impl UserSetting for DismissedVersionExpirySetting {
+    const KEY: &'static str = "dismissed_version_expiry";
+
+    fn encode(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(self.0.timestamp().to_be_bytes().to_vec())
+    }
+
+    fn decode(bytes: Vec<u8>) -> anyhow::Result<Self> {
+        let bytes: [u8; 8] = bytes
+            .try_into()
+            .map_err(|_| anyhow!("invalid dismissed_version_expiry bytes"))?;
+        DateTime::from_timestamp(i64::from_be_bytes(bytes), 0)
+            .map(Self)
+            .ok_or_else(|| anyhow!("dismissed_version_expiry out of range"))
     }
 }
 

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -55,7 +55,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1410455381;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -452056076;
 
 // Section: executor
 
@@ -6552,6 +6552,31 @@ let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decod
         }
         let api_that_guard = api_that_guard.unwrap();
  let output_ok = crate::api::user_settings_cubit::UserSettingsCubitBase::set_developer_mode(&*api_that_guard, api_value).await?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_dismissed_version_expiry_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "UserSettingsCubitBase_set_dismissed_version_expiry", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserSettingsCubitBase>>>::sse_decode(&mut deserializer);
+let api_value = <chrono::DateTime::<chrono::Utc>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>((move || async move {
+                        let mut api_that_guard = None;
+let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(&api_that, 0, false)]);
+        for i in decode_indices_ {
+            match i {
+                0 => api_that_guard = Some(api_that.lockable_decode_async_ref().await),
+                _ => unreachable!(),
+            }
+        }
+        let api_that_guard = api_that_guard.unwrap();
+ let output_ok = crate::api::user_settings_cubit::UserSettingsCubitBase::set_dismissed_version_expiry(&*api_that_guard, api_value).await?;   Ok(output_ok)
                     })().await)
                 } })
 }
@@ -13097,6 +13122,8 @@ impl SseDecode for crate::api::user_settings_cubit::UserSettings {
         let mut var_developerMode = <bool>::sse_decode(deserializer);
         let mut var_experimentalFeatures = <bool>::sse_decode(deserializer);
         let mut var_defaultEmojiSkinTone = <u8>::sse_decode(deserializer);
+        let mut var_dismissedVersionExpiry =
+            <Option<chrono::DateTime<chrono::Utc>>>::sse_decode(deserializer);
         return crate::api::user_settings_cubit::UserSettings {
             locale: var_locale,
             interface_scale: var_interfaceScale,
@@ -13106,6 +13133,7 @@ impl SseDecode for crate::api::user_settings_cubit::UserSettings {
             developer_mode: var_developerMode,
             experimental_features: var_experimentalFeatures,
             default_emoji_skin_tone: var_defaultEmojiSkinTone,
+            dismissed_version_expiry: var_dismissedVersionExpiry,
         };
     }
 }
@@ -13245,51 +13273,52 @@ fn pde_ffi_dispatcher_primary_impl(
 121 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
 124 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_default_emoji_skin_tone_impl(port, ptr, rust_vec_len, data_len),
 125 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_developer_mode_impl(port, ptr, rust_vec_len, data_len),
-126 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_experimental_features_impl(port, ptr, rust_vec_len, data_len),
-127 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_interface_scale_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
-137 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__user__User_trigger_timed_task_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
-144 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
-150 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-154 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-155 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
-156 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
-157 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__registration__create_admission_session_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__registration__get_registration_info_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
-167 => wire__crate__api__linked_devices_cubit__linked_devices_state_default_impl(port, ptr, rust_vec_len, data_len),
-168 => wire__crate__api__user_settings_cubit__load_user_settings_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__multi_device__multi_device_link_client_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__multi_device__multi_device_provision_client_impl(port, ptr, rust_vec_len, data_len),
-176 => wire__crate__api__notification_context__notification_policy_default_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
-181 => wire__crate__api__share_cubit__share_state_default_impl(port, ptr, rust_vec_len, data_len),
-182 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
-183 => wire__crate__api__share_cubit__ui_share_send_status_default_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_dismissed_version_expiry_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_experimental_features_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_interface_scale_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
+138 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__user__User_trigger_timed_task_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
+145 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
+151 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+155 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+156 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
+157 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
+158 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__registration__create_admission_session_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__registration__get_registration_info_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
+168 => wire__crate__api__linked_devices_cubit__linked_devices_state_default_impl(port, ptr, rust_vec_len, data_len),
+169 => wire__crate__api__user_settings_cubit__load_user_settings_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__multi_device__multi_device_link_client_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__multi_device__multi_device_provision_client_impl(port, ptr, rust_vec_len, data_len),
+177 => wire__crate__api__notification_context__notification_policy_default_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
+182 => wire__crate__api__share_cubit__share_state_default_impl(port, ptr, rust_vec_len, data_len),
+183 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
+184 => wire__crate__api__share_cubit__ui_share_send_status_default_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -13483,47 +13512,47 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        132 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
+        133 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        134 => wire__crate__api__user__User_client_record_id_impl(ptr, rust_vec_len, data_len),
-        141 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
+        135 => wire__crate__api__user__User_client_record_id_impl(ptr, rust_vec_len, data_len),
+        142 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        145 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
-        147 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
+        146 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
+        148 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        148 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
-        149 => {
+        149 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
+        150 => {
             wire__crate__api__users_cubit__UsersCubitBase_state_impl(ptr, rust_vec_len, data_len)
         }
-        151 => {
+        152 => {
             wire__crate__api__users_cubit__UsersState_display_name_impl(ptr, rust_vec_len, data_len)
         }
-        152 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
-        153 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
+        153 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
+        154 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        163 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
-        164 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
-        172 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
+        164 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
+        165 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
+        173 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        184 => {
+        185 => {
             wire__crate__api__types__ui_username_validation_error_impl(ptr, rust_vec_len, data_len)
         }
-        185 => wire__crate__api__username_suggestions__username_from_display_impl(
+        186 => wire__crate__api__username_suggestions__username_from_display_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -16338,6 +16367,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::user_settings_cubit::UserSett
             self.developer_mode.into_into_dart().into_dart(),
             self.experimental_features.into_into_dart().into_dart(),
             self.default_emoji_skin_tone.into_into_dart().into_dart(),
+            self.dismissed_version_expiry.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -19474,6 +19504,10 @@ impl SseEncode for crate::api::user_settings_cubit::UserSettings {
         <bool>::sse_encode(self.developer_mode, serializer);
         <bool>::sse_encode(self.experimental_features, serializer);
         <u8>::sse_encode(self.default_emoji_skin_tone, serializer);
+        <Option<chrono::DateTime<chrono::Utc>>>::sse_encode(
+            self.dismissed_version_expiry,
+            serializer,
+        );
     }
 }
 

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -55,7 +55,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -137990403;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1410455381;
 
 // Section: executor
 
@@ -4674,54 +4674,6 @@ fn wire__crate__api__user_cubit__UiUser_account_unlinked_impl(
         },
     )
 }
-fn wire__crate__api__user_cubit__UiUser_unsupported_version_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "UiUser_unsupported_version",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UiUser>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, false,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
-                        _ => unreachable!(),
-                    }
-                }
-                let api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok(
-                    crate::api::user_cubit::UiUser::unsupported_version(&*api_that_guard),
-                )?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
 fn wire__crate__api__user_cubit__UiUser_user_id_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -4812,6 +4764,54 @@ fn wire__crate__api__user_cubit__UiUser_usernames_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::user_cubit::UiUser::usernames(
                     &*api_that_guard,
                 ))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__user_cubit__UiUser_version_status_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "UiUser_version_status",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UiUser>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(
+                    crate::api::user_cubit::UiUser::version_status(&*api_that_guard),
+                )?;
                 Ok(output_ok)
             })())
         },
@@ -13132,6 +13132,28 @@ impl SseDecode for usize {
     }
 }
 
+impl SseDecode for crate::api::user_cubit::VersionStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::user_cubit::VersionStatus::Supported;
+            }
+            1 => {
+                return crate::api::user_cubit::VersionStatus::Unsupported;
+            }
+            2 => {
+                let mut var_field0 = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
+                return crate::api::user_cubit::VersionStatus::ExpiresAt(var_field0);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 fn pde_ffi_dispatcher_primary_impl(
     func_id: i32,
     port: flutter_rust_bridge::for_generated::MessagePort,
@@ -13438,13 +13460,9 @@ fn pde_ffi_dispatcher_sync_impl(
         91 => {
             wire__crate__api__user_cubit__UiUser_account_unlinked_impl(ptr, rust_vec_len, data_len)
         }
-        92 => wire__crate__api__user_cubit__UiUser_unsupported_version_impl(
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        93 => wire__crate__api__user_cubit__UiUser_user_id_impl(ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__user_cubit__UiUser_usernames_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__user_cubit__UiUser_user_id_impl(ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__user_cubit__UiUser_usernames_impl(ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__user_cubit__UiUser_version_status_impl(ptr, rust_vec_len, data_len),
         107 => {
             wire__crate__api__user_cubit__UserCubitBase_is_closed_impl(ptr, rust_vec_len, data_len)
         }
@@ -16357,6 +16375,32 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<crate::api::types::UsernameVal
 {
     fn into_into_dart(self) -> FrbWrapper<crate::api::types::UsernameValidationError> {
         self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::user_cubit::VersionStatus {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::user_cubit::VersionStatus::Supported => [0.into_dart()].into_dart(),
+            crate::api::user_cubit::VersionStatus::Unsupported => [1.into_dart()].into_dart(),
+            crate::api::user_cubit::VersionStatus::ExpiresAt(field0) => {
+                [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::user_cubit::VersionStatus
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::user_cubit::VersionStatus>
+    for crate::api::user_cubit::VersionStatus
+{
+    fn into_into_dart(self) -> crate::api::user_cubit::VersionStatus {
+        self
     }
 }
 
@@ -19459,6 +19503,27 @@ impl SseEncode for usize {
             .cursor
             .write_u64::<NativeEndian>(self as _)
             .unwrap();
+    }
+}
+
+impl SseEncode for crate::api::user_cubit::VersionStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::user_cubit::VersionStatus::Supported => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::user_cubit::VersionStatus::Unsupported => {
+                <i32>::sse_encode(1, serializer);
+            }
+            crate::api::user_cubit::VersionStatus::ExpiresAt(field0) => {
+                <i32>::sse_encode(2, serializer);
+                <chrono::DateTime<chrono::Utc>>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 

--- a/applogic/src/messages.rs
+++ b/applogic/src/messages.rs
@@ -46,7 +46,9 @@ impl User {
                             messages.push(queue_message);
                         }
                     }
-                    Some(listen_response::Event::Payload(_)) | None => {}
+                    Some(listen_response::Event::Payload(_))
+                    | Some(listen_response::Event::VersionStatus(_))
+                    | None => {}
                 },
                 // Terminal status => stream is over, acks cannot be confirmed
                 Some(Err(error)) => {

--- a/backend/src/qs/grpc.rs
+++ b/backend/src/qs/grpc.rs
@@ -467,15 +467,20 @@ impl QueueService for GrpcQs {
             return Err(ListenQueueProtocolViolation::MissingInitRequest.into());
         };
 
-        let client_version = self
-            .verify_client_version(
-                init_request
-                    .payload
-                    .as_ref()
-                    .and_then(|p| p.client_metadata.as_ref())
-                    .or(init_request.client_metadata.as_ref()),
-            )?
-            .version;
+        let verified_client_version = self.verify_client_version(
+            init_request
+                .payload
+                .as_ref()
+                .and_then(|p| p.client_metadata.as_ref())
+                .or(init_request.client_metadata.as_ref()),
+        )?;
+        let version_status = ListenResponse {
+            event: Some(listen_response::Event::VersionStatus(VersionStatus {
+                expires_at: verified_client_version
+                    .expires_at
+                    .map(|ts| TimeStamp::from(ts).into()),
+            })),
+        };
 
         let payload_bytes = init_request
             .payload
@@ -498,7 +503,11 @@ impl QueueService for GrpcQs {
         let queue_messages = self
             .qs
             .queues
-            .listen(client_id, client_version, sequence_number_start)
+            .listen(
+                client_id,
+                verified_client_version.version,
+                sequence_number_start,
+            )
             .await?;
         let events = queue_messages.map(|message| match message {
             Some(event) => event,
@@ -506,6 +515,7 @@ impl QueueService for GrpcQs {
                 event: Some(listen_response::Event::Empty(QueueEmpty {})),
             },
         });
+        let events = tokio_stream::once(version_status).chain(events);
 
         self.update_client_activity_and_report_metrics(client_id)
             .await

--- a/backend/src/version.rs
+++ b/backend/src/version.rs
@@ -49,8 +49,6 @@ impl VersionExpiration {
 pub(crate) struct VerifiedClientVersion {
     pub(crate) version: Option<Version>,
     /// Set if the version expires in the future
-    // TODO: Will be communicated back to client over QS listen stream
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) expires_at: Option<DateTime<Utc>>,
 }
 

--- a/coreclient/src/clients/mod.rs
+++ b/coreclient/src/clients/mod.rs
@@ -569,8 +569,9 @@ impl CoreUser {
                         messages.push(queue_message);
                     }
                 }
-                Some(listen_response::Event::Payload(_)) => {}
-                None => {}
+                Some(listen_response::Event::Payload(_))
+                | Some(listen_response::Event::VersionStatus(_))
+                | None => {}
             }
         }
 

--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -738,7 +738,9 @@ impl CoreUser {
                             messages.push(queue_message);
                         }
                     }
-                    Some(listen_response::Event::Payload(_)) | None => {}
+                    Some(listen_response::Event::Payload(_))
+                    | Some(listen_response::Event::VersionStatus(_))
+                    | None => {}
                 },
                 // Terminal status => stream is over, acks cannot be confirmed
                 Some(Err(error)) => {

--- a/coreclient/src/clients/process/qs_stream.rs
+++ b/coreclient/src/clients/process/qs_stream.rs
@@ -113,6 +113,11 @@ impl QsStreamProcessor {
 
                 result
             }
+            Some(listen_response::Event::VersionStatus(_)) => {
+                // We don't handle version expires events
+                warn!("ignoring QS listen version expires event");
+                QsProcessEventResult::Ignored
+            }
         }
     }
 }

--- a/coreclient/src/clients/process/qs_stream.rs
+++ b/coreclient/src/clients/process/qs_stream.rs
@@ -113,11 +113,7 @@ impl QsStreamProcessor {
 
                 result
             }
-            Some(listen_response::Event::VersionStatus(_)) => {
-                // We don't handle version expires events
-                warn!("ignoring QS listen version expires event");
-                QsProcessEventResult::Ignored
-            }
+            Some(listen_response::Event::VersionStatus(_)) => QsProcessEventResult::Ignored,
         }
     }
 }

--- a/protos/api/queue_service/v1/queue_service.proto
+++ b/protos/api/queue_service/v1/queue_service.proto
@@ -339,6 +339,7 @@ message ListenResponse {
     QueueEmpty empty = 1;
     QueueMessage message = 2;
     QueueEventPayload payload = 3;
+    VersionStatus version_status = 4;
   }
 }
 
@@ -358,4 +359,9 @@ message QueueEventPayload {
   delivery_service.v1.GroupEpoch epoch = 3;
   common.v1.Timestamp timestamp = 4;
   bytes payload = 5;
+}
+
+message VersionStatus {
+  // Not set if the version is supported and does not expire.
+  common.v1.Timestamp expires_at = 1;
 }

--- a/server/tests/tests/server.rs
+++ b/server/tests/tests/server.rs
@@ -34,7 +34,7 @@ use airprotos::{
     auth_service::v1::auth_service_server,
     common::v1::{StatusDetails, StatusDetailsCode},
     delivery_service::v1::delivery_service_server,
-    queue_service::v1::queue_service_server,
+    queue_service::v1::{VersionStatus, queue_service_server},
 };
 use airserver_test_harness::utils::setup::{TestBackend, TestBackendParams, TestUser};
 use chrono::{DateTime, Utc};
@@ -1325,6 +1325,64 @@ async fn unsupported_client_version() {
 
     let details = StatusDetails::from_status(&status).unwrap();
     assert_matches!(details.code(), StatusDetailsCode::VersionUnsupported);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Version status on listen queue", skip_all)]
+async fn listen_queue_version_status() {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+    let alice_user = setup.get_user(&alice).user.clone();
+
+    let (mut stream, _responder) = alice_user.listen_queue().await.unwrap();
+
+    // The first event reports the version status, then the queue-empty sentinel follows.
+    assert_matches!(
+        stream.next().await,
+        Some(Ok(ListenResponse {
+            event: Some(listen_response::Event::VersionStatus(VersionStatus {
+                expires_at: None,
+            })),
+        }))
+    );
+    assert_matches!(
+        stream.next().await,
+        Some(Ok(ListenResponse {
+            event: Some(listen_response::Event::Empty(_)),
+        }))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Expiring version status on listen queue", skip_all)]
+async fn listen_queue_version_status_expiring() {
+    let expires_on = Utc::now() + chrono::Duration::days(10);
+    let mut setup = TestBackend::single_with_params(TestBackendParams {
+        version_policy: VersionPolicy::new(vec![VersionExpiration {
+            older_than: Version::new(999, 0, 0),
+            expires_on,
+        }]),
+        ..Default::default()
+    })
+    .await;
+
+    let alice = setup.add_user().await;
+    let alice_user = setup.get_user(&alice).user.clone();
+
+    let (mut stream, _responder) = alice_user.listen_queue().await.unwrap();
+
+    // The first event reports the upcoming expiry, then the queue-empty sentinel follows.
+    let response = stream.next().await.unwrap().unwrap();
+    let Some(listen_response::Event::VersionStatus(status)) = response.event else {
+        panic!("expected version status, got {response:?}");
+    };
+    assert_eq!(status.expires_at.unwrap().seconds, expires_on.timestamp());
+    assert_matches!(
+        stream.next().await,
+        Some(Ok(ListenResponse {
+            event: Some(listen_response::Event::Empty(_)),
+        }))
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/server/tests/tests/server.rs
+++ b/server/tests/tests/server.rs
@@ -41,7 +41,7 @@ use chrono::{DateTime, Utc};
 use mimi_content::MimiContent;
 use semver::Version;
 use tokio::time::{sleep, timeout};
-use tokio_stream::StreamExt;
+use tokio_stream::{Stream, StreamExt};
 use tonic::{Code, codegen::http, transport::Channel};
 use tonic_health::pb::{
     HealthCheckRequest, health_check_response::ServingStatus, health_client::HealthClient,
@@ -1327,6 +1327,18 @@ async fn unsupported_client_version() {
     assert_matches!(details.code(), StatusDetailsCode::VersionUnsupported);
 }
 
+/// Consumes the version status the server sends first on every listen stream.
+async fn skip_version_status(
+    stream: &mut (impl Stream<Item = Result<ListenResponse, tonic::Status>> + Unpin),
+) {
+    assert_matches!(
+        stream.next().await,
+        Some(Ok(ListenResponse {
+            event: Some(listen_response::Event::VersionStatus(_)),
+        }))
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[tracing::instrument(name = "Version status on listen queue", skip_all)]
 async fn listen_queue_version_status() {
@@ -1427,6 +1439,7 @@ async fn listen_stream_eviction() {
 
     // QS events stream is evicted when another stream is opened
     let (mut stream_a, _responder_a) = alice_user.listen_queue().await.unwrap();
+    skip_version_status(&mut stream_a).await;
     assert_matches!(
         stream_a.next().await,
         Some(Ok(ListenResponse {
@@ -1435,6 +1448,7 @@ async fn listen_stream_eviction() {
     );
 
     let (mut stream_b, _responder_b) = alice_user.listen_queue().await.unwrap();
+    skip_version_status(&mut stream_b).await;
     assert_matches!(
         stream_b.next().await,
         Some(Ok(ListenResponse {
@@ -1491,6 +1505,7 @@ async fn listen_stream_durable_acks() {
     // Bob receives the message on the listen stream and acks it.
     let bob_user = &setup.get_user(&bob).user;
     let (mut stream, responder) = bob_user.listen_queue().await.unwrap();
+    skip_version_status(&mut stream).await;
     let sequence_number = match stream.next().await {
         Some(Ok(ListenResponse {
             event: Some(listen_response::Event::Message(message)),
@@ -1518,6 +1533,7 @@ async fn listen_stream_durable_acks() {
 
     // On reconnect, the acked message is not redelivered.
     let (mut stream, _responder) = bob_user.listen_queue().await.unwrap();
+    skip_version_status(&mut stream).await;
     assert_matches!(
         stream.next().await,
         Some(Ok(ListenResponse {


### PR DESCRIPTION
The server already blocks expired client versions, but users learn about
it once the app stop working. Now the QS listen stream opens with a
version status event carrying the expiry, if any, so a client with an
upcoming expiry can warn the user while the app still works.

The status is sent on every stream rather than only when expiring. The
client then simply mirrors the server and needs no logic to clear a
stale warning after a policy change.

The app shows a banner with the data and a link to the store. Dismissal
is stored as a device-local user setting keyed by the announced date. A
postponed expiry shows the banner again.