### PR TITLE
fix(app): remove delay when tapping reaction chips

### DIFF
--- a/app/lib/features/message_list/text_message_tile.dart
+++ b/app/lib/features/message_list/text_message_tile.dart
@@ -573,6 +573,17 @@ class _MessageShell extends StatelessWidget {
         enableSelection: enableSelection,
       ),
     );
+    // Mobile: double-tap a message to react. Only wrap the bubble (not the
+    // reaction chips), otherwise it will delay other taps.
+    if (isMobilePlatform && isReplyable) {
+      bubble = GestureDetector(
+        onDoubleTap: () {
+          AppHaptics.confirm();
+          commands.openReactionMenu();
+        },
+        child: bubble,
+      );
+    }
     if (!enableSelection && isReplyable) {
       bubble = SwipeToReplyBubble(
         icon: AppIcon.cornerLeft(
@@ -618,15 +629,6 @@ class _MessageShell extends StatelessWidget {
             child: GestureDetector(
               behavior: .deferToChild,
               onTap: isHidden ? () => isRevealed.value = true : null,
-              // Mobile: double-tap a message to react. On desktop, the
-              // recognizer must not be registered at all, otherwise it wins the
-              // gesture arena and blocks double-click text selection.
-              onDoubleTap: isMobilePlatform && isReplyable
-                  ? () {
-                      AppHaptics.confirm();
-                      commands.openReactionMenu();
-                    }
-                  : null,
               onLongPress: onLongPress,
               child: band,
             ),


### PR DESCRIPTION
Double tap was delaying other taps, in particular the tap on an emoji chip. In this case, the emoji overview was shown with a delay. Only the mobile app was affected.