### PR TITLE
fix(app): don't open virtual keyboard on reactions

### DIFF
--- a/app/lib/ds/foundations/foundations.dart
+++ b/app/lib/ds/foundations/foundations.dart
@@ -32,6 +32,7 @@ export 'package:air/ds/foundations/device_type.dart';
 export 'package:air/ds/foundations/dimensions.dart';
 export 'package:air/ds/foundations/effects.dart';
 export 'package:air/ds/foundations/icons.dart';
+export 'package:air/ds/foundations/keyboard_focus.dart';
 export 'package:air/ds/foundations/monospace.dart';
 export 'package:air/ds/foundations/primitives.dart';
 export 'package:air/ds/foundations/semantic_colors.dart';

--- a/app/lib/ds/foundations/keyboard_focus.dart
+++ b/app/lib/ds/foundations/keyboard_focus.dart
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/widgets.dart';
+
+/// Keyboard focus parked while a modal is up.
+///
+/// Makes it possible to restore the focus of a node which has the primary
+/// focus, but only if the virtual keyboard was shown.
+///
+/// Call [suspend] before pushing the modal to drop that focus and [restore]
+/// once the modal is gone to bring the keyboard back only if it was showing
+/// before.
+class SuspendedKeyboardFocus {
+  SuspendedKeyboardFocus._(this._node);
+
+  /// The field to refocus, null when the keyboard was not showing.
+  final FocusNode? _node;
+
+  static SuspendedKeyboardFocus suspend(BuildContext context) {
+    final node = FocusManager.instance.primaryFocus;
+    final keyboardShown = View.of(context).viewInsets.bottom > 0;
+    node?.unfocus();
+    return SuspendedKeyboardFocus._(keyboardShown ? node : null);
+  }
+
+  void restore() {
+    final node = _node;
+    // Gone from the tree, e.g. the chat was left while the modal was up.
+    if (node == null || node.context == null || !node.canRequestFocus) return;
+    node.requestFocus();
+  }
+}

--- a/app/lib/ds/patterns/adaptive_modal/adaptive_modal.dart
+++ b/app/lib/ds/patterns/adaptive_modal/adaptive_modal.dart
@@ -61,26 +61,27 @@ Future<T?> _showBottomSheet<T>({
   bool enableDrag = true,
   Color? barrierColor,
 }) {
-  return Navigator.of(context, rootNavigator: true).push<T>(
-    _BottomSheetRoute<T>(
-      barrierDismissible: isDismissible,
-      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-      transitionDuration: Effect.duration(BottomSheetTokens.enter),
-      reverseDuration: Effect.duration(BottomSheetTokens.exit),
-      // The page drives every part of the transition off the route animation,
-      // so the route itself hands the child through untouched.
-      transitionBuilder: (context, animation, secondaryAnimation, child) =>
-          child,
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          _BottomSheetModal(
-            animation: animation,
-            builder: builder,
-            enableDrag: enableDrag,
-            contentPadding: contentPadding,
-            scrimColor: barrierColor,
-          ),
+  final focus = SuspendedKeyboardFocus.suspend(context);
+  final route = _BottomSheetRoute<T>(
+    barrierDismissible: isDismissible,
+    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    transitionDuration: Effect.duration(BottomSheetTokens.enter),
+    reverseDuration: Effect.duration(BottomSheetTokens.exit),
+    // The page drives every part of the transition off the route animation,
+    // so the route itself hands the child through untouched.
+    transitionBuilder: (context, animation, secondaryAnimation, child) => child,
+    pageBuilder: (context, animation, secondaryAnimation) => _BottomSheetModal(
+      animation: animation,
+      builder: builder,
+      enableDrag: enableDrag,
+      contentPadding: contentPadding,
+      scrimColor: barrierColor,
     ),
   );
+  // Only once the sheet has slid out, so the keyboard does not push a card
+  // that is still on its way down.
+  unawaited(route.completed.then((_) => focus.restore()));
+  return Navigator.of(context, rootNavigator: true).push<T>(route);
 }
 
 /// A dialog route whose exit is quicker than its entry, which

--- a/app/lib/features/message_list/mobile_message_actions.dart
+++ b/app/lib/features/message_list/mobile_message_actions.dart
@@ -43,6 +43,7 @@ Future<void> showMobileMessageActions({
   void Function(String emoji)? onReact,
   VoidCallback? onReactMore,
 }) {
+  final focus = SuspendedKeyboardFocus.suspend(context);
   // Drop taps that land during the closing transition.
   var consumed = false;
   // Deliver a picked reaction only after the exit transition settled.
@@ -69,9 +70,9 @@ Future<void> showMobileMessageActions({
       if (!exitListenerAttached) {
         exitListenerAttached = true;
         animation.addStatusListener((status) {
-          if (status == .dismissed && pickedEmoji != null) {
-            onReact?.call(pickedEmoji!);
-          }
+          if (status != .dismissed) return;
+          if (pickedEmoji != null) onReact?.call(pickedEmoji!);
+          focus.restore();
         });
       }
 


### PR DESCRIPTION
If the virtual keyboard is closed, it stays closed after a reaction / closing bubble context menu / reactions overview bottom sheet. Every such action closes the keyboard, if it was open, but restores it after it is done.