### PR TITLE
fix(app): leave group vc double system message

### DIFF
--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -2474,6 +2474,20 @@ impl Group {
         })
     }
 
+    /// Whether the proposal store holds a self-remove proposal from our own leaf.
+    pub(crate) fn has_pending_own_self_remove(&self) -> bool {
+        let own_index = self.mls_group().own_leaf_index();
+        self.mls_group().pending_proposals().any(|p| {
+            if let Proposal::SelfRemove = p.proposal()
+                && let Sender::Member(index) = p.sender()
+            {
+                *index == own_index
+            } else {
+                false
+            }
+        })
+    }
+
     fn staged_commit_removes(
         &self,
         staged_commit: Option<&'_ StagedCommit>,

--- a/coreclient/src/job/chat_operation.rs
+++ b/coreclient/src/job/chat_operation.rs
@@ -348,14 +348,36 @@ impl ChatOperation {
         context: &mut JobContext<'_, '_>,
     ) -> Result<Vec<ChatMessage>, JobError<ChatOperationError>> {
         let JobContext { db, key_store, .. } = context;
-        let job = db
+        let Some(job) = db
             .write()
             .await?
             .with_transaction(async |txn| {
-                PendingChatOperation::create_leave(txn, &key_store.signing_key, self.chat_id).await
-            })
-            .await?;
+                let mut chat = Chat::load(&mut *txn, &self.chat_id)
+                    .await?
+                    .with_context(|| format!("No chat with id {}", self.chat_id))?;
+                let group = Group::load_clean_verified(&mut *txn, chat.group_id())
+                    .await?
+                    .with_context(|| format!("No group with id {:?}", chat.group_id()))?;
 
+                // Short-circuit if the group has already a pending self-remove proposal from our
+                // own leaf from other virtual client.
+                if group.group().has_pending_own_self_remove() {
+                    if !matches!(chat.status(), ChatStatus::Inactive(_)) {
+                        // A leave system message is already recorded. Just deactivate the chat.
+                        chat.set_status(&mut *txn, ChatStatus::inactive(Vec::new()))
+                            .await?;
+                    }
+                    return Ok(None);
+                }
+
+                PendingChatOperation::create_leave(txn, &key_store.signing_key, self.chat_id)
+                    .await
+                    .map(Some)
+            })
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
         job.execute(context).await
     }
 

--- a/server/tests/tests/multi_device.rs
+++ b/server/tests/tests/multi_device.rs
@@ -6,7 +6,8 @@ use std::collections::HashSet;
 
 use aircommon::{credentials::LeafCredential, identifiers::UserId};
 use aircoreclient::{
-    ChatId, ChatStatus, ChatType, Message, ReadReceiptsSetting, UserProfile,
+    ChatId, ChatStatus, ChatType, EventMessage, Message, ReadReceiptsSetting, SystemMessage,
+    UserProfile,
     clients::{
         CoreUser, MarkChatAsRead,
         multi_device::{MultiDeviceLinkClientError, MultiDeviceProvisionStep},
@@ -16,7 +17,9 @@ use airprotos::{auth_service::v1::OperationType, relay_service::v1::LinkingSessi
 use airserver_test_harness::utils::setup::TestBackend;
 use chrono::{DateTime, Utc};
 use mimi_content::{MessageStatus, MimiContent};
+use std::time::Duration;
 use tempfile::TempDir;
+use tokio::time::sleep;
 use uuid::Uuid;
 
 /// Sends `text` from `sender` into the self-group chat and asserts that
@@ -2242,5 +2245,375 @@ async fn multi_device_own_echo_confirms_unconfirmed_edit() {
         count_messages_with_text(bob_device, chat_id, FINAL_TEXT).await,
         1,
         "bob should see the second edit"
+    );
+}
+
+/// Alice in a group with Bob and Charlie, plus a second linked device of Alice
+/// that has onboarded itself into the group. Both of Alice's devices are
+/// drained, so they sit on the same epoch of the shared leaf.
+async fn setup_group_with_linked_device() -> (
+    TestBackend,
+    UserId,
+    UserId,
+    UserId,
+    ChatId,
+    CoreUser,
+    TempDir,
+) {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+    let bob = setup.add_user().await;
+    setup.connect_users(&alice, &bob).await;
+    let charlie = setup.add_user().await;
+    setup.connect_users(&alice, &charlie).await;
+
+    let chat_id = setup.create_group(&alice).await;
+    setup
+        .invite_to_group(chat_id, &alice, vec![&bob, &charlie])
+        .await;
+
+    let (new_device, tmp) = link_new_device(&setup, &alice).await;
+    // Onboarding into the pre-existing group runs in the background.
+    new_device.outbound_service().run_once().await;
+    drain_queue(setup.get_user(&alice).user()).await;
+    drain_queue(&new_device).await;
+
+    (setup, alice, bob, charlie, chat_id, new_device, tmp)
+}
+
+/// Drains the device's queue and fails the test if any message could not be
+/// processed.
+async fn drain_queue_ok(user: &CoreUser, what: &str) {
+    let messages = user.qs_fetch_messages().await.unwrap();
+    let processed = user.fully_process_qs_messages(messages).await;
+    assert!(
+        processed.errors.is_empty(),
+        "{what}: {:?}",
+        processed.errors
+    );
+}
+
+/// How many "`user_id` left" system messages the device stores for the chat.
+async fn count_self_removes(user: &CoreUser, chat_id: ChatId, user_id: &UserId) -> usize {
+    user.messages(chat_id, 100)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|message| {
+            matches!(
+                message.message(),
+                Message::Event(EventMessage::System(SystemMessage::Remove(remover, removed)))
+                    if remover == user_id && removed == user_id
+            )
+        })
+        .count()
+}
+
+/// Asserts that the device's chat is inactive. With `past_members` given,
+/// also asserts whom the chat remembers. A leave only records the members
+/// once the removal is committed, so the check right after the leave passes
+/// `None`.
+async fn assert_inactive(
+    user: &CoreUser,
+    chat_id: ChatId,
+    past_members: Option<&HashSet<UserId>>,
+    what: &str,
+) {
+    let chat = user.chat(&chat_id).await.unwrap();
+    match chat.status() {
+        ChatStatus::Inactive(inactive) => {
+            if let Some(past_members) = past_members {
+                let remembered: HashSet<_> = inactive.past_members().iter().cloned().collect();
+                assert_eq!(&remembered, past_members, "{what}: wrong past members");
+            }
+        }
+        status => panic!("{what}: expected an inactive chat, got {status:?}"),
+    }
+}
+
+/// `leaver` leaves the group while `sibling` shares the leaf. The sibling sees
+/// the pending self-remove on the shared leaf, the leaver copes with the echo of
+/// its own proposal, and both devices turn the chat inactive once bob commits.
+async fn leave_and_follow(
+    setup: &TestBackend,
+    alice: &UserId,
+    bob: &UserId,
+    charlie: &UserId,
+    chat_id: ChatId,
+    leaver: &CoreUser,
+    sibling: &CoreUser,
+) {
+    let all_members: HashSet<UserId> = [alice, bob, charlie].into_iter().cloned().collect();
+    let remaining: HashSet<UserId> = [bob, charlie].into_iter().cloned().collect();
+
+    leaver.leave_chat(chat_id).await.unwrap();
+    assert_inactive(
+        leaver,
+        chat_id,
+        None,
+        "the leaver turns the chat inactive right away",
+    )
+    .await;
+    assert_eq!(count_self_removes(leaver, chat_id, alice).await, 1);
+
+    // The DS fans the self-remove back to the shared leaf, so the sibling learns
+    // about it from the queue, like any other member does.
+    drain_queue_ok(
+        sibling,
+        "the sibling failed to process the self-remove of its own leaf",
+    )
+    .await;
+    assert_eq!(
+        sibling.pending_removes(chat_id).await.unwrap(),
+        vec![alice.clone()],
+        "the sibling should hold the pending removal of its own leaf"
+    );
+    assert_eq!(count_self_removes(sibling, chat_id, alice).await, 1);
+
+    // The leaver already holds the proposal, so the echo must be a no-op.
+    drain_queue_ok(
+        leaver,
+        "the leaver failed to process the echo of its own self-remove",
+    )
+    .await;
+    assert_eq!(
+        count_self_removes(leaver, chat_id, alice).await,
+        1,
+        "the echo of the own self-remove must not add a second system message"
+    );
+
+    // Another member commits the pending self-remove.
+    let bob_user = setup.get_user(bob).user();
+    drain_queue_ok(bob_user, "bob failed to process the self-remove").await;
+    assert_eq!(
+        bob_user.pending_removes(chat_id).await.unwrap(),
+        vec![alice.clone()]
+    );
+    bob_user.update_key(chat_id).await.unwrap();
+    assert_eq!(
+        bob_user.mls_chat_participants(chat_id).await.unwrap(),
+        remaining
+    );
+
+    // Both of alice's devices follow the commit that removes their shared leaf.
+    drain_queue_ok(sibling, "the sibling failed to process the commit").await;
+    assert_inactive(
+        sibling,
+        chat_id,
+        Some(&all_members),
+        "the sibling turns the chat inactive with the commit",
+    )
+    .await;
+    drain_queue_ok(leaver, "the leaver failed to process the commit").await;
+    assert_inactive(
+        leaver,
+        chat_id,
+        Some(&all_members),
+        "the leaver keeps the chat inactive",
+    )
+    .await;
+    for (device, what) in [(leaver, "leaver"), (sibling, "sibling")] {
+        assert_eq!(
+            count_self_removes(device, chat_id, alice).await,
+            1,
+            "the {what} must record the leave exactly once"
+        );
+        assert!(
+            device
+                .pending_chat_operation_info(chat_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "the {what} must not keep a pending operation for the left group"
+        );
+    }
+
+    let charlie_user = setup.get_user(charlie).user();
+    drain_queue_ok(charlie_user, "charlie failed to process the commit").await;
+    assert_eq!(
+        charlie_user.mls_chat_participants(chat_id).await.unwrap(),
+        remaining
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Leave a group from the linked device", skip_all)]
+async fn multi_device_leave_from_linked_device_is_followed_by_the_sibling() {
+    let (setup, alice, bob, charlie, chat_id, new_device, _tmp) =
+        setup_group_with_linked_device().await;
+    let old_device = setup.get_user(&alice).user();
+
+    leave_and_follow(
+        &setup,
+        &alice,
+        &bob,
+        &charlie,
+        chat_id,
+        &new_device,
+        old_device,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Leave a group from the old device", skip_all)]
+async fn multi_device_leave_from_old_device_is_followed_by_the_linked_device() {
+    let (setup, alice, bob, charlie, chat_id, new_device, _tmp) =
+        setup_group_with_linked_device().await;
+    let old_device = setup.get_user(&alice).user();
+
+    leave_and_follow(
+        &setup,
+        &alice,
+        &bob,
+        &charlie,
+        chat_id,
+        old_device,
+        &new_device,
+    )
+    .await;
+}
+
+/// A leave whose DS response got lost is retried with the same proposal. The
+/// DS fans the retry out to the shared leaf again, and the sibling must treat
+/// it as the duplicate it is.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Retried leave is ignored by the sibling", skip_all)]
+async fn multi_device_retried_leave_is_ignored_by_the_sibling() {
+    let (setup, alice, bob, charlie, chat_id, new_device, _tmp) =
+        setup_group_with_linked_device().await;
+    let old_device = setup.get_user(&alice).user();
+    let all_members: HashSet<UserId> = [&alice, &bob, &charlie].into_iter().cloned().collect();
+
+    setup.listener_control_handle().set_drop_next_response();
+    old_device.leave_chat(chat_id).await.unwrap();
+    let pending = old_device
+        .pending_chat_operation_info(chat_id)
+        .await
+        .unwrap()
+        .expect("the leave must stay pending after the dropped response");
+    assert_eq!(pending.operation_type, "leave");
+    assert_inactive(old_device, chat_id, None, "the leaver").await;
+
+    // The DS did accept the proposal, so the sibling sees it once.
+    drain_queue_ok(&new_device, "the sibling failed to process the self-remove").await;
+    assert_eq!(count_self_removes(&new_device, chat_id, &alice).await, 1);
+
+    // The retry re-sends the same proposal.
+    sleep(Duration::from_secs(2)).await;
+    drain_queue_ok(old_device, "the leaver failed to process its queue").await;
+    old_device.outbound_service().run_once().await;
+    assert!(
+        old_device
+            .pending_chat_operation_info(chat_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the retry must complete the pending leave"
+    );
+
+    drain_queue_ok(
+        &new_device,
+        "the sibling failed to process the retried self-remove",
+    )
+    .await;
+    assert_eq!(
+        count_self_removes(&new_device, chat_id, &alice).await,
+        1,
+        "the retried self-remove must not be recorded twice"
+    );
+    assert_eq!(
+        new_device.pending_removes(chat_id).await.unwrap(),
+        vec![alice.clone()]
+    );
+
+    // Bob commits and both devices turn the chat inactive.
+    let bob_user = setup.get_user(&bob).user();
+    drain_queue_ok(bob_user, "bob failed to process the self-remove").await;
+    bob_user.update_key(chat_id).await.unwrap();
+
+    drain_queue_ok(&new_device, "the sibling failed to process the commit").await;
+    assert_inactive(&new_device, chat_id, Some(&all_members), "the sibling").await;
+    drain_queue_ok(old_device, "the leaver failed to process the commit").await;
+    assert_inactive(old_device, chat_id, Some(&all_members), "the leaver").await;
+    assert_eq!(count_self_removes(&new_device, chat_id, &alice).await, 1);
+    assert_eq!(count_self_removes(old_device, chat_id, &alice).await, 1);
+}
+
+/// Both devices leave before anyone commits: the second leave proposes the
+/// removal of a leaf that is already pending removal. Neither device may end up
+/// with a duplicate record or a stuck pending operation, and the group must
+/// still converge on the commit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Both devices leave before the commit", skip_all)]
+async fn multi_device_both_devices_leave_before_the_commit() {
+    let (setup, alice, bob, charlie, chat_id, new_device, _tmp) =
+        setup_group_with_linked_device().await;
+    let old_device = setup.get_user(&alice).user();
+    let all_members: HashSet<UserId> = [&alice, &bob, &charlie].into_iter().cloned().collect();
+    let remaining: HashSet<UserId> = [&bob, &charlie].into_iter().cloned().collect();
+
+    new_device.leave_chat(chat_id).await.unwrap();
+    drain_queue_ok(
+        old_device,
+        "the old device failed to process the self-remove",
+    )
+    .await;
+
+    // The user leaves on the other device as well.
+    old_device.leave_chat(chat_id).await.unwrap();
+    assert_inactive(old_device, chat_id, None, "the second leaver").await;
+
+    drain_queue_ok(
+        &new_device,
+        "the first leaver failed to process the second leave",
+    )
+    .await;
+    drain_queue_ok(old_device, "the second leaver failed to process its echo").await;
+    for (device, what) in [(&new_device, "first leaver"), (old_device, "second leaver")] {
+        assert_eq!(
+            count_self_removes(device, chat_id, &alice).await,
+            1,
+            "the {what} must record the leave exactly once"
+        );
+        assert_eq!(
+            device.pending_removes(chat_id).await.unwrap(),
+            vec![alice.clone()],
+            "the {what} must hold a single pending removal"
+        );
+    }
+
+    let bob_user = setup.get_user(&bob).user();
+    drain_queue_ok(bob_user, "bob failed to process the self-removes").await;
+    assert_eq!(
+        bob_user.pending_removes(chat_id).await.unwrap(),
+        vec![alice.clone()],
+        "bob must see the shared leaf pending removal once"
+    );
+    bob_user.update_key(chat_id).await.unwrap();
+    assert_eq!(
+        bob_user.mls_chat_participants(chat_id).await.unwrap(),
+        remaining
+    );
+
+    for (device, what) in [(&new_device, "first leaver"), (old_device, "second leaver")] {
+        drain_queue_ok(device, &format!("the {what} failed to process the commit")).await;
+        assert_inactive(device, chat_id, Some(&all_members), what).await;
+        assert_eq!(count_self_removes(device, chat_id, &alice).await, 1);
+        assert!(
+            device
+                .pending_chat_operation_info(chat_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "the {what} must not keep a pending operation"
+        );
+    }
+
+    let charlie_user = setup.get_user(&charlie).user();
+    drain_queue_ok(charlie_user, "charlie failed to process the commit").await;
+    assert_eq!(
+        charlie_user.mls_chat_participants(chat_id).await.unwrap(),
+        remaining
     );
 }


### PR DESCRIPTION
When two virtual clients leave a group at the same time, the leave system message was recorded twice. This fix skips the second leave when there is a pending self-remove proposal from the other virtual client, and just deactivates the chat.