### PR TITLE
chore: synced contact blocking receive logic

### DIFF
--- a/coreclient/src/clients/block_contact/pending.rs
+++ b/coreclient/src/clients/block_contact/pending.rs
@@ -14,17 +14,13 @@
 //! changes, so two devices changing different contacts do not cancel each
 //! other.
 
-// The pending changes have no callers yet. The receive path and the send path
-// land in the next stages.
-#![allow(dead_code)]
-
 use aircommon::identifiers::UserId;
 use airprotos::client::{
     group_bootstrap::PeerUserId,
     self_group::{BlockedContactEntry, BlockedContactState, ContactBlocked, ContactUnblocked},
 };
 use chrono::{DateTime, Utc};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     db::access::{ReadConnection, WriteConnection, WriteDbTransaction},
@@ -61,6 +57,49 @@ impl BlockedState {
             Self::Unblocked => BlockedContactState::Unblocked(ContactUnblocked {}),
         }
     }
+
+    /// The state of an incoming entry.
+    ///
+    /// `None` for an entry this client cannot make sense of. For example, a
+    /// state a newer sibling knows and we do not, a timestamp outside the
+    /// representable range, or a display name that does not validate.
+    fn from_entry_state(state: &BlockedContactState) -> Option<Self> {
+        match state {
+            BlockedContactState::Blocked(ContactBlocked {
+                blocked_at,
+                last_display_name,
+            }) => {
+                let Some(blocked_at) = i64::try_from(*blocked_at)
+                    .ok()
+                    .and_then(|seconds| DateTime::from_timestamp(seconds, 0))
+                else {
+                    warn!(
+                        %blocked_at,
+                        "Skipping a blocked-contact entry with an out-of-range timestamp"
+                    );
+                    return None;
+                };
+                let last_display_name = last_display_name
+                    .parse()
+                    .inspect_err(|error| {
+                        warn!(
+                            %error,
+                            "Skipping a blocked-contact entry with an invalid display name"
+                        );
+                    })
+                    .ok()?;
+                Some(Self::Blocked {
+                    blocked_at,
+                    last_display_name,
+                })
+            }
+            BlockedContactState::Unblocked(ContactUnblocked {}) => Some(Self::Unblocked),
+            BlockedContactState::Unknown => {
+                debug!("Skipping a blocked-contact entry with an unknown state");
+                None
+            }
+        }
+    }
 }
 
 /// One contact's not-yet-synchronized blocked-state change.
@@ -76,6 +115,8 @@ pub(crate) struct PendingBlockedContactChange {
 
 impl PendingBlockedContactChange {
     /// Records a local blocked-state change.
+    // Called by the send path, which lands in the next stage.
+    #[allow(dead_code)]
     pub(crate) async fn record(
         txn: &mut WriteDbTransaction<'_>,
         user_id: &UserId,
@@ -136,6 +177,8 @@ impl PendingBlockedContactChange {
 
     /// Rolls the touched contacts back to the state stored before their first
     /// touch and clears the pending changes. Used when a send fails terminally.
+    // Called by the send path, which lands in the next stage.
+    #[allow(dead_code)]
     pub(crate) async fn roll_back_and_clear(txn: &mut WriteDbTransaction<'_>) -> sqlx::Result<()> {
         for pending in Self::load_all(&mut *txn).await? {
             let current = BlockedState::load(&mut *txn, &pending.user_id).await?;
@@ -149,6 +192,8 @@ impl PendingBlockedContactChange {
 
     /// Loads the pending changes as the entries a commit carries, sorted by
     /// user id so the encoding is canonical.
+    // Called by the send path, which lands in the next stage.
+    #[allow(dead_code)]
     pub(crate) async fn load_entries(
         connection: impl ReadConnection,
     ) -> sqlx::Result<Vec<BlockedContactEntry>> {
@@ -161,6 +206,29 @@ impl PendingBlockedContactChange {
             })
             .collect())
     }
+}
+
+/// Applies the entries of a sibling's accepted blocked-contacts update.
+///
+/// Entries apply in order, so the last entry for a contact wins. An entry
+/// this client cannot make sense of is skipped, see
+/// [`BlockedState::from_entry_state`] and [`parse_peer_user_id`]. Skipped
+/// entries still count as covered, so the caller hands the full list to
+/// [`PendingBlockedContactChange::remove_covered`] either way.
+pub(crate) async fn apply_blocked_contacts_update(
+    txn: &mut WriteDbTransaction<'_>,
+    entries: &[BlockedContactEntry],
+) -> sqlx::Result<()> {
+    for entry in entries {
+        let Some(user_id) = parse_peer_user_id(&entry.user_id) else {
+            continue;
+        };
+        let Some(state) = BlockedState::from_entry_state(&entry.state) else {
+            continue;
+        };
+        state.apply(&mut *txn, &user_id).await?;
+    }
+    Ok(())
 }
 
 /// Parses a user id off the wire, skipping ids that are not well-formed.
@@ -229,7 +297,7 @@ mod persistence {
 
     impl BlockedState {
         /// Reads the stored blocked state of a contact.
-        pub(super) async fn load(
+        pub(crate) async fn load(
             mut connection: impl ReadConnection,
             user_id: &UserId,
         ) -> sqlx::Result<Self> {
@@ -262,7 +330,7 @@ mod persistence {
 
         /// Writes this state to `blocked_contact`, emitting the same per-user
         /// change notification the local block and unblock paths emit.
-        pub(super) async fn apply(
+        pub(crate) async fn apply(
             &self,
             connection: impl WriteConnection,
             user_id: &UserId,

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -39,6 +39,7 @@ use tracing::{debug, error, instrument, warn};
 use crate::{
     clients::{
         api_clients::ApiClients,
+        block_contact::pending::{PendingBlockedContactChange, apply_blocked_contacts_update},
         user_settings::{SettingChanges, apply_settings_update, merge_settings_update},
     },
     db::access::WriteDbTransaction,
@@ -88,6 +89,14 @@ async fn apply_self_group_payload(
         for seed in &payload.token_seeds {
             privacy_pass::apply_incoming_seed(txn, seed).await?;
         }
+    }
+
+    if own_echo {
+        PendingBlockedContactChange::complete_sent(txn, &payload.blocked_contacts).await?;
+    } else {
+        apply_blocked_contacts_update(txn, &payload.blocked_contacts).await?;
+        // Contacts in a sibling's accepted commit are no longer ours to change.
+        PendingBlockedContactChange::remove_covered(txn, &payload.blocked_contacts).await?;
     }
 
     Ok(())
@@ -1067,14 +1076,60 @@ fn validate_join_connection_group_commit(
 
 #[cfg(test)]
 mod tests {
-    use aircommon::credentials::SelfGroupCredential;
+    use aircommon::{credentials::SelfGroupCredential, identifiers::UserId};
+    use airprotos::client::self_group::{
+        BlockedContactEntry, BlockedContactState, ContactBlocked, ContactUnblocked,
+    };
+    use chrono::DateTime;
     use openmls::prelude::LeafNodeIndex;
+    use sqlx::SqlitePool;
     use uuid::Uuid;
+
+    use crate::{clients::block_contact::pending::BlockedState, db::access::DbAccess};
 
     use super::*;
 
     fn self_group_credential(client_id: u128) -> LeafCredential {
         LeafCredential::SelfGroup(SelfGroupCredential::new(Uuid::from_u128(client_id)))
+    }
+
+    fn user(n: u128) -> UserId {
+        UserId::new(Uuid::from_u128(n), "localhost".parse().unwrap())
+    }
+
+    fn blocked_state(blocked_at: i64, last_display_name: &str) -> BlockedState {
+        BlockedState::Blocked {
+            blocked_at: DateTime::from_timestamp(blocked_at, 0).unwrap(),
+            last_display_name: last_display_name.parse().unwrap(),
+        }
+    }
+
+    fn blocked_entry(
+        user_id: &UserId,
+        blocked_at: u64,
+        last_display_name: &str,
+    ) -> BlockedContactEntry {
+        BlockedContactEntry {
+            user_id: user_id.clone().into(),
+            state: BlockedContactState::Blocked(ContactBlocked {
+                blocked_at,
+                last_display_name: last_display_name.to_owned(),
+            }),
+        }
+    }
+
+    fn unblocked_entry(user_id: &UserId) -> BlockedContactEntry {
+        BlockedContactEntry {
+            user_id: user_id.clone().into(),
+            state: BlockedContactState::Unblocked(ContactUnblocked {}),
+        }
+    }
+
+    fn blocked_contacts_payload(entries: Vec<BlockedContactEntry>) -> SelfGroupPayload {
+        SelfGroupPayload {
+            blocked_contacts: entries,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -1139,5 +1194,164 @@ mod tests {
                 "unexpected error: {error:#}"
             );
         }
+    }
+
+    #[sqlx::test]
+    async fn sibling_update_blocks_and_unblocks_contacts(pool: SqlitePool) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let to_block = user(1);
+        let to_unblock = user(2);
+
+        pool.with_write_transaction(async |txn| -> anyhow::Result<()> {
+            blocked_state(10, "Alice")
+                .apply(&mut *txn, &to_unblock)
+                .await?;
+
+            let payload = blocked_contacts_payload(vec![
+                blocked_entry(&to_block, 1_767_225_600, "Bob"),
+                unblocked_entry(&to_unblock),
+            ]);
+            apply_self_group_payload(txn, &payload, false).await?;
+
+            assert_eq!(
+                BlockedState::load(&mut *txn, &to_block).await?,
+                blocked_state(1_767_225_600, "Bob"),
+                "the block must keep the sender's timestamp and display name"
+            );
+            assert_eq!(
+                BlockedState::load(&mut *txn, &to_unblock).await?,
+                BlockedState::Unblocked
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    #[sqlx::test]
+    async fn sibling_update_drops_the_pending_change_it_covers(
+        pool: SqlitePool,
+    ) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let covered = user(1);
+        let untouched = user(2);
+
+        pool.with_write_transaction(async |txn| -> anyhow::Result<()> {
+            PendingBlockedContactChange::record(txn, &covered, blocked_state(10, "Alice")).await?;
+            PendingBlockedContactChange::record(txn, &untouched, blocked_state(20, "Bob")).await?;
+
+            let payload = blocked_contacts_payload(vec![unblocked_entry(&covered)]);
+            apply_self_group_payload(txn, &payload, false).await?;
+
+            assert_eq!(
+                BlockedState::load(&mut *txn, &covered).await?,
+                BlockedState::Unblocked,
+                "the sibling's state must win over our pending one"
+            );
+            assert_eq!(
+                PendingBlockedContactChange::load_entries(&mut *txn).await?,
+                vec![blocked_entry(&untouched, 20, "Bob")],
+                "a contact the update does not name must stay pending"
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    #[sqlx::test]
+    async fn own_echo_completes_without_reapplying(pool: SqlitePool) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let user = user(1);
+
+        pool.with_write_transaction(async |txn| -> anyhow::Result<()> {
+            PendingBlockedContactChange::record(txn, &user, blocked_state(10, "Alice")).await?;
+            let sent = PendingBlockedContactChange::load_entries(&mut *txn).await?;
+            // The stored state moved on after the commit went out.
+            blocked_state(30, "Alice B").apply(&mut *txn, &user).await?;
+
+            apply_self_group_payload(txn, &blocked_contacts_payload(sent), true).await?;
+
+            assert_eq!(
+                BlockedState::load(&mut *txn, &user).await?,
+                blocked_state(30, "Alice B"),
+                "an echo must not write the sent values back"
+            );
+            assert!(
+                PendingBlockedContactChange::load_entries(&mut *txn)
+                    .await?
+                    .is_empty(),
+                "the accepted commit must complete the pending change"
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    #[sqlx::test]
+    async fn sibling_update_skips_unusable_entries_but_covers_them(
+        pool: SqlitePool,
+    ) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let unknown_state = user(1);
+        let invalid_name = user(2);
+
+        pool.with_write_transaction(async |txn| -> anyhow::Result<()> {
+            PendingBlockedContactChange::record(txn, &unknown_state, blocked_state(10, "Alice"))
+                .await?;
+            PendingBlockedContactChange::record(txn, &invalid_name, blocked_state(20, "Bob"))
+                .await?;
+
+            let payload = blocked_contacts_payload(vec![
+                BlockedContactEntry {
+                    user_id: unknown_state.clone().into(),
+                    state: BlockedContactState::Unknown,
+                },
+                blocked_entry(&invalid_name, 30, " \n "),
+            ]);
+            apply_self_group_payload(txn, &payload, false).await?;
+
+            assert_eq!(
+                BlockedState::load(&mut *txn, &unknown_state).await?,
+                blocked_state(10, "Alice")
+            );
+            assert_eq!(
+                BlockedState::load(&mut *txn, &invalid_name).await?,
+                blocked_state(20, "Bob")
+            );
+            assert!(
+                PendingBlockedContactChange::load_entries(&mut *txn)
+                    .await?
+                    .is_empty()
+            );
+            Ok(())
+        })
+        .await
+    }
+
+    #[sqlx::test]
+    async fn the_last_entry_for_a_contact_wins(pool: SqlitePool) -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(pool);
+        let reblocked = user(1);
+        let unblocked = user(2);
+
+        pool.with_write_transaction(async |txn| -> anyhow::Result<()> {
+            let payload = blocked_contacts_payload(vec![
+                unblocked_entry(&reblocked),
+                blocked_entry(&unblocked, 40, "Bob"),
+                blocked_entry(&reblocked, 50, "Alice"),
+                unblocked_entry(&unblocked),
+            ]);
+            apply_self_group_payload(txn, &payload, false).await?;
+
+            assert_eq!(
+                BlockedState::load(&mut *txn, &reblocked).await?,
+                blocked_state(50, "Alice")
+            );
+            assert_eq!(
+                BlockedState::load(&mut *txn, &unblocked).await?,
+                BlockedState::Unblocked
+            );
+            Ok(())
+        })
+        .await
     }
 }

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -38,7 +38,8 @@ use aircommon::{
 use airprotos::client::{
     component::{AIR_COMPONENT_ID, AirComponent},
     self_group::{
-        AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate, TokenSeed,
+        AppEphemeralPayload, BlockedContactEntry, SelfGroupMessage, SelfGroupMessages,
+        SettingsUpdate, TokenSeed,
     },
     virtual_client::VirtualClientCommitData,
 };
@@ -348,8 +349,8 @@ impl Group {
                 match message {
                     SelfGroupMessage::SettingsUpdate(update) => extracted.updates.push(update),
                     SelfGroupMessage::TokenSeed(seed) => extracted.token_seeds.push(seed),
-                    SelfGroupMessage::BlockedContactsUpdate(_) => {
-                        debug!("Skipping blocked-contacts update, no receive path yet");
+                    SelfGroupMessage::BlockedContactsUpdate(update) => {
+                        extracted.blocked_contacts.extend(update.contacts);
                     }
                     // A message kind added by a newer client.
                     SelfGroupMessage::Unknown => debug!("Skipping unknown self-group message"),
@@ -368,11 +369,13 @@ pub(crate) struct SelfGroupPayload {
     pub(crate) updates: Vec<SettingsUpdate>,
     /// Token seeds published by the sender.
     pub(crate) token_seeds: Vec<TokenSeed>,
+    /// Blocked-contact changes.
+    pub(crate) blocked_contacts: Vec<BlockedContactEntry>,
 }
 
 impl SelfGroupPayload {
     pub(crate) fn is_empty(&self) -> bool {
-        self.updates.is_empty() && self.token_seeds.is_empty()
+        self.updates.is_empty() && self.token_seeds.is_empty() && self.blocked_contacts.is_empty()
     }
 }
 
@@ -517,7 +520,10 @@ mod derivation_tests {
     };
     use airprotos::client::{
         component::{AIR_COMPONENT_ID, AirComponent},
-        self_group::{AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate},
+        self_group::{
+            AppEphemeralPayload, BlockedContactEntry, BlockedContactState, BlockedContactsUpdate,
+            ContactBlocked, SelfGroupMessage, SelfGroupMessages, SettingsUpdate,
+        },
     };
     use openmls::group::{AppDataUpdateValidationError, CreateCommitError};
     use openmls::prelude::{AppEphemeralProposal, GroupId, Proposal};
@@ -538,6 +544,20 @@ mod derivation_tests {
             Uuid::new_v4(),
             "example.com".parse().unwrap(),
         ))
+    }
+
+    /// A one-entry blocked-contacts update, blocking `uuid` at `blocked_at`.
+    fn blocked_contacts_update(uuid: u128, blocked_at: u64) -> BlockedContactsUpdate {
+        let user_id = UserId::new(Uuid::from_u128(uuid), "example.com".parse().unwrap());
+        BlockedContactsUpdate {
+            contacts: vec![BlockedContactEntry {
+                user_id: user_id.into(),
+                state: BlockedContactState::Blocked(ContactBlocked {
+                    blocked_at,
+                    last_display_name: "Alice".to_owned(),
+                }),
+            }],
+        }
     }
 
     /// Per-device self-group signer and its leaf wrapper, as used by real
@@ -850,6 +870,52 @@ mod derivation_tests {
 
         assert_eq!(extracted.updates, vec![update]);
         assert!(extracted.token_seeds.is_empty());
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn extract_blocked_contacts_updates_keeps_entry_order() -> anyhow::Result<()> {
+        let pool = DbAccess::for_tests(open_db_in_memory().await?);
+        let (sg_signer, signer) = self_group_signer()?;
+        let user_id = UserId::random("example.com".parse()?);
+
+        let mut connection = pool.write().await?;
+        let mut txn = connection.begin().await?;
+
+        let mut group = create_group(&mut txn, &signer, user_id.clone(), true)?;
+        group.store(&mut txn).await?;
+        store_own_client_info(&mut txn, user_id).await?;
+
+        let first = blocked_contacts_update(1, 10);
+        let second = blocked_contacts_update(2, 20);
+        let proposal = group
+            .self_group_messages_proposal(
+                &mut txn,
+                vec![
+                    SelfGroupMessage::BlockedContactsUpdate(first.clone()),
+                    SelfGroupMessage::BlockedContactsUpdate(second.clone()),
+                ],
+            )
+            .await?;
+        group
+            .stage_self_group_message_commit(&mut txn, &sg_signer, proposal)
+            .await?;
+
+        let mut receiver = Group::load(&mut txn, group.group_id())
+            .await?
+            .expect("group stored above");
+        let staged = group
+            .mls_group()
+            .pending_commit()
+            .expect("commit should be staged");
+        let extracted = receiver.extract_self_group_messages(&mut txn, staged).await;
+
+        let mut expected = first.contacts;
+        expected.extend(second.contacts);
+        assert_eq!(extracted.blocked_contacts, expected);
+        assert!(extracted.updates.is_empty());
 
         txn.commit().await?;
         Ok(())


### PR DESCRIPTION
This PR adds the receiver-side logic required for a user's clients to sync blocked contacts.