### PR TITLE
refactor: introduce typed views of Air's MLS app data dictionary 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
 criterion = { version = "0.8.2", features = ["html_reports", "async", "async_tokio"] }
 dashmap = "6.1.0"
-derive_more = { version = "2.1.1", features = ["from"] }
+derive_more = { version = "2.1.1", features = ["from", "display"] }
 deunicode = "1.6.2"
 digest-io = "0.1.0"
 displaydoc = "0.2.5"

--- a/backend/src/ds/create_group.rs
+++ b/backend/src/ds/create_group.rs
@@ -8,7 +8,7 @@ use aircommon::{
     identifiers::{QsReference, QualifiedGroupId},
 };
 use airprotos::{
-    client::component::AirComponent,
+    client::app_data::GroupAppData,
     convert::TryRefInto,
     delivery_service::v1::{GroupSessionData, UserCredential as UserCredentialProto},
     validation::{InvalidTlsExt, MissingFieldExt},
@@ -102,7 +102,7 @@ impl<Qep: QsConnector, As: AsConnector> GrpcDs<Qep, As> {
         let leaf_credential = LeafCredential::from_credential(&member.credential)
             .map_err(|_| Status::invalid_argument("invalid credential"))?;
         let is_self_group =
-            AirComponent::is_self_group_context(group.group_info().group_context().extensions());
+            GroupAppData::is_self_group_context(group.group_info().group_context().extensions());
         if !leaf_credential_matches_flag(&leaf_credential, is_self_group) {
             return Err(Status::invalid_argument(
                 "creator leaf credential does not match group kind",

--- a/backend/src/ds/group_state/mod.rs
+++ b/backend/src/ds/group_state/mod.rs
@@ -15,10 +15,9 @@ use aircommon::{
         errors::{DecryptionError, EncryptionError},
     },
     identifiers::{QsReference, SealedClientReference},
-    mls_group_config::leaf_node_is_virtual_client,
     time::TimeStamp,
 };
-use airprotos::client::component::AirComponent;
+use airprotos::client::app_data::{ClientAppData, GroupAppData};
 use apqmls::extension::ApqInfo;
 use mimi_room_policy::{MimiProposal, RoleIndex, RoomState, VerifiedRoomState};
 use mls_assist::{
@@ -285,32 +284,32 @@ impl DsGroupState {
             .map(|(_, client_profile)| client_profile.client_queue_config.clone())
     }
 
-    /// Returns `true` if the group context's [`AirComponent`] marks this group as a
+    /// Returns `true` if the group context's [`GroupAppData`] marks this group as a
     /// self-group. The flag is fixed at group creation.
     pub(crate) fn is_self_group(&self) -> bool {
-        AirComponent::is_self_group_context(self.group().group_info().group_context().extensions())
+        GroupAppData::is_self_group_context(self.group().group_info().group_context().extensions())
     }
 
-    /// If the group context's [`AirComponent`] marks this group
+    /// If the group context's [`GroupAppData`] marks this group
     /// as a virtual-client self-group, disable virtual-client broadcasting.
     pub(crate) fn broadcast_to_all_client_queues(&self) -> bool {
         !self.is_self_group()
     }
 
-    /// The self-group flag in the group context's [`AirComponent`] is fixed at
+    /// The self-group flag in the group context's [`GroupAppData`] is fixed at
     /// group creation. Returns `true` if merging `staged_commit` keeps it
     /// unchanged.
     pub(crate) fn self_group_flag_unchanged(&self, staged_commit: &StagedCommit) -> bool {
         let current_extensions = self.group().group_info().group_context().extensions();
-        AirComponent::is_self_group_context(staged_commit.group_context().extensions())
-            == AirComponent::is_self_group_context(current_extensions)
+        GroupAppData::is_self_group_context(staged_commit.group_context().extensions())
+            == GroupAppData::is_self_group_context(current_extensions)
     }
 
     /// Returns `true` if the leaf declares a `VC_COMPONENT_ID` entry in its `AppDataDictionary` extension.
     pub(super) fn leaf_is_virtual_client(&self, leaf_index: LeafNodeIndex) -> bool {
         self.group()
             .leaf(leaf_index)
-            .is_some_and(leaf_node_is_virtual_client)
+            .is_some_and(ClientAppData::leaf_is_virtual_client)
     }
 
     /// The queue reference recorded for `leaf_index`, if any.

--- a/backend/src/ds/resync.rs
+++ b/backend/src/ds/resync.rs
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use aircommon::{
-    credentials::LeafCredential, identifiers::QsReference,
-    mls_group_config::leaf_node_is_virtual_client, utils::removed_clients,
-};
+use aircommon::{credentials::LeafCredential, identifiers::QsReference, utils::removed_clients};
+use airprotos::client::app_data::ClientAppData;
 use mimi_room_policy::RoleIndex;
 use mls_assist::{
     group::{
@@ -162,7 +160,7 @@ impl DsGroupState {
         let sibling_queue = (!self.leaf_is_virtual_client(sender_index)
             && staged_commit_message
                 .update_path_leaf_node()
-                .is_some_and(leaf_node_is_virtual_client))
+                .is_some_and(ClientAppData::leaf_is_virtual_client))
         .then(|| self.queue_config_at(sender_index))
         .flatten();
 
@@ -337,7 +335,7 @@ impl DsGroupState {
         let sibling_queue = (!t_group_state.leaf_is_virtual_client(t_sender_index)
             && t_staged_commit
                 .update_path_leaf_node()
-                .is_some_and(leaf_node_is_virtual_client))
+                .is_some_and(ClientAppData::leaf_is_virtual_client))
         .then(|| t_group_state.queue_config_at(t_sender_index))
         .flatten();
 

--- a/common/src/mls_group_config.rs
+++ b/common/src/mls_group_config.rs
@@ -5,44 +5,15 @@
 //! Configuration for MLS groups.
 
 use apqmls::ApqCiphersuite;
-use mls_assist::{
-    components::ComponentsList,
-    openmls::{
-        component::{ComponentId, ComponentType},
-        components::vc_derivation_info::VC_COMPONENT_ID,
-        group::{MlsGroupJoinConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
-        prelude::{
-            AppDataDictionary, AppDataDictionaryExtension, Capabilities, Ciphersuite,
-            CredentialType, Extension, ExtensionType, ExtensionValidator, Extensions,
-            InvalidExtensionError, KeyPackage, LeafNode, ProposalType, ProtocolVersion,
-            RequiredCapabilitiesExtension, SenderRatchetConfiguration,
-        },
+use mls_assist::openmls::{
+    group::{MlsGroupJoinConfig, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
+    prelude::{
+        Capabilities, Ciphersuite, CredentialType, ExtensionType, ProposalType, ProtocolVersion,
+        RequiredCapabilitiesExtension, SenderRatchetConfiguration,
     },
 };
-use tls_codec::{DeserializeBytes, Serialize};
-use tracing::warn;
 
 use crate::credentials::SELF_GROUP_CREDENTIAL_TYPE;
-
-/// An app-level MLS component that can be stored in the app data dictionary of a group, leaf node,
-/// or key package.
-///
-/// This is a dependency-inversion. The implementation lives in higher-level crates so that this
-/// crate stays free of any specific component's data model.
-pub trait AppComponent {
-    /// The component id under which the serialized component is stored in the app data dictionary.
-    const COMPONENT_ID: ComponentId;
-
-    /// The default component instance to store in a freshly-created leaf node or key package.
-    fn default_for_leaf_or_key_package() -> Self;
-
-    /// The default component instance to store in a freshly-created self-group for virtual clients.
-    fn default_for_self_group() -> Self;
-
-    /// Serializes the component into the on-the-wire bytes that are stored in the app data
-    /// dictionary.
-    fn to_bytes(&self) -> Vec<u8>;
-}
 
 /// Dictates for how many past epochs we want to keep around message secrets.
 pub const MAX_PAST_EPOCHS: usize = 5;
@@ -146,140 +117,9 @@ pub fn self_group_leaf_node_capabilities() -> Capabilities {
     )
 }
 
-/// Extension used in the leaf node.
-pub fn default_leaf_node_extensions<C: AppComponent>() -> Extensions<LeafNode> {
-    default_extensions::<LeafNode, C>()
-}
-
-/// Extensions for a leaf node that is operated by a virtual client.
-pub fn vc_leaf_node_extensions<C: AppComponent>() -> Extensions<LeafNode> {
-    Extensions::from_vec(vec![app_data_dictionary_extension::<C>(&[VC_COMPONENT_ID])])
-        .expect("invalid extensions")
-}
-
-/// Returns `true` if the leaf is operated by a virtual client.
-///
-/// [`vc_leaf_node_extensions`] adds [`VC_COMPONENT_ID`] to the app data components
-/// it when the leaf is first created for a virtual client, and later commits carry it over.
-pub fn leaf_node_is_virtual_client(leaf: &LeafNode) -> bool {
-    leaf.extensions()
-        .app_data_dictionary()
-        .and_then(|ext| ext.dictionary().get(&ComponentType::AppComponents.into()))
-        .and_then(|data| {
-            ComponentsList::tls_deserialize_exact_bytes(data)
-                .inspect_err(|error| {
-                    warn!(%error, "Failed to deserialize app components");
-                })
-                .ok()
-        })
-        .is_some_and(|list| list.component_ids.contains(&VC_COMPONENT_ID))
-}
-
-/// Extension used in the key package.
-pub fn default_key_package_extensions<C: AppComponent>() -> Extensions<KeyPackage> {
-    default_extensions::<KeyPackage, C>()
-}
-
-/// # Panics
-///
-/// Since we are building a single static essential extension here, we can assume that this
-/// function never panics. Panic-safety is additionally tested in the unit tests.
-fn default_extensions<T, C>() -> Extensions<T>
-where
-    T: ExtensionValidator,
-    InvalidExtensionError: From<T::Error>,
-    C: AppComponent,
-{
-    Extensions::from_vec(vec![default_app_data_dictionary_extension::<C>()])
-        .expect("invalid extensions")
-}
-
-/// Extension which contains the default app data dictionary for the group context.
-///
-/// Embeds `component` in the dictionary and advertises it via the `AppComponents` entry.
-///
-/// If `safe_aad_required` is true, the app data dictionary sets the `SafeAad` component as a
-/// required component.
-pub fn default_group_context_app_data_dictionary_extension<C: AppComponent>(
-    component: C,
-    safe_aad_components: Option<Vec<ComponentId>>,
-) -> Extension {
-    let mut component_ids = vec![C::COMPONENT_ID];
-    if safe_aad_components.is_some() {
-        component_ids.push(ComponentType::SafeAad.into());
-    }
-
-    let mut app_data_dictionary = AppDataDictionary::new();
-    app_data_dictionary.insert(
-        ComponentType::AppComponents.into(),
-        ComponentsList { component_ids }
-            .tls_serialize_detached()
-            .expect("invalid component list"),
-    );
-    app_data_dictionary.insert(C::COMPONENT_ID, component.to_bytes());
-    if let Some(component_ids) = safe_aad_components {
-        app_data_dictionary.insert(
-            ComponentType::SafeAad.into(),
-            ComponentsList { component_ids }
-                .tls_serialize_detached()
-                .expect("invalid component list"),
-        );
-    }
-
-    Extension::AppDataDictionary(AppDataDictionaryExtension::new(app_data_dictionary))
-}
-
-/// Extension which contains the default app data dictionary for the leaf node/key package.
-pub fn default_app_data_dictionary_extension<C: AppComponent>() -> Extension {
-    app_data_dictionary_extension::<C>(&[])
-}
-
-fn app_data_dictionary_extension<C: AppComponent>(
-    extra_component_ids: &[ComponentId],
-) -> Extension {
-    let mut component_ids = vec![C::COMPONENT_ID];
-    component_ids.extend_from_slice(extra_component_ids);
-
-    let mut app_data_dictionary = AppDataDictionary::new();
-
-    // Advertise that we support the component in the app data dictionary.
-    app_data_dictionary.insert(
-        ComponentType::AppComponents.into(),
-        ComponentsList { component_ids }
-            .tls_serialize_detached()
-            .expect("invalid component list"),
-    );
-
-    // Add the component to the app data dictionary.
-    app_data_dictionary.insert(
-        C::COMPONENT_ID,
-        C::default_for_leaf_or_key_package().to_bytes(),
-    );
-
-    Extension::AppDataDictionary(AppDataDictionaryExtension::new(app_data_dictionary))
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-
-    struct TestComponent;
-
-    impl AppComponent for TestComponent {
-        const COMPONENT_ID: ComponentId = 0x8043;
-
-        fn default_for_leaf_or_key_package() -> Self {
-            Self
-        }
-
-        fn default_for_self_group() -> Self {
-            Self
-        }
-
-        fn to_bytes(&self) -> Vec<u8> {
-            b"test".to_vec()
-        }
-    }
 
     #[test]
     fn required_capabilities_is_subset_of_supported_capabilities() {
@@ -302,64 +142,5 @@ mod test {
         for capability in group_extensions {
             assert!(leaf_node_extensions.contains(capability));
         }
-    }
-
-    fn dictionary_of(extension: Extension) -> AppDataDictionary {
-        let Extension::AppDataDictionary(extension) = extension else {
-            panic!("not an app data dictionary extension");
-        };
-        extension.dictionary().clone()
-    }
-
-    /// `safe_aad_required()` on the group context checks for a dictionary entry whose *key* is the
-    /// SafeAad component id. This pins that the helper puts the marker in the right place: a wrong
-    /// placement compiles and runs, but silently disables the entire SafeAAD pipeline.
-    #[test]
-    fn group_context_dictionary_with_safe_aad() {
-        const REQUIRED_SAFE_AAD_COMPONENT_ID: ComponentId = 0x8042;
-        let dictionary = dictionary_of(default_group_context_app_data_dictionary_extension(
-            TestComponent,
-            Some(vec![REQUIRED_SAFE_AAD_COMPONENT_ID]),
-        ));
-
-        // The SafeAad entry is present as a dictionary key...
-        let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
-        assert!(dictionary.contains(&safe_aad_id));
-
-        // ...and its value parses as a `ComponentsList` carrying the given ids
-        // (`safe_aad_required_components()` errors on unparsable values).
-        let value = dictionary.get(&safe_aad_id).unwrap();
-        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
-        assert_eq!(list.component_ids, vec![REQUIRED_SAFE_AAD_COMPONENT_ID]);
-
-        // The AppComponents entry is present and parseable, too, and advertises the embedded
-        // component.
-        let value = dictionary
-            .get(&ComponentId::from(ComponentType::AppComponents))
-            .unwrap();
-        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
-        assert!(list.component_ids.contains(&TestComponent::COMPONENT_ID));
-
-        // The component itself is embedded in the dictionary.
-        assert_eq!(
-            dictionary.get(&TestComponent::COMPONENT_ID).unwrap(),
-            TestComponent.to_bytes()
-        );
-    }
-
-    #[test]
-    fn group_context_dictionary_without_safe_aad() {
-        let dictionary = dictionary_of(default_group_context_app_data_dictionary_extension(
-            TestComponent,
-            None,
-        ));
-
-        assert!(!dictionary.contains(&ComponentId::from(ComponentType::SafeAad)));
-
-        let value = dictionary
-            .get(&ComponentId::from(ComponentType::AppComponents))
-            .unwrap();
-        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
-        assert_eq!(list.component_ids, vec![TestComponent::COMPONENT_ID]);
     }
 }

--- a/coreclient/src/clients/multi_device.rs
+++ b/coreclient/src/clients/multi_device.rs
@@ -19,10 +19,9 @@ use aircommon::crypto::signatures::keys::{QsClientSigningKey, QsUserSigningKey};
 use aircommon::identifiers::{Fqdn, QsClientId, QsUserId, UserId};
 use aircommon::messages::{FriendshipToken, QueueMessage};
 use aircommon::mls_group_config::{
-    APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE, default_key_package_extensions,
-    default_leaf_node_extensions, self_group_leaf_node_capabilities,
+    APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE, self_group_leaf_node_capabilities,
 };
-use airprotos::client::component::AirComponent;
+use airprotos::client::app_data::ClientAppData;
 use airprotos::client::self_group::{LinkedDevice, SettingsUpdate, TokenSeed};
 use airprotos::relay_service::v1::{LinkingSessionId, RelayFrame};
 use anyhow::{Context, anyhow, bail};
@@ -637,7 +636,7 @@ impl CoreUser {
             },
         };
 
-        let mut leaf_node_extensions = default_leaf_node_extensions::<AirComponent>();
+        let mut leaf_node_extensions = ClientAppData::current().leaf_node_extensions();
         let client_reference = self.create_own_client_reference();
         // TODO: don't use Extension::Unknown
         leaf_node_extensions.add(Extension::Unknown(
@@ -645,7 +644,7 @@ impl CoreUser {
             UnknownExtension(client_reference.tls_serialize_detached()?),
         ))?;
         // add two fields AirComponent Option<QsClientId> and Option<QsUserId>
-        let key_package_extensions = default_key_package_extensions::<AirComponent>();
+        let key_package_extensions = ClientAppData::current().key_package_extensions();
 
         self.db()
             .with_write_transaction(async |txn| -> anyhow::Result<_> {

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -1749,6 +1749,7 @@ mod tests {
         crypto::aead::keys::IdentityLinkWrapperKey,
         identifiers::{QsClientId, QsUserId},
     };
+    use airprotos::client::app_data::GroupAppData;
     use openmls::{
         components::vc_derivation_info::{KeyPackageUpload, VC_COMPONENT_ID},
         prelude::tls_codec::Serialize as _,
@@ -1805,8 +1806,10 @@ mod tests {
                     t_group_id,
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
-                    Some(vec![VC_COMPONENT_ID]),
-                    true,
+                    GroupAppData {
+                        is_self_group: true,
+                        safe_aad_components: Some(vec![VC_COMPONENT_ID]),
+                    },
                 )?;
                 group.store(&mut *txn).await?;
                 OwnClientInfo::set_self_group(&mut *txn, group.group_id(), &signing_key).await?;

--- a/coreclient/src/clients/process/process_qs.rs
+++ b/coreclient/src/clients/process/process_qs.rs
@@ -1748,9 +1748,7 @@ mod tests {
         credentials::keys::{LeafSigningKey, SelfGroupSigningKey},
         crypto::aead::keys::IdentityLinkWrapperKey,
         identifiers::{QsClientId, QsUserId},
-        mls_group_config::AppComponent,
     };
-    use airprotos::client::component::AirComponent;
     use openmls::{
         components::vc_derivation_info::{KeyPackageUpload, VC_COMPONENT_ID},
         prelude::tls_codec::Serialize as _,
@@ -1808,7 +1806,7 @@ mod tests {
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     Some(vec![VC_COMPONENT_ID]),
-                    AirComponent::default_for_self_group(),
+                    true,
                 )?;
                 group.store(&mut *txn).await?;
                 OwnClientInfo::set_self_group(&mut *txn, group.group_id(), &signing_key).await?;

--- a/coreclient/src/clients/test_utils.rs
+++ b/coreclient/src/clients/test_utils.rs
@@ -360,7 +360,7 @@ impl CoreUser {
         Ok(Some(GroupData::decode(&bytes)?))
     }
 
-    /// Sends a self-update commit that forces the given [`AirComponent`] into the own leaf node.
+    /// Sends a self-update commit that forces the given [`AirFeatures`] into the own leaf node.
     ///
     /// Use this in tests to simulate an old client that advertises a different set of feature
     /// flags.

--- a/coreclient/src/clients/test_utils.rs
+++ b/coreclient/src/clients/test_utils.rs
@@ -4,13 +4,15 @@
 
 #[cfg(any(test, feature = "test_utils"))]
 use aircommon::messages::client_ds_out::SendMessageCollisionTag;
+#[cfg(any(test, feature = "test_utils"))]
+use airprotos::client::component::AirFeatures;
 use openmls::group::{GroupEpoch, Member};
 
 use aircommon::{codec::PersistenceCodec, identifiers::QualifiedGroupId};
 use openmls::prelude::GroupId;
 use uuid::Uuid;
 
-use airprotos::client::{component::AirComponent, group::GroupData};
+use airprotos::client::group::GroupData;
 
 use crate::{
     chats::GroupDataExt,
@@ -363,19 +365,19 @@ impl CoreUser {
     /// Use this in tests to simulate an old client that advertises a different set of feature
     /// flags.
     #[cfg(any(test, feature = "test_utils"))]
-    pub async fn set_group_air_component(
+    pub async fn set_group_features(
         &self,
         chat_id: ChatId,
-        air_component: AirComponent,
+        features: AirFeatures,
     ) -> anyhow::Result<()> {
         let op = self
             .db()
             .with_write_transaction(async |txn| {
-                PendingChatOperation::create_update_with_air_component(
+                PendingChatOperation::create_update_with_features(
                     txn,
                     self.signing_key(),
                     chat_id,
-                    air_component,
+                    features,
                 )
                 .await
             })

--- a/coreclient/src/contacts/mod.rs
+++ b/coreclient/src/contacts/mod.rs
@@ -146,9 +146,9 @@ impl Contact {
         connection: impl ReadConnection,
     ) -> sqlx::Result<()> {
         if let Some(group) = Group::load_by_connection_user_id(connection, &self.user_id).await?
-            && let Some(air_component) = group.member_air_component(&self.user_id)
+            && let Some(app_data) = group.member_app_data(&self.user_id)
         {
-            self.supported_features = Some(air_component.features);
+            self.supported_features = Some(app_data.features);
         }
         Ok(())
     }

--- a/coreclient/src/groups/apq_group.rs
+++ b/coreclient/src/groups/apq_group.rs
@@ -8,13 +8,12 @@ use aircommon::{
     identifiers::UserId,
     mls_group_config::{
         APQ_CIPHERSUITE, GROUP_DATA_EXTENSION_TYPE, MAX_PAST_EPOCHS,
-        default_group_context_app_data_dictionary_extension, default_group_required_extensions,
-        default_leaf_node_capabilities, default_sender_ratchet_configuration,
-        self_group_leaf_node_capabilities,
+        default_group_required_extensions, default_leaf_node_capabilities,
+        default_sender_ratchet_configuration, self_group_leaf_node_capabilities,
     },
     time::TimeStamp,
 };
-use airprotos::client::component::AirComponent;
+use airprotos::client::app_data::GroupAppData;
 use apqmls::{ApqMlsGroup, authentication::ApqCredentialWithKey};
 use mimi_room_policy::{RoomPolicy, VerifiedRoomState};
 use openmls::{
@@ -60,7 +59,7 @@ impl Group {
         pq_group_id: GroupId,
         group_data_bytes: GroupDataBytes,
         safe_aad_components: Option<Vec<ComponentId>>,
-        air_component: AirComponent,
+        is_self_group: bool,
     ) -> anyhow::Result<(Self, PartialCreateGroupParams)> {
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
@@ -78,7 +77,11 @@ impl Group {
             required_capabilities,
             // APQ groups automatically add an app data dictionary extension (to required
             // capabilities), so we can safely add it here for all APQ groups.
-            default_group_context_app_data_dictionary_extension(air_component, safe_aad_components),
+            GroupAppData {
+                is_self_group,
+                safe_aad_components,
+            }
+            .to_extension(),
         ])?;
 
         // The leaf signature key is the signer's own key.

--- a/coreclient/src/groups/apq_group.rs
+++ b/coreclient/src/groups/apq_group.rs
@@ -17,7 +17,6 @@ use airprotos::client::app_data::GroupAppData;
 use apqmls::{ApqMlsGroup, authentication::ApqCredentialWithKey};
 use mimi_room_policy::{RoomPolicy, VerifiedRoomState};
 use openmls::{
-    component::ComponentId,
     group::{GroupId, MlsGroup, PURE_PLAINTEXT_WIRE_FORMAT_POLICY},
     prelude::{
         Credential, CredentialType, CredentialWithKey, Extension, Extensions, UnknownExtension,
@@ -58,8 +57,7 @@ impl Group {
         t_group_id: GroupId,
         pq_group_id: GroupId,
         group_data_bytes: GroupDataBytes,
-        safe_aad_components: Option<Vec<ComponentId>>,
-        is_self_group: bool,
+        group_app_data: GroupAppData,
     ) -> anyhow::Result<(Self, PartialCreateGroupParams)> {
         let provider = AirOpenMlsProvider::new(connection.as_mut());
 
@@ -77,11 +75,7 @@ impl Group {
             required_capabilities,
             // APQ groups automatically add an app data dictionary extension (to required
             // capabilities), so we can safely add it here for all APQ groups.
-            GroupAppData {
-                is_self_group,
-                safe_aad_components,
-            }
-            .to_extension(),
+            group_app_data.to_extension(),
         ])?;
 
         // The leaf signature key is the signer's own key.

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod process;
 pub(crate) mod self_group;
 pub(crate) mod self_group_message_key;
 
+#[cfg(feature = "test_utils")]
+use airprotos::client::component::AirFeatures;
 use apqmls::{
     authentication::{ApqCredentialWithKey, ApqSigner},
     commit_builder::ApqCommitMessageBundle,
@@ -77,15 +79,12 @@ use aircommon::{
     time::TimeStamp,
     utils::removed_client,
 };
-use airprotos::client::{
-    app_data::{ClientAppData, GroupAppData, SUPPORTED_COMPONENTS},
-    component::{AIR_COMPONENT_ID, AirComponent},
-};
+use airprotos::client::app_data::{ClientAppData, GroupAppData};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hkdf::Hkdf;
 use mimi_content::{MessageStatus, MessageStatusReport, MimiContent, PerMessageStatus};
 use mimi_room_policy::{MimiProposal, RoleIndex, RoomPolicy, VerifiedRoomState};
-use mls_assist::{components::ComponentsList, messages::AssistedMessageOut};
+use mls_assist::messages::AssistedMessageOut;
 use openmls_provider::AirOpenMlsProvider;
 use openmls_traits::signatures::Signer;
 use openmls_traits::storage::StorageProvider;
@@ -113,7 +112,6 @@ use crate::{
 };
 
 use openmls::{
-    component::ComponentType,
     components::vc_derivation_info::GenerationId,
     group::{
         CreateCommitError, ExportSecretError, ExternalCommitBuilder, GroupEpoch, JoinBuilder,
@@ -469,13 +467,13 @@ impl Group {
         })?;
 
         let leaf_node = self.mls_group.public_group().leaf(member.index)?;
-        ClientAppData::from_extensions(leaf_node.extensions())
+        ClientAppData::from_leaf(leaf_node)
     }
 
     pub(crate) fn members_app_data(&self) -> impl Iterator<Item = Option<ClientAppData>> {
         self.mls_group.members().map(|member| {
             let leaf_node = self.mls_group.public_group().leaf(member.index)?;
-            ClientAppData::from_extensions(leaf_node.extensions())
+            ClientAppData::from_leaf(leaf_node)
         })
     }
 
@@ -2939,11 +2937,11 @@ impl Group {
     /// Creates a self-update commit forcing a specific [`AirComponent`] into the leaf node.
     ///
     /// Useful for simulating old clients that lack certain feature flags.
-    pub(crate) async fn update_with_air_component(
+    pub(crate) async fn update_with_features(
         &mut self,
         txn: &mut WriteDbTransaction<'_>,
         signer: &LeafSigningKey,
-        air_component: AirComponent,
+        features: AirFeatures,
     ) -> Result<GroupOperationParamsOut> {
         let aad = AadMessage::from(AadPayload::GroupOperation(GroupOperationParamsAad {
             new_encrypted_user_profile_keys: Vec::new(),
@@ -2951,10 +2949,10 @@ impl Group {
         .tls_serialize_detached()?;
 
         let own_leaf_node = self.mls_group.own_leaf_node().context("No own leaf node")?;
-        let leaf_node_parameters = Self::forced_air_component_leaf_params(
+        let leaf_node_parameters = Self::forced_features_leaf_params(
             own_leaf_node.extensions(),
             self.own_leaf_capabilities(),
-            air_component,
+            features,
         )?;
 
         self.mls_group.set_aad(aad);
@@ -2983,38 +2981,25 @@ impl Group {
         })
     }
 
-    fn forced_air_component_leaf_params(
+    fn forced_features_leaf_params(
         leaf_node_extensions: &Extensions<LeafNode>,
         capabilities: Capabilities,
-        air_component: AirComponent,
+        features: AirFeatures,
     ) -> anyhow::Result<LeafNodeParameters> {
-        let mut leaf_node_parameters =
-            LeafNodeParameters::builder().with_capabilities(capabilities);
-
         let mut dict = leaf_node_extensions
             .app_data_dictionary()
             .map(|e| e.dictionary().clone())
             .unwrap_or_default();
+        ClientAppData::refresh_features(&mut dict, features);
 
-        // Ensure AppComponents entry is present
-        if dict.get(&ComponentType::AppComponents.into()).is_none() {
-            dict.insert(
-                ComponentType::AppComponents.into(),
-                ComponentsList {
-                    component_ids: SUPPORTED_COMPONENTS.to_vec(),
-                }
-                .tls_serialize_detached()?,
-            );
-        }
-        // Force the given air component, overriding whatever was there before
-        dict.insert(AIR_COMPONENT_ID, air_component.to_bytes()?);
-
-        let mut new_leaf_node_extensions = leaf_node_extensions.clone();
-        new_leaf_node_extensions.add_or_replace(Extension::AppDataDictionary(
+        let mut leaf_node_extensions = leaf_node_extensions.clone();
+        leaf_node_extensions.add_or_replace(Extension::AppDataDictionary(
             AppDataDictionaryExtension::new(dict),
         ))?;
-        leaf_node_parameters = leaf_node_parameters.with_extensions(new_leaf_node_extensions);
-        Ok(leaf_node_parameters.build())
+        Ok(LeafNodeParameters::builder()
+            .with_capabilities(capabilities)
+            .with_extensions(leaf_node_extensions)
+            .build())
     }
 }
 
@@ -3416,15 +3401,15 @@ fn to_capabilities_mismatch(error: CreateCommitError) -> anyhow::Result<LeafNode
 mod tests {
     use aircommon::mls_group_config::default_leaf_node_capabilities;
     use airprotos::client::{
-        app_data::{ClientAppData, SUPPORTED_COMPONENTS},
-        component::AIR_COMPONENT_ID,
+        app_data::ClientAppData,
+        component::{AIR_COMPONENT_ID, AirFeatures},
     };
     use mls_assist::components::ComponentsList;
     use openmls::{
         component::ComponentType,
         prelude::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, LeafNode},
     };
-    use tls_codec::{DeserializeBytes, Serialize as TlsSerializeTrait};
+    use tls_codec::DeserializeBytes;
 
     use super::Group;
 
@@ -3466,26 +3451,20 @@ mod tests {
         assert!(ids.contains(&AIR_COMPONENT_ID));
     }
 
-    /// AppComponents present with a foreign id -> replaced by the supported components. The list
-    /// is the client's own claim about itself, so nothing foreign survives.
     #[test]
-    fn app_components_are_replaced() {
-        let other_id: u16 = 0x8043;
-        let mut dict = AppDataDictionary::new();
-        dict.insert(
-            ComponentType::AppComponents.into(),
-            ComponentsList {
-                component_ids: vec![other_id],
-            }
-            .tls_serialize_detached()
-            .unwrap(),
-        );
-        let extensions = extensions_with_dict(dict);
+    fn stale_app_data_is_refreshed() {
+        let stale = ClientAppData {
+            features: AirFeatures::default(),
+            virtual_client: false,
+        };
+        let extensions = stale.leaf_node_extensions();
         let params =
             Group::update_leaf_node_extensions(&extensions, default_leaf_node_capabilities())
                 .unwrap();
-        let ids = air_component_ids(params.extensions().unwrap()).unwrap();
-        assert_eq!(ids, SUPPORTED_COMPONENTS);
+        assert_eq!(
+            params.extensions(),
+            Some(&ClientAppData::current().leaf_node_extensions())
+        );
     }
 
     /// Up-to-date app data -> extensions in params are unchanged (None)

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -3400,27 +3400,12 @@ fn to_capabilities_mismatch(error: CreateCommitError) -> anyhow::Result<LeafNode
 #[cfg(test)]
 mod tests {
     use aircommon::mls_group_config::default_leaf_node_capabilities;
-    use airprotos::client::{
-        app_data::ClientAppData,
-        component::{AIR_COMPONENT_ID, AirFeatures},
+    use airprotos::client::{app_data::ClientAppData, component::AirFeatures};
+    use openmls::prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, LeafNode,
     };
-    use mls_assist::components::ComponentsList;
-    use openmls::{
-        component::ComponentType,
-        prelude::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, LeafNode},
-    };
-    use tls_codec::DeserializeBytes;
 
     use super::Group;
-
-    fn air_component_ids(params_extensions: &Extensions<LeafNode>) -> Option<Vec<u16>> {
-        params_extensions
-            .app_data_dictionary()?
-            .dictionary()
-            .get(&ComponentType::AppComponents.into())
-            .and_then(|data| ComponentsList::tls_deserialize_exact_bytes(data).ok())
-            .map(|list| list.component_ids)
-    }
 
     fn extensions_with_dict(dict: AppDataDictionary) -> Extensions<LeafNode> {
         Extensions::from_vec(vec![Extension::AppDataDictionary(
@@ -3429,26 +3414,30 @@ mod tests {
         .expect("valid extensions")
     }
 
-    /// No app data dictionary -> add the default one containing AIR_COMPONENT_ID
+    /// No app data dictionary -> add the current one
     #[test]
     fn no_app_data_dictionary() {
         let extensions = Extensions::empty();
         let params =
             Group::update_leaf_node_extensions(&extensions, default_leaf_node_capabilities())
                 .unwrap();
-        let ids = air_component_ids(params.extensions().unwrap()).unwrap();
-        assert!(ids.contains(&AIR_COMPONENT_ID));
+        assert_eq!(
+            params.extensions(),
+            Some(&ClientAppData::current().leaf_node_extensions())
+        );
     }
 
-    /// App data dictionary present but no AppComponents key -> add AppComponents with AIR_COMPONENT_ID
+    /// Empty app data dictionary -> filled with the current one
     #[test]
-    fn app_data_dictionary_without_app_components() {
+    fn empty_app_data_dictionary() {
         let extensions = extensions_with_dict(AppDataDictionary::new());
         let params =
             Group::update_leaf_node_extensions(&extensions, default_leaf_node_capabilities())
                 .unwrap();
-        let ids = air_component_ids(params.extensions().unwrap()).unwrap();
-        assert!(ids.contains(&AIR_COMPONENT_ID));
+        assert_eq!(
+            params.extensions(),
+            Some(&ClientAppData::current().leaf_node_extensions())
+        );
     }
 
     #[test]

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -70,17 +70,16 @@ use aircommon::{
         },
     },
     mls_group_config::{
-        AppComponent, GROUP_DATA_EXTENSION_TYPE, MAX_PAST_EPOCHS,
-        default_app_data_dictionary_extension, default_group_required_extensions,
-        default_leaf_node_capabilities, default_leaf_node_extensions,
-        default_mls_group_join_config, default_sender_ratchet_configuration,
-        leaf_node_is_virtual_client, self_group_leaf_node_capabilities, vc_leaf_node_extensions,
+        GROUP_DATA_EXTENSION_TYPE, MAX_PAST_EPOCHS, default_group_required_extensions,
+        default_leaf_node_capabilities, default_mls_group_join_config,
+        default_sender_ratchet_configuration, self_group_leaf_node_capabilities,
     },
     time::TimeStamp,
     utils::removed_client,
 };
-use airprotos::client::component::{
-    AIR_COMPONENT_ID, AirComponent, AirFeatures, SUPPORTED_COMPONENTS,
+use airprotos::client::{
+    app_data::{ClientAppData, GroupAppData, SUPPORTED_COMPONENTS},
+    component::{AIR_COMPONENT_ID, AirComponent},
 };
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use hkdf::Hkdf;
@@ -460,9 +459,9 @@ impl Group {
         Ok(())
     }
 
-    /// Returns the [`AirComponent`] from the leaf node of the given member, or `None` if the member
-    /// is not in the group.
-    pub(crate) fn member_air_component(&self, user_id: &UserId) -> Option<AirComponent> {
+    /// Returns the [`ClientAppData`] from the leaf node of the given member, or `None` if the
+    /// member is not in the group or its leaf carries no Air component.
+    pub(crate) fn member_app_data(&self, user_id: &UserId) -> Option<ClientAppData> {
         let member = self.mls_group.members().find(|m| {
             LeafCredential::from_credential(&m.credential)
                 .map(|c| c.user_id(self.own_user_id()) == user_id)
@@ -470,29 +469,13 @@ impl Group {
         })?;
 
         let leaf_node = self.mls_group.public_group().leaf(member.index)?;
-        leaf_node
-            .extensions()
-            .app_data_dictionary()
-            .and_then(|dict| dict.dictionary().get(&AIR_COMPONENT_ID))
-            .and_then(|data| {
-                AirComponent::from_bytes(data)
-                    .inspect_err(|error| {
-                        error!(%error, "Failed to deserialize member air component");
-                    })
-                    .ok()
-            })
+        ClientAppData::from_extensions(leaf_node.extensions())
     }
 
-    pub(crate) fn members_air_component(&self) -> impl Iterator<Item = Option<AirComponent>> {
+    pub(crate) fn members_app_data(&self) -> impl Iterator<Item = Option<ClientAppData>> {
         self.mls_group.members().map(|member| {
             let leaf_node = self.mls_group.public_group().leaf(member.index)?;
-            let dict = leaf_node.extensions().app_data_dictionary()?;
-            let data = dict.dictionary().get(&AIR_COMPONENT_ID)?;
-            AirComponent::from_bytes(data)
-                .inspect_err(|error| {
-                    error!(%error, "Failed to deserialize member air component");
-                })
-                .ok()
+            ClientAppData::from_extensions(leaf_node.extensions())
         })
     }
 
@@ -526,7 +509,7 @@ impl Group {
             .with_group_id(group_id.clone())
             .with_capabilities(default_leaf_node_capabilities())
             .with_group_context_extensions(gc_extensions)
-            .with_leaf_node_extensions(default_leaf_node_extensions::<AirComponent>())?
+            .with_leaf_node_extensions(ClientAppData::current().leaf_node_extensions())?
             .sender_ratchet_configuration(default_sender_ratchet_configuration())
             .max_past_epochs(MAX_PAST_EPOCHS)
             .with_wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
@@ -667,7 +650,7 @@ impl Group {
 
         // Self-groups are only ever joined during device linking, which uses the APQ join path.
         ensure!(
-            !AirComponent::is_self_group_context(mls_group.extensions()),
+            !GroupAppData::is_self_group_context(mls_group.extensions()),
             "refusing to join a group marked as self-group"
         );
 
@@ -904,8 +887,8 @@ impl Group {
         // recorded as our own self-group. Conversely, our own self-group must carry the flag,
         // since its self-group credentials are only accepted there.
         ensure!(
-            AirComponent::is_self_group_context(t_mls_group.extensions()) == is_self_group
-                && AirComponent::is_self_group_context(pq_mls_group.extensions()) == is_self_group,
+            GroupAppData::is_self_group_context(t_mls_group.extensions()) == is_self_group
+                && GroupAppData::is_self_group_context(pq_mls_group.extensions()) == is_self_group,
             "self-group flag does not match the recorded self-group"
         );
         let credentials =
@@ -1149,9 +1132,9 @@ impl Group {
             };
 
             let leaf_node_extensions = if vc_group_id.is_some() {
-                vc_leaf_node_extensions::<AirComponent>()
+                ClientAppData::current_virtual_client().leaf_node_extensions()
             } else {
-                default_leaf_node_extensions::<AirComponent>()
+                ClientAppData::current().leaf_node_extensions()
             };
             let leaf_node_parameters = LeafNodeParameters::builder()
                 .with_capabilities(default_leaf_node_capabilities())
@@ -1208,7 +1191,7 @@ impl Group {
         let is_self_group =
             OwnClientInfo::is_own_self_group(&mut *txn, mls_group.group_id()).await?;
         ensure!(
-            AirComponent::is_self_group_context(mls_group.extensions()) == is_self_group,
+            GroupAppData::is_self_group_context(mls_group.extensions()) == is_self_group,
             "self-group flag does not match the recorded self-group"
         );
 
@@ -1327,9 +1310,9 @@ impl Group {
         // Build the group
         let mls_group_config = default_mls_group_join_config();
         let leaf_node_extensions = if vc_group_id.is_some() {
-            vc_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current_virtual_client().leaf_node_extensions()
         } else {
-            default_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current().leaf_node_extensions()
         };
         let capabilities = match signer {
             LeafSigningKey::User(_) => default_leaf_node_capabilities(),
@@ -1380,8 +1363,8 @@ impl Group {
         // A group flagged as self-group must be recorded as our own self-group and vice versa.
         let is_self_group = OwnClientInfo::is_own_self_group(&mut *txn, t_group.group_id()).await?;
         ensure!(
-            AirComponent::is_self_group_context(t_group.extensions()) == is_self_group
-                && AirComponent::is_self_group_context(pq_group.extensions()) == is_self_group,
+            GroupAppData::is_self_group_context(t_group.extensions()) == is_self_group
+                && GroupAppData::is_self_group_context(pq_group.extensions()) == is_self_group,
             "self-group flag does not match the recorded self-group"
         );
         // The self group must be rejoined with the per-device self-group key, other groups with
@@ -2311,80 +2294,29 @@ impl Group {
         let mut leaf_node_parameters =
             LeafNodeParameters::builder().with_capabilities(capabilities);
 
-        if let Some(app_data_dictionary) = leaf_node_extensions.app_data_dictionary() {
-            let dict = app_data_dictionary.dictionary();
-            let mut updated_dict = None;
-
-            // Augment app components
-            if let Some(mut app_components) = dict
-                .get(&ComponentType::AppComponents.into())
-                .and_then(|data| {
-                    ComponentsList::tls_deserialize_exact_bytes(data)
-                        .inspect_err(|error| {
-                            error!(%error, "Failed to deserialize app components; will replace");
-                        })
-                        .ok()
-                })
-            {
-                if !app_components.component_ids.contains(&AIR_COMPONENT_ID) {
-                    // Advertise that we support the Air component in the app data dictionary.
-                    app_components.component_ids.push(AIR_COMPONENT_ID);
-                    updated_dict.get_or_insert_with(|| dict.clone()).insert(
-                        ComponentType::AppComponents.into(),
-                        app_components.tls_serialize_detached()?,
-                    );
-                }
-            } else {
-                // Add app components list to the app data dictionary.
-                updated_dict.get_or_insert_with(|| dict.clone()).insert(
-                    ComponentType::AppComponents.into(),
-                    ComponentsList {
-                        component_ids: SUPPORTED_COMPONENTS.to_vec(),
-                    }
-                    .tls_serialize_detached()?,
-                );
-            }
-
-            // Augment Air component
-            if let Some(mut air_component) = dict.get(&AIR_COMPONENT_ID).and_then(|data| {
-                AirComponent::from_bytes(data)
-                    .inspect_err(|error| {
-                        error!(%error, "Failed to deserialize air component; will replace");
-                    })
-                    .ok()
-            }) {
-                // Update features to the current version of the client
-                let current_features = AirFeatures::default_leaf_or_key_package_features();
-                if air_component.features != current_features {
-                    air_component.features = current_features;
-                    updated_dict
-                        .get_or_insert_with(|| dict.clone())
-                        .insert(AIR_COMPONENT_ID, air_component.to_bytes()?);
-                }
-            } else {
-                // Add air component to the app data dictionary.
-                updated_dict.get_or_insert_with(|| dict.clone()).insert(
-                    AIR_COMPONENT_ID,
-                    AirComponent::default_for_leaf_or_key_package()
-                        .to_bytes()
-                        .expect("invalid Air component"),
-                );
-            };
-
-            if let Some(dict) = updated_dict {
-                // Replace the app data dictionary with the updated one
+        // Refresh the app data to what this version of the client advertises. Only touch the
+        // leaf node extensions if something actually changed.
+        let refreshed = leaf_node_extensions.app_data_dictionary().map(|current| {
+            let mut dict = current.dictionary().clone();
+            ClientAppData::refresh(&mut dict);
+            (&dict != current.dictionary()).then_some(dict)
+        });
+        match refreshed {
+            // Up to date
+            Some(None) => {}
+            Some(Some(dict)) => {
                 let mut leaf_node_extensions = leaf_node_extensions.clone();
                 leaf_node_extensions.add_or_replace(Extension::AppDataDictionary(
                     AppDataDictionaryExtension::new(dict),
                 ))?;
-                leaf_node_parameters =
-                    leaf_node_parameters.with_extensions(leaf_node_extensions.clone());
+                leaf_node_parameters = leaf_node_parameters.with_extensions(leaf_node_extensions);
             }
-        } else {
-            // App data extension is not present, add it with default values
-            let mut leaf_node_extensions = leaf_node_extensions.clone();
-            leaf_node_extensions.add(default_app_data_dictionary_extension::<AirComponent>())?;
-            leaf_node_parameters = leaf_node_parameters.with_extensions(leaf_node_extensions);
+            None => {
+                // App data extension is not present, add it with default values
+                let mut leaf_node_extensions = leaf_node_extensions.clone();
+                leaf_node_extensions.add(ClientAppData::current().to_extension())?;
+                leaf_node_parameters = leaf_node_parameters.with_extensions(leaf_node_extensions);
+            }
         }
 
         Ok(leaf_node_parameters.build())
@@ -2656,7 +2588,7 @@ impl Group {
     pub(crate) fn own_leaf_is_virtual_client(&self) -> bool {
         self.mls_group()
             .own_leaf_node()
-            .is_some_and(leaf_node_is_virtual_client)
+            .is_some_and(ClientAppData::leaf_is_virtual_client)
     }
 
     /// The emulation group a commit replacing our leaf has to derive from, or
@@ -3482,10 +3414,11 @@ fn to_capabilities_mismatch(error: CreateCommitError) -> anyhow::Result<LeafNode
 
 #[cfg(test)]
 mod tests {
-    use aircommon::mls_group_config::{
-        default_app_data_dictionary_extension, default_leaf_node_capabilities,
+    use aircommon::mls_group_config::default_leaf_node_capabilities;
+    use airprotos::client::{
+        app_data::{ClientAppData, SUPPORTED_COMPONENTS},
+        component::AIR_COMPONENT_ID,
     };
-    use airprotos::client::component::{AIR_COMPONENT_ID, AirComponent};
     use mls_assist::components::ComponentsList;
     use openmls::{
         component::ComponentType,
@@ -3533,10 +3466,11 @@ mod tests {
         assert!(ids.contains(&AIR_COMPONENT_ID));
     }
 
-    /// AppComponents present but AIR_COMPONENT_ID missing -> add it
+    /// AppComponents present with a foreign id -> replaced by the supported components. The list
+    /// is the client's own claim about itself, so nothing foreign survives.
     #[test]
-    fn app_components_without_air_component_id() {
-        let other_id: u16 = 0x0001;
+    fn app_components_are_replaced() {
+        let other_id: u16 = 0x8043;
         let mut dict = AppDataDictionary::new();
         dict.insert(
             ComponentType::AppComponents.into(),
@@ -3551,16 +3485,13 @@ mod tests {
             Group::update_leaf_node_extensions(&extensions, default_leaf_node_capabilities())
                 .unwrap();
         let ids = air_component_ids(params.extensions().unwrap()).unwrap();
-        assert!(ids.contains(&AIR_COMPONENT_ID));
-        assert!(ids.contains(&other_id));
+        assert_eq!(ids, SUPPORTED_COMPONENTS);
     }
 
-    /// AIR_COMPONENT_ID already present -> extensions in params are unchanged (None)
+    /// Up-to-date app data -> extensions in params are unchanged (None)
     #[test]
-    fn app_components_with_air_component_id_already() {
-        let extensions =
-            Extensions::from_vec(vec![default_app_data_dictionary_extension::<AirComponent>()])
-                .expect("valid extensions");
+    fn up_to_date_app_data_is_left_alone() {
+        let extensions = ClientAppData::current().leaf_node_extensions();
         let params =
             Group::update_leaf_node_extensions(&extensions, default_leaf_node_capabilities())
                 .unwrap();

--- a/coreclient/src/groups/mod.rs
+++ b/coreclient/src/groups/mod.rs
@@ -2934,7 +2934,7 @@ mod test_utils {
 
 #[cfg(feature = "test_utils")]
 impl Group {
-    /// Creates a self-update commit forcing a specific [`AirComponent`] into the leaf node.
+    /// Creates a self-update commit forcing a specific [`AirFeatures`] into the leaf node.
     ///
     /// Useful for simulating old clients that lack certain feature flags.
     pub(crate) async fn update_with_features(

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -938,8 +938,8 @@ impl Group {
     }
 }
 
-/// Verify that merging `staged_commit` keeps the self-group flag of the group
-/// context's [`AirComponent`] unchanged. The flag is fixed at group creation.
+/// Verify that merging `staged_commit` keeps the self-group flag of the group context's unchanged.
+/// The flag is fixed at group creation.
 fn ensure_self_group_flag_unchanged(
     mls_group: &MlsGroup,
     staged_commit: &StagedCommit,

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -15,7 +15,7 @@ use aircommon::{
     },
     utils::removed_client,
 };
-use airprotos::client::{component::AirComponent, self_group::SettingsUpdate};
+use airprotos::client::{app_data::GroupAppData, self_group::SettingsUpdate};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use apqmls::{
     ApqMlsGroupMut,
@@ -945,8 +945,8 @@ fn ensure_self_group_flag_unchanged(
     staged_commit: &StagedCommit,
 ) -> Result<()> {
     ensure!(
-        AirComponent::is_self_group_context(staged_commit.group_context().extensions())
-            == AirComponent::is_self_group_context(mls_group.extensions()),
+        GroupAppData::is_self_group_context(staged_commit.group_context().extensions())
+            == GroupAppData::is_self_group_context(mls_group.extensions()),
         "commit would toggle the self-group flag"
     );
     Ok(())

--- a/coreclient/src/groups/process.rs
+++ b/coreclient/src/groups/process.rs
@@ -938,7 +938,7 @@ impl Group {
     }
 }
 
-/// Verify that merging `staged_commit` keeps the self-group flag of the group context's unchanged.
+/// Verify that merging `staged_commit` keeps the self-group flag in the group context unchanged.
 /// The flag is fixed at group creation.
 fn ensure_self_group_flag_unchanged(
     mls_group: &MlsGroup,

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -14,10 +14,8 @@ use aircommon::{
         client_ds::{AadMessage, AadPayload, GroupOperationParamsAad},
         client_ds_out::ApqGroupOperationParamsOut,
     },
-    mls_group_config::AppComponent,
 };
 use airprotos::client::{
-    component::AirComponent,
     group::{EncryptedGroupTitle, GroupData},
     virtual_client::{
         VirtualClientAction, VirtualClientCommitData, extract_virtual_client_commit_data,
@@ -317,7 +315,7 @@ impl CoreUser {
                     pq_group_id,
                     group_data_bytes,
                     safe_aad_components,
-                    AirComponent::default_for_self_group(),
+                    true,
                 )?;
 
                 let user_profile_key = UserProfileKey::load_own(&mut *txn).await?;

--- a/coreclient/src/groups/self_group.rs
+++ b/coreclient/src/groups/self_group.rs
@@ -16,6 +16,7 @@ use aircommon::{
     },
 };
 use airprotos::client::{
+    app_data::GroupAppData,
     group::{EncryptedGroupTitle, GroupData},
     virtual_client::{
         VirtualClientAction, VirtualClientCommitData, extract_virtual_client_commit_data,
@@ -305,7 +306,10 @@ impl CoreUser {
         let (group, partial_params, user_profile_key) = self
             .db()
             .with_write_transaction(async move |txn| -> anyhow::Result<_> {
-                let safe_aad_components = Some(vec![VC_COMPONENT_ID]);
+                let client_app_data = GroupAppData {
+                    is_self_group: true,
+                    safe_aad_components: Some(vec![VC_COMPONENT_ID]),
+                };
                 let (group, partial_params) = Group::create_apq_group(
                     &mut *txn,
                     &group_signer,
@@ -314,8 +318,7 @@ impl CoreUser {
                     group_id,
                     pq_group_id,
                     group_data_bytes,
-                    safe_aad_components,
-                    true,
+                    client_app_data,
                 )?;
 
                 let user_profile_key = UserProfileKey::load_own(&mut *txn).await?;

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -36,16 +36,14 @@ use aircommon::{
     },
 };
 use airprotos::client::{
-    component::{AIR_COMPONENT_ID, AirComponent},
+    app_data::GroupAppData,
+    component::AIR_COMPONENT_ID,
     self_group::{
         AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate, TokenSeed,
     },
 };
 use anyhow::{Result, anyhow, ensure};
-use openmls::prelude::{
-    AppEphemeralProposal, Extensions, GroupContext, Proposal, StagedCommit,
-    tls_codec::Serialize as _,
-};
+use openmls::prelude::{AppEphemeralProposal, Proposal, StagedCommit, tls_codec::Serialize as _};
 use openmls_traits::OpenMlsProvider;
 use tracing::{debug, warn};
 
@@ -53,22 +51,6 @@ use crate::{
     db::access::WriteDbTransaction,
     groups::{Group, openmls_provider::AirOpenMlsProvider},
 };
-
-/// Reads the `is_self_group` flag from a group context's app-data dictionary.
-///
-/// The flag lives in the [`AirComponent`] entry under [`AIR_COMPONENT_ID`]. A
-/// missing component or entry means "not a self-group". Works on any
-/// [`Extensions<GroupContext>`], so it can be applied both to a live group's
-/// extensions and to the provisional post-commit context of a
-/// [`StagedCommit`](openmls::prelude::StagedCommit).
-pub(crate) fn extensions_claim_self_group(extensions: &Extensions<GroupContext>) -> bool {
-    extensions
-        .app_data_dictionary()
-        .and_then(|dict| dict.dictionary().get(&AIR_COMPONENT_ID))
-        .and_then(|data| AirComponent::from_bytes(data).ok())
-        .map(|component| component.is_self_group)
-        .unwrap_or(false)
-}
 
 impl Group {
     /// Returns whether this group claims to be a self-group, per the
@@ -83,7 +65,7 @@ impl Group {
     /// assume an adversary cannot make a client join a non-legitimate
     /// self-group.
     pub(crate) fn is_self_group(&self) -> bool {
-        extensions_claim_self_group(self.mls_group().extensions())
+        GroupAppData::is_self_group_context(self.mls_group().extensions())
     }
 
     /// Returns the message key for the self-group's current epoch, deriving and
@@ -522,8 +504,6 @@ mod derivation_tests {
         utils::persistence::open_db_in_memory,
     };
 
-    use super::extensions_claim_self_group;
-
     fn random_group_id() -> GroupId {
         GroupId::from(QualifiedGroupId::new(
             Uuid::new_v4(),
@@ -783,7 +763,7 @@ mod derivation_tests {
             }
             .to_extension(),
         )?;
-        assert!(!extensions_claim_self_group(&flipped));
+        assert!(!GroupAppData::is_self_group_context(&flipped));
 
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let (t_mls_group, _pq_mls_group) = group.apq_mls_groups_mut()?;

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -556,8 +556,10 @@ mod derivation_tests {
             random_group_id(),
             random_group_id(),
             GroupDataBytes::from(b"test-group-data".to_vec()),
-            None,
-            is_self_group,
+            GroupAppData {
+                is_self_group,
+                safe_aad_components: None,
+            },
         )?;
         Ok(group)
     }

--- a/coreclient/src/groups/self_group_message_key.rs
+++ b/coreclient/src/groups/self_group_message_key.rs
@@ -504,10 +504,10 @@ mod derivation_tests {
             kdf::{KdfDerivable, keys::SelfGroupExporterSecret},
         },
         identifiers::{QsClientId, QsUserId, QualifiedGroupId, UserId},
-        mls_group_config::{AppComponent, default_group_context_app_data_dictionary_extension},
     };
     use airprotos::client::{
-        component::{AIR_COMPONENT_ID, AirComponent},
+        app_data::GroupAppData,
+        component::AIR_COMPONENT_ID,
         self_group::{AppEphemeralPayload, SelfGroupMessage, SelfGroupMessages, SettingsUpdate},
     };
     use openmls::group::{AppDataUpdateValidationError, CreateCommitError};
@@ -540,19 +540,14 @@ mod derivation_tests {
     }
 
     /// Creates a fresh single-member APQ group. When `is_self_group` is set,
-    /// the group context carries `AirComponent::default_for_self_group`, which
-    /// is what the accessor's guard checks.
+    /// the group context marks the group as a self group, which is what the
+    /// accessor's guard checks.
     fn create_group(
         txn: &mut WriteDbTransaction<'_>,
         signer: &LeafSigningKey,
         user_id: UserId,
         is_self_group: bool,
     ) -> anyhow::Result<Group> {
-        let air_component = if is_self_group {
-            AirComponent::default_for_self_group()
-        } else {
-            AirComponent::default_for_leaf_or_key_package()
-        };
         let (group, _params) = Group::create_apq_group(
             &mut *txn,
             signer,
@@ -562,7 +557,7 @@ mod derivation_tests {
             random_group_id(),
             GroupDataBytes::from(b"test-group-data".to_vec()),
             None,
-            air_component,
+            is_self_group,
         )?;
         Ok(group)
     }
@@ -779,10 +774,13 @@ mod derivation_tests {
         // Extensions that clear the self-group flag by replacing the AIR
         // component in the app data dictionary.
         let mut flipped = group.mls_group().extensions().clone();
-        flipped.add_or_replace(default_group_context_app_data_dictionary_extension(
-            AirComponent::default_for_leaf_or_key_package(),
-            None,
-        ))?;
+        flipped.add_or_replace(
+            GroupAppData {
+                is_self_group: false,
+                safe_aad_components: None,
+            }
+            .to_extension(),
+        )?;
         assert!(!extensions_claim_self_group(&flipped));
 
         let provider = AirOpenMlsProvider::new(txn.as_mut());

--- a/coreclient/src/job/create_chat.rs
+++ b/coreclient/src/job/create_chat.rs
@@ -10,7 +10,10 @@ use aircommon::{
     identifiers::QsReference,
     time::TimeStamp,
 };
-use airprotos::client::group::{EncryptedGroupTitle, GroupData, GroupProfile};
+use airprotos::client::{
+    app_data::GroupAppData,
+    group::{EncryptedGroupTitle, GroupData, GroupProfile},
+};
 use anyhow::Context;
 use tracing::error;
 
@@ -140,7 +143,6 @@ impl CreateChat {
             .await?
             .with_transaction(async |txn| -> anyhow::Result<_> {
                 let (group, partial_params) = if is_apq {
-                    let disable_safe_aad = None;
                     Group::create_apq_group(
                         &mut *txn,
                         &LeafSigningKey::User(key_store.signing_key.clone()),
@@ -149,8 +151,10 @@ impl CreateChat {
                         group_id,
                         pq_group_id.context("Missing PQ group ID")?,
                         group_data_bytes.clone(),
-                        disable_safe_aad,
-                        false,
+                        GroupAppData {
+                            is_self_group: false,
+                            safe_aad_components: None,
+                        },
                     )?
                 } else {
                     Group::create_group(

--- a/coreclient/src/job/create_chat.rs
+++ b/coreclient/src/job/create_chat.rs
@@ -8,10 +8,8 @@ use aircommon::{
     credentials::keys::LeafSigningKey,
     crypto::{aead::keys::IdentityLinkWrapperKey, indexed_aead::keys::UserProfileKey},
     identifiers::QsReference,
-    mls_group_config::AppComponent,
     time::TimeStamp,
 };
-use airprotos::client::component::AirComponent;
 use airprotos::client::group::{EncryptedGroupTitle, GroupData, GroupProfile};
 use anyhow::Context;
 use tracing::error;
@@ -152,7 +150,7 @@ impl CreateChat {
                         pq_group_id.context("Missing PQ group ID")?,
                         group_data_bytes.clone(),
                         disable_safe_aad,
-                        AirComponent::default_for_leaf_or_key_package(),
+                        false,
                     )?
                 } else {
                     Group::create_group(

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -1626,7 +1626,7 @@ mod persistence {
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils {
 
-    use airprotos::client::component::AirComponent;
+    use airprotos::client::component::AirFeatures;
 
     use crate::db::access::ReadConnection;
 
@@ -1676,11 +1676,11 @@ pub mod test_utils {
         ///
         /// Use this in tests to simulate an old client that advertises a different set of feature
         /// flags.
-        pub(crate) async fn create_update_with_air_component(
+        pub(crate) async fn create_update_with_features(
             txn: &mut WriteDbTransaction<'_>,
             signer: &UserSigningKey,
             chat_id: ChatId,
-            air_component: AirComponent,
+            features: AirFeatures,
         ) -> anyhow::Result<Self> {
             let chat = Chat::load(&mut *txn, &chat_id)
                 .await?
@@ -1694,7 +1694,7 @@ pub mod test_utils {
                 OwnClientInfo::signer_for_group(&mut *txn, group.group_id(), signer).await?;
             let params = group
                 .group_mut()
-                .update_with_air_component(&mut *txn, &signer, air_component)
+                .update_with_features(&mut *txn, &signer, features)
                 .await?;
 
             let job = Self::new(group, OperationType::other(params));
@@ -1760,7 +1760,7 @@ mod tests {
         identifiers::{QsClientId, QsUserId, QualifiedGroupId, UserId},
     };
     use airprotos::{
-        client::app_data::ClientAppData,
+        client::app_data::{ClientAppData, GroupAppData},
         common::v1::{StatusDetails, StatusDetailsCode, WrongEpochDetail, status_details::Detail},
     };
     use chrono::{Duration, Utc};
@@ -1822,8 +1822,10 @@ mod tests {
                     t_group_id,
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
-                    None,
-                    true,
+                    GroupAppData {
+                        is_self_group: true,
+                        safe_aad_components: None,
+                    },
                 )?;
                 group.store(&mut *txn).await?;
                 let mut group = VerifiedGroup::new_for_test(group);
@@ -1972,8 +1974,10 @@ mod tests {
                     t_group_id.clone(),
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
-                    None,
-                    true,
+                    GroupAppData {
+                        is_self_group: true,
+                        safe_aad_components: None,
+                    },
                 )?;
                 group.store(&mut *txn).await?;
                 let chat =
@@ -2056,8 +2060,10 @@ mod tests {
                     t_group_id.clone(),
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
-                    Some(vec![VC_COMPONENT_ID]),
-                    true,
+                    GroupAppData {
+                        is_self_group: true,
+                        safe_aad_components: Some(vec![VC_COMPONENT_ID]),
+                    },
                 )?;
                 group.store(&mut *txn).await?;
 

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -1671,7 +1671,7 @@ pub mod test_utils {
     }
 
     impl PendingChatOperation {
-        /// Creates a self-update commit that forces the given [`AirComponent`] into the own leaf
+        /// Creates a self-update commit that forces the given [`AirFeatures`] into the own leaf
         /// node.
         ///
         /// Use this in tests to simulate an old client that advertises a different set of feature

--- a/coreclient/src/job/pending_chat_operation.rs
+++ b/coreclient/src/job/pending_chat_operation.rs
@@ -1758,10 +1758,9 @@ mod tests {
         },
         crypto::aead::keys::IdentityLinkWrapperKey,
         identifiers::{QsClientId, QsUserId, QualifiedGroupId, UserId},
-        mls_group_config::AppComponent,
     };
     use airprotos::{
-        client::component::AirComponent,
+        client::app_data::ClientAppData,
         common::v1::{StatusDetails, StatusDetailsCode, WrongEpochDetail, status_details::Detail},
     };
     use chrono::{Duration, Utc};
@@ -1824,7 +1823,7 @@ mod tests {
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     None,
-                    AirComponent::default_for_self_group(),
+                    true,
                 )?;
                 group.store(&mut *txn).await?;
                 let mut group = VerifiedGroup::new_for_test(group);
@@ -1974,7 +1973,7 @@ mod tests {
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     None,
-                    AirComponent::default_for_self_group(),
+                    true,
                 )?;
                 group.store(&mut *txn).await?;
                 let chat =
@@ -2058,7 +2057,7 @@ mod tests {
                     pq_group_id,
                     GroupDataBytes::from(b"test-group-data".to_vec()),
                     Some(vec![VC_COMPONENT_ID]),
-                    AirComponent::default_for_self_group(),
+                    true,
                 )?;
                 group.store(&mut *txn).await?;
 
@@ -2085,7 +2084,6 @@ mod tests {
             identifiers::{ClientConfig, QsReference},
             mls_group_config::{
                 APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE,
-                default_key_package_extensions, default_leaf_node_extensions,
                 self_group_leaf_node_capabilities,
             },
         };
@@ -2123,15 +2121,17 @@ mod tests {
                 &[],
             ),
         };
-        let mut leaf_node_extensions = default_leaf_node_extensions::<AirComponent>();
+        let mut leaf_node_extensions = ClientAppData::current().leaf_node_extensions();
         leaf_node_extensions.add(Extension::Unknown(
             QS_CLIENT_REFERENCE_EXTENSION_TYPE,
             UnknownExtension(client_reference.tls_serialize_detached()?),
         ))?;
 
+        let key_package_extensions = ClientAppData::current().key_package_extensions();
+
         let provider = AirOpenMlsProvider::new(txn.as_mut());
         let bundle = ApqKeyPackage::builder()
-            .key_package_extensions(default_key_package_extensions::<AirComponent>())
+            .key_package_extensions(key_package_extensions)
             .leaf_node_capabilities(self_group_leaf_node_capabilities())
             .leaf_node_extensions(leaf_node_extensions)
             .build(&provider, APQ_CIPHERSUITE, &signer, credential)?;

--- a/coreclient/src/key_stores/mod.rs
+++ b/coreclient/src/key_stores/mod.rs
@@ -8,11 +8,10 @@ use aircommon::{
     crypto::hpke::{ClientIdEncryptionKey, HpkeEncryptable},
     identifiers::{ClientConfig, QsClientId, QsReference},
     mls_group_config::{
-        APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE, default_key_package_extensions,
-        default_leaf_node_capabilities, default_leaf_node_extensions, vc_leaf_node_extensions,
+        APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE, default_leaf_node_capabilities,
     },
 };
-use airprotos::client::component::AirComponent;
+use airprotos::client::app_data::ClientAppData;
 use anyhow::{Context, Result, ensure};
 use apqmls::{
     authentication::ApqCredentialWithKey, key_package::ApqKeyPackageBuilder,
@@ -96,9 +95,9 @@ impl MemoryUserKeyStore {
         virtual_client: bool,
     ) -> Result<KeyPackageBuilder> {
         let mut leaf_node_extensions = if virtual_client {
-            vc_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current_virtual_client().leaf_node_extensions()
         } else {
-            default_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current().leaf_node_extensions()
         };
 
         let client_reference = self.create_own_client_reference(qs_client_id);
@@ -109,12 +108,12 @@ impl MemoryUserKeyStore {
         leaf_node_extensions.add(client_ref_extension)?;
 
         let key_package_extensions = if last_resort {
-            let mut extensions = default_key_package_extensions::<AirComponent>();
+            let mut extensions = ClientAppData::current().key_package_extensions();
             let last_resort_extension = Extension::LastResort(LastResortExtension::new());
             extensions.add(last_resort_extension)?;
             extensions
         } else {
-            default_key_package_extensions::<AirComponent>()
+            ClientAppData::current().key_package_extensions()
         };
 
         let builder = KeyPackage::builder()
@@ -155,9 +154,9 @@ impl MemoryUserKeyStore {
         virtual_client: bool,
     ) -> Result<ApqKeyPackageBuilder> {
         let mut leaf_node_extensions = if virtual_client {
-            vc_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current_virtual_client().leaf_node_extensions()
         } else {
-            default_leaf_node_extensions::<AirComponent>()
+            ClientAppData::current().leaf_node_extensions()
         };
 
         let client_reference = self.create_own_client_reference(qs_client_id);
@@ -168,12 +167,12 @@ impl MemoryUserKeyStore {
         leaf_node_extensions.add(client_ref_extension)?;
 
         let key_package_extensions = if last_resort {
-            let mut extensions = default_key_package_extensions::<AirComponent>();
+            let mut extensions = ClientAppData::current().key_package_extensions();
             let last_resort_extension = Extension::LastResort(LastResortExtension::new());
             extensions.add(last_resort_extension)?;
             extensions
         } else {
-            default_key_package_extensions::<AirComponent>()
+            ClientAppData::current().key_package_extensions()
         };
 
         Ok(ApqKeyPackage::builder()

--- a/coreclient/src/outbound_service/timed_tasks.rs
+++ b/coreclient/src/outbound_service/timed_tasks.rs
@@ -5,7 +5,7 @@
 use aircommon::identifiers::USERNAME_REFRESH_THRESHOLD;
 use airprotos::{
     auth_service::v1::OperationType,
-    client::{component::AirComponent, group::GroupData},
+    client::{app_data::GroupAppData, group::GroupData},
 };
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -504,10 +504,9 @@ impl OutboundServiceContext {
             // For connection chats, that support empty connection group titles, we can erase the data.
             let is_connection = chat.is_connection();
             let erase_attributes = if is_connection {
-                group.members_air_component().all(|component| {
-                    component
-                        .map(|component| component.features.empty_connection_group_attributes)
-                        .unwrap_or(false)
+                group.members_app_data().all(|app_data| {
+                    app_data
+                        .is_some_and(|app_data| app_data.features.empty_connection_group_attributes)
                 })
             } else {
                 false
@@ -528,7 +527,7 @@ impl OutboundServiceContext {
             // non-emulation group and cannot register one. An unmarked
             // self-update would only bounce off the DS, so skip it and leave a
             // diagnosable trace.
-            if AirComponent::is_self_group_context(group.mls_group().extensions()) {
+            if GroupAppData::is_self_group_context(group.mls_group().extensions()) {
                 error!(
                     %chat_id,
                     "self group has no derivation epoch and cannot register one, \

--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -32,6 +32,7 @@ thiserror.workspace = true
 tls_codec.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [build-dependencies]

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -279,7 +279,7 @@ mod test {
         let _ = ClientAppData::current_virtual_client().leaf_node_extensions();
     }
 
-    /// Default extensions can be extended by must be backwards compatible.
+    /// Default extensions can be extended but must be backwards compatible.
     #[test]
     fn default_extensions_stability() {
         let leaf_node_extensions = ClientAppData::current().leaf_node_extensions();

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -30,7 +30,7 @@ use tracing::error;
 use crate::client::component::{AIR_COMPONENT_ID, AirComponent, AirFeatures};
 
 /// List of components supported by this client.
-pub const SUPPORTED_COMPONENTS: &[ComponentId] = &[AIR_COMPONENT_ID];
+const SUPPORTED_COMPONENTS: &[ComponentId] = &[AIR_COMPONENT_ID];
 
 /// App data a client advertises in its leaf node or key package.
 ///
@@ -78,7 +78,7 @@ impl ClientAppData {
     // Layer 2: the dictionary
 
     /// `None` if the dictionary carries no Air component.
-    pub fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
+    fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
         let component = air_component(dict)?;
         Some(Self {
             features: component.features,
@@ -95,6 +95,18 @@ impl ClientAppData {
         Self {
             virtual_client: is_virtual_client(dict),
             ..Self::current()
+        }
+        .write_into(dict);
+    }
+
+    /// Same as [`Self::refresh`], but advertises `features` instead of the current ones.
+    ///
+    /// Whether the leaf is operated by a virtual client is preserved. Entries not owned by Air are
+    /// left untouched.
+    pub fn refresh_features(dict: &mut AppDataDictionary, features: AirFeatures) {
+        Self {
+            features,
+            virtual_client: is_virtual_client(dict),
         }
         .write_into(dict);
     }
@@ -116,7 +128,7 @@ impl ClientAppData {
         );
     }
 
-    pub fn to_dictionary(&self) -> AppDataDictionary {
+    fn to_dictionary(&self) -> AppDataDictionary {
         let mut dict = AppDataDictionary::new();
         self.write_into(&mut dict);
         dict
@@ -124,7 +136,11 @@ impl ClientAppData {
 
     // Layer 3 and 4: extension and extensions list.
 
-    pub fn from_extensions<T>(extensions: &Extensions<T>) -> Option<Self> {
+    pub fn from_leaf(leaf: &LeafNode) -> Option<Self> {
+        Self::from_leaf_extensions(leaf.extensions())
+    }
+
+    fn from_leaf_extensions(extensions: &Extensions<LeafNode>) -> Option<Self> {
         Self::from_dictionary(extensions.app_data_dictionary()?.dictionary())
     }
 
@@ -154,7 +170,7 @@ impl ClientAppData {
 impl GroupAppData {
     // Layer 2: the dictionary
 
-    pub fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
+    fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
         let component = air_component(dict)?;
         let safe_aad_components =
             components_list(dict, ComponentType::SafeAad.into()).map(|list| list.component_ids);
@@ -164,7 +180,7 @@ impl GroupAppData {
         })
     }
 
-    pub fn to_dictionary(&self) -> AppDataDictionary {
+    fn to_dictionary(&self) -> AppDataDictionary {
         let mut component_ids = SUPPORTED_COMPONENTS.to_vec();
         if self.safe_aad_components.is_some() {
             component_ids.push(ComponentType::SafeAad.into());
@@ -191,7 +207,7 @@ impl GroupAppData {
 
     // Layer 3 and 4: extension and extensions list.
 
-    pub fn from_group_context(extensions: &Extensions<GroupContext>) -> Option<Self> {
+    fn from_group_context(extensions: &Extensions<GroupContext>) -> Option<Self> {
         Self::from_dictionary(extensions.app_data_dictionary()?.dictionary())
     }
 
@@ -294,11 +310,11 @@ mod test {
 
         let leaf = ClientAppData::current().leaf_node_extensions();
         assert_eq!(
-            ClientAppData::from_extensions(&leaf),
+            ClientAppData::from_leaf_extensions(&leaf),
             Some(ClientAppData::current())
         );
         assert_eq!(
-            ClientAppData::from_extensions(&Extensions::<LeafNode>::empty()),
+            ClientAppData::from_leaf_extensions(&Extensions::<LeafNode>::empty()),
             None
         );
     }
@@ -379,7 +395,7 @@ mod test {
     #[test]
     fn group_context_dictionary_with_safe_aad() {
         const REQUIRED_SAFE_AAD_COMPONENT_ID: ComponentId = 0x8042;
-        let dictionary = dictionary_of(
+        let dict = dictionary_of(
             GroupAppData {
                 is_self_group: false,
                 safe_aad_components: Some(vec![REQUIRED_SAFE_AAD_COMPONENT_ID]),
@@ -389,29 +405,29 @@ mod test {
 
         // The SafeAad entry is present as a dictionary key...
         let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
-        assert!(dictionary.contains(&safe_aad_id));
+        assert!(dict.contains(&safe_aad_id));
 
         // ...and its value parses as a `ComponentsList` carrying the given ids
         // (`safe_aad_required_components()` errors on unparsable values).
-        let value = dictionary.get(&safe_aad_id).unwrap();
+        let value = dict.get(&safe_aad_id).unwrap();
         let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
         assert_eq!(list.component_ids, vec![REQUIRED_SAFE_AAD_COMPONENT_ID]);
 
         // The AppComponents entry is present and parseable, too, and advertises the embedded
         // component.
-        let value = dictionary
+        let value = dict
             .get(&ComponentId::from(ComponentType::AppComponents))
             .unwrap();
         let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
         assert!(list.component_ids.contains(&AIR_COMPONENT_ID));
 
         // The component itself is embedded in the dictionary.
-        assert!(dictionary.contains(&AIR_COMPONENT_ID));
+        assert!(dict.contains(&AIR_COMPONENT_ID));
     }
 
     #[test]
     fn group_context_dictionary_without_safe_aad() {
-        let dictionary = dictionary_of(
+        let dict = dictionary_of(
             GroupAppData {
                 is_self_group: false,
                 safe_aad_components: None,
@@ -419,12 +435,25 @@ mod test {
             .to_extension(),
         );
 
-        assert!(!dictionary.contains(&ComponentId::from(ComponentType::SafeAad)));
+        assert!(!dict.contains(&ComponentId::from(ComponentType::SafeAad)));
 
-        let value = dictionary
+        let value = dict
             .get(&ComponentId::from(ComponentType::AppComponents))
             .unwrap();
         let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
         assert_eq!(list.component_ids, vec![AIR_COMPONENT_ID]);
+    }
+
+    #[test]
+    fn refresh_replaces_foreign_component_ids() {
+        let mut dict = AppDataDictionary::new();
+        insert_components_list(&mut dict, ComponentType::AppComponents.into(), vec![0x8043]);
+
+        ClientAppData::refresh(&mut dict);
+
+        let ids = components_list(&dict, ComponentType::AppComponents.into())
+            .unwrap()
+            .component_ids;
+        assert_eq!(ids, SUPPORTED_COMPONENTS);
     }
 }

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Typed views of Air's MLS app data dictionary.
+//!
+//! There are four layers:
+//!
+//! 1. Component bodies: bytes under an id. Live in `component.rs`.
+//! 2. The dictionary: `AppDataDictionary`, a map from id to bytes, plus the meta entries
+//!    `AppComponents` and `SafeAad`. This is what the types below model.
+//! 3. The extension: `Extension::AppDataDictionary(AppDataDictionaryExtension)`, one entry in an
+//!    extensions list. Wrapper around the second layer.
+//! 4. The extension list: `Extensions<LeafNode>`, `Extensions<KeyPackage>`,
+//!    `Extensions<GroupContext>`. Holds the third layer next to unrelated things: the QS client
+//!    reference in leaves, required capabilities and group data extension in the group context.
+
+use mls_assist::components::ComponentsList;
+use openmls::{
+    component::{ComponentId, ComponentType},
+    components::vc_derivation_info::VC_COMPONENT_ID,
+    group::GroupContext,
+    prelude::{
+        AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions, KeyPackage, LeafNode,
+    },
+};
+use tls_codec::{DeserializeBytes, Serialize};
+use tracing::error;
+
+use crate::client::component::{AIR_COMPONENT_ID, AirComponent, AirFeatures};
+
+/// List of components supported by this client.
+pub const SUPPORTED_COMPONENTS: &[ComponentId] = &[AIR_COMPONENT_ID];
+
+/// App data a client advertises in its leaf node or key package.
+///
+/// Typed view of the app data dictionary in those places. The group context has its own view, see
+/// [`GroupAppData`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientAppData {
+    /// Features of the client operating the leaf.
+    pub features: AirFeatures,
+    /// The leaf is operated by a virtual client
+    ///
+    /// Read from the `AppComponents` entry, see `VC_COMPONENT_ID`.
+    pub virtual_client: bool,
+}
+
+/// App data describing a group, stored in its group context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupAppData {
+    /// Fixed at creation
+    pub is_self_group: bool,
+    /// Components whose SafeAAD is required.
+    ///
+    /// None if the group does not use SafeAAD.
+    pub safe_aad_components: Option<Vec<ComponentId>>,
+    // LATER
+    // pub group_profile: Option<GroupProfileComponent>,
+}
+
+impl ClientAppData {
+    /// What this version of the client advertises.
+    pub fn current() -> Self {
+        Self {
+            features: AirFeatures::default_leaf_or_key_package_features(),
+            virtual_client: false,
+        }
+    }
+
+    pub fn current_virtual_client() -> Self {
+        Self {
+            virtual_client: true,
+            ..Self::current()
+        }
+    }
+
+    // Layer 2: the dictionary
+
+    /// `None` if the dictionary carries no Air component.
+    pub fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
+        let component = air_component(dict)?;
+        Some(Self {
+            features: component.features,
+            virtual_client: is_virtual_client(dict),
+        })
+    }
+
+    /// Refreshes the client app data in an existing leaf dictionary to what this version of the
+    /// client advertises.
+    ///
+    /// Whether the leaf is operated by a virtual client is preserved. Entries not owned by Air are
+    /// left untouched.
+    pub fn refresh(dict: &mut AppDataDictionary) {
+        Self {
+            virtual_client: is_virtual_client(dict),
+            ..Self::current()
+        }
+        .write_into(dict);
+    }
+
+    fn write_into(&self, dict: &mut AppDataDictionary) {
+        let mut component_ids = SUPPORTED_COMPONENTS.to_vec();
+        if self.virtual_client {
+            component_ids.push(VC_COMPONENT_ID);
+        }
+        insert_components_list(dict, ComponentType::AppComponents.into(), component_ids);
+        insert_air_component(
+            dict,
+            &AirComponent {
+                features: self.features.clone(),
+                // In a leaf node or a key package, this flag has no meaning
+                // => it must be false.
+                is_self_group: false,
+            },
+        );
+    }
+
+    pub fn to_dictionary(&self) -> AppDataDictionary {
+        let mut dict = AppDataDictionary::new();
+        self.write_into(&mut dict);
+        dict
+    }
+
+    // Layer 3 and 4: extension and extensions list.
+
+    pub fn from_extensions<T>(extensions: &Extensions<T>) -> Option<Self> {
+        Self::from_dictionary(extensions.app_data_dictionary()?.dictionary())
+    }
+
+    /// Whether the leaf is operated by a virtual client.
+    ///
+    /// Only looks at the `AppComponents` entry, so it also works for leaves
+    /// without a decodable Air component.
+    pub fn leaf_is_virtual_client(leaf: &LeafNode) -> bool {
+        leaf.extensions()
+            .app_data_dictionary()
+            .is_some_and(|extension| is_virtual_client(extension.dictionary()))
+    }
+
+    pub fn to_extension(&self) -> Extension {
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(self.to_dictionary()))
+    }
+
+    pub fn leaf_node_extensions(&self) -> Extensions<LeafNode> {
+        Extensions::from_vec(vec![self.to_extension()]).expect("invalid extensions")
+    }
+
+    pub fn key_package_extensions(&self) -> Extensions<KeyPackage> {
+        Extensions::from_vec(vec![self.to_extension()]).expect("invalid extensions")
+    }
+}
+
+impl GroupAppData {
+    // Layer 2: the dictionary
+
+    pub fn from_dictionary(dict: &AppDataDictionary) -> Option<Self> {
+        let component = air_component(dict)?;
+        let safe_aad_components =
+            components_list(dict, ComponentType::SafeAad.into()).map(|list| list.component_ids);
+        Some(Self {
+            is_self_group: component.is_self_group,
+            safe_aad_components,
+        })
+    }
+
+    pub fn to_dictionary(&self) -> AppDataDictionary {
+        let mut component_ids = SUPPORTED_COMPONENTS.to_vec();
+        if self.safe_aad_components.is_some() {
+            component_ids.push(ComponentType::SafeAad.into());
+        }
+        let mut dict = AppDataDictionary::new();
+        insert_components_list(
+            &mut dict,
+            ComponentType::AppComponents.into(),
+            component_ids,
+        );
+        if let Some(ids) = &self.safe_aad_components {
+            insert_components_list(&mut dict, ComponentType::SafeAad.into(), ids.clone());
+        }
+        insert_air_component(
+            &mut dict,
+            &AirComponent {
+                // TODO: What is actually the meaning of this feature matrix in the group context?
+                features: AirFeatures::default_leaf_or_key_package_features(),
+                is_self_group: self.is_self_group,
+            },
+        );
+        dict
+    }
+
+    // Layer 3 and 4: extension and extensions list.
+
+    pub fn from_group_context(extensions: &Extensions<GroupContext>) -> Option<Self> {
+        Self::from_dictionary(extensions.app_data_dictionary()?.dictionary())
+    }
+
+    pub fn is_self_group_context(extensions: &Extensions<GroupContext>) -> bool {
+        Self::from_group_context(extensions).is_some_and(|data| data.is_self_group)
+    }
+
+    pub fn to_extension(&self) -> Extension {
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(self.to_dictionary()))
+    }
+}
+
+/// Returns the components list for the given component id.
+///
+/// Note that both components `AppComponents` and `SafeAad` are stored in the app data as a
+/// components list.
+fn components_list(dict: &AppDataDictionary, id: ComponentId) -> Option<ComponentsList> {
+    let data = dict.get(&id)?;
+    ComponentsList::tls_deserialize_exact_bytes(data)
+        .inspect_err(|error| error!(%error, "Failed to deserialize components list"))
+        .ok()
+}
+
+fn insert_components_list(
+    dict: &mut AppDataDictionary,
+    id: ComponentId,
+    component_ids: Vec<ComponentId>,
+) {
+    dict.insert(
+        id,
+        ComponentsList { component_ids }
+            .tls_serialize_detached()
+            .expect("invalid components list"),
+    );
+}
+
+fn air_component(dict: &AppDataDictionary) -> Option<AirComponent> {
+    let data = dict.get(&AIR_COMPONENT_ID)?;
+    AirComponent::from_bytes(data)
+        .inspect_err(|error| error!(%error, "Failed to deserialize Air component"))
+        .ok()
+}
+
+fn insert_air_component(dict: &mut AppDataDictionary, component: &AirComponent) {
+    dict.insert(
+        AIR_COMPONENT_ID,
+        component.to_bytes().expect("invalid Air component"),
+    );
+}
+
+fn is_virtual_client(dict: &AppDataDictionary) -> bool {
+    components_list(dict, ComponentType::AppComponents.into())
+        .is_some_and(|list| list.component_ids.contains(&VC_COMPONENT_ID))
+}
+
+#[cfg(test)]
+mod test {
+    use aircommon::codec::PersistenceCodec;
+
+    use super::*;
+
+    fn dictionary_of(extension: Extension) -> AppDataDictionary {
+        let Extension::AppDataDictionary(extension) = extension else {
+            panic!("not an app data dictionary extension");
+        };
+        extension.dictionary().clone()
+    }
+
+    #[test]
+    fn default_extensions_are_valid() {
+        // Checks that the functions below never panic
+        let _ = ClientAppData::current().to_extension();
+        let _ = ClientAppData::current().leaf_node_extensions();
+        let _ = ClientAppData::current().key_package_extensions();
+        let _ = ClientAppData::current_virtual_client().leaf_node_extensions();
+    }
+
+    /// Default extensions can be extended by must be backwards compatible.
+    #[test]
+    fn default_extensions_stability() {
+        let leaf_node_extensions = ClientAppData::current().leaf_node_extensions();
+        let key_package_extensions = ClientAppData::current().key_package_extensions();
+        for (a, b) in leaf_node_extensions
+            .iter()
+            .zip(key_package_extensions.iter())
+        {
+            assert_eq!(a, b);
+        }
+
+        let bytes = PersistenceCodec::to_vec(&leaf_node_extensions).unwrap();
+        let diag = cbor_diag::parse_bytes(&bytes[1..]).unwrap().to_hex();
+        insta::assert_snapshot!(diag);
+    }
+
+    #[test]
+    fn client_app_data_round_trip() {
+        let data = ClientAppData::current_virtual_client();
+        let dict = data.to_dictionary();
+        assert_eq!(ClientAppData::from_dictionary(&dict), Some(data));
+
+        let leaf = ClientAppData::current().leaf_node_extensions();
+        assert_eq!(
+            ClientAppData::from_extensions(&leaf),
+            Some(ClientAppData::current())
+        );
+        assert_eq!(
+            ClientAppData::from_extensions(&Extensions::<LeafNode>::empty()),
+            None
+        );
+    }
+
+    #[test]
+    fn refresh_keeps_virtual_client_marker_and_foreign_entries() {
+        const FOREIGN_COMPONENT_ID: ComponentId = 0x8043;
+        let mut dict = ClientAppData {
+            features: AirFeatures::default(),
+            virtual_client: true,
+        }
+        .to_dictionary();
+        dict.insert(FOREIGN_COMPONENT_ID, b"foreign".to_vec());
+
+        ClientAppData::refresh(&mut dict);
+
+        let data = ClientAppData::from_dictionary(&dict).unwrap();
+        assert!(data.virtual_client);
+        assert_eq!(
+            data.features,
+            AirFeatures::default_leaf_or_key_package_features()
+        );
+        assert_eq!(
+            dict.get(&FOREIGN_COMPONENT_ID).unwrap(),
+            b"foreign".to_vec()
+        );
+    }
+
+    #[test]
+    fn refresh_adds_missing_air_component() {
+        let mut dict = AppDataDictionary::new();
+        assert_eq!(ClientAppData::from_dictionary(&dict), None);
+
+        ClientAppData::refresh(&mut dict);
+        assert_eq!(
+            ClientAppData::from_dictionary(&dict),
+            Some(ClientAppData::current())
+        );
+    }
+
+    #[test]
+    fn self_group_flag_is_read_from_group_context_extensions() {
+        let group_context_extensions = |is_self_group| {
+            Extensions::from_vec(vec![
+                GroupAppData {
+                    is_self_group,
+                    safe_aad_components: None,
+                }
+                .to_extension(),
+            ])
+            .unwrap()
+        };
+
+        assert!(GroupAppData::is_self_group_context(
+            &group_context_extensions(true)
+        ));
+        assert!(!GroupAppData::is_self_group_context(
+            &group_context_extensions(false)
+        ));
+
+        // A missing component counts as not a self-group.
+        assert!(!GroupAppData::is_self_group_context(&Extensions::empty()));
+    }
+
+    #[test]
+    fn group_app_data_round_trip() {
+        let data = GroupAppData {
+            is_self_group: true,
+            safe_aad_components: Some(vec![0x8042]),
+        };
+        let extensions = Extensions::from_vec(vec![data.to_extension()]).unwrap();
+        assert_eq!(GroupAppData::from_group_context(&extensions), Some(data));
+    }
+
+    /// `safe_aad_required()` on the group context checks for a dictionary entry whose *key* is the
+    /// SafeAad component id. This pins that the helper puts the marker in the right place: a wrong
+    /// placement compiles and runs, but silently disables the entire SafeAAD pipeline.
+    #[test]
+    fn group_context_dictionary_with_safe_aad() {
+        const REQUIRED_SAFE_AAD_COMPONENT_ID: ComponentId = 0x8042;
+        let dictionary = dictionary_of(
+            GroupAppData {
+                is_self_group: false,
+                safe_aad_components: Some(vec![REQUIRED_SAFE_AAD_COMPONENT_ID]),
+            }
+            .to_extension(),
+        );
+
+        // The SafeAad entry is present as a dictionary key...
+        let safe_aad_id = ComponentId::from(ComponentType::SafeAad);
+        assert!(dictionary.contains(&safe_aad_id));
+
+        // ...and its value parses as a `ComponentsList` carrying the given ids
+        // (`safe_aad_required_components()` errors on unparsable values).
+        let value = dictionary.get(&safe_aad_id).unwrap();
+        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
+        assert_eq!(list.component_ids, vec![REQUIRED_SAFE_AAD_COMPONENT_ID]);
+
+        // The AppComponents entry is present and parseable, too, and advertises the embedded
+        // component.
+        let value = dictionary
+            .get(&ComponentId::from(ComponentType::AppComponents))
+            .unwrap();
+        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
+        assert!(list.component_ids.contains(&AIR_COMPONENT_ID));
+
+        // The component itself is embedded in the dictionary.
+        assert!(dictionary.contains(&AIR_COMPONENT_ID));
+    }
+
+    #[test]
+    fn group_context_dictionary_without_safe_aad() {
+        let dictionary = dictionary_of(
+            GroupAppData {
+                is_self_group: false,
+                safe_aad_components: None,
+            }
+            .to_extension(),
+        );
+
+        assert!(!dictionary.contains(&ComponentId::from(ComponentType::SafeAad)));
+
+        let value = dictionary
+            .get(&ComponentId::from(ComponentType::AppComponents))
+            .unwrap();
+        let list: ComponentsList = tls_codec::Deserialize::tls_deserialize_exact(value).unwrap();
+        assert_eq!(list.component_ids, vec![AIR_COMPONENT_ID]);
+    }
+}

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -87,8 +87,9 @@ impl ClientAppData {
     /// Refreshes the client app data in an existing leaf dictionary to what this version of the
     /// client advertises.
     ///
-    /// Whether the leaf is operated by a virtual client is preserved. Entries not owned by Air are
-    /// left untouched.
+    /// Only the Air component and the list of app component ids are touched. The former is
+    /// replaced. The latter only gets ids added, never removed, so ids owned by other components
+    /// and the virtual client maker survive.
     pub fn refresh(dict: &mut AppDataDictionary) {
         Self {
             virtual_client: is_virtual_client(dict),
@@ -107,11 +108,20 @@ impl ClientAppData {
     }
 
     fn write_into(&self, dict: &mut AppDataDictionary) {
-        let mut component_ids = SUPPORTED_COMPONENTS.to_vec();
-        if self.virtual_client {
-            component_ids.push(VC_COMPONENT_ID);
+        let app_component_ids = ComponentType::AppComponents.into();
+        let mut component_ids = components_list(dict, app_component_ids)
+            .map(|list| list.component_ids)
+            .unwrap_or_default();
+        let wanted = SUPPORTED_COMPONENTS
+            .iter()
+            .copied()
+            .chain(self.virtual_client.then_some(VC_COMPONENT_ID));
+        for id in wanted {
+            if !component_ids.contains(&id) {
+                component_ids.push(id);
+            }
         }
-        insert_components_list(dict, ComponentType::AppComponents.into(), component_ids);
+        insert_components_list(dict, app_component_ids, component_ids);
         insert_air_component(
             dict,
             &AirComponent {
@@ -438,16 +448,29 @@ mod test {
         assert_eq!(list.component_ids, vec![AIR_COMPONENT_ID]);
     }
 
+    /// Ids owned by other components (e.g. APQ) share the list with Air's. Refreshing must not
+    /// drop them.
     #[test]
-    fn refresh_replaces_foreign_component_ids() {
+    fn refresh_keeps_foreign_component_ids() {
+        const FOREIGN_COMPONENT_ID: ComponentId = 0x8043;
+        let app_components_id: ComponentId = ComponentType::AppComponents.into();
         let mut dict = AppDataDictionary::new();
-        insert_components_list(&mut dict, ComponentType::AppComponents.into(), vec![0x8043]);
-
+        insert_components_list(
+            &mut dict,
+            app_components_id,
+            vec![FOREIGN_COMPONENT_ID, AIR_COMPONENT_ID],
+        );
+        insert_air_component(&mut dict, &AirComponent::default());
         ClientAppData::refresh(&mut dict);
-
-        let ids = components_list(&dict, ComponentType::AppComponents.into())
+        let ids = components_list(&dict, app_components_id)
             .unwrap()
             .component_ids;
-        assert_eq!(ids, SUPPORTED_COMPONENTS);
+        assert!(ids.contains(&FOREIGN_COMPONENT_ID));
+        assert!(ids.contains(&AIR_COMPONENT_ID));
+
+        // Already complete -> nothing changes
+        let before = dict.clone();
+        ClientAppData::refresh(&mut dict);
+        assert_eq!(dict, before);
     }
 }

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -89,7 +89,7 @@ impl ClientAppData {
     ///
     /// Only the Air component and the list of app component ids are touched. The former is
     /// replaced. The latter only gets ids added, never removed, so ids owned by other components
-    /// and the virtual client maker survive.
+    /// and the virtual client marker survive.
     pub fn refresh(dict: &mut AppDataDictionary) {
         Self {
             virtual_client: is_virtual_client(dict),

--- a/protos/src/client/app_data.rs
+++ b/protos/src/client/app_data.rs
@@ -40,7 +40,7 @@ const SUPPORTED_COMPONENTS: &[ComponentId] = &[AIR_COMPONENT_ID];
 pub struct ClientAppData {
     /// Features of the client operating the leaf.
     pub features: AirFeatures,
-    /// The leaf is operated by a virtual client
+    /// The leaf is operated by a virtual client.
     ///
     /// Read from the `AppComponents` entry, see `VC_COMPONENT_ID`.
     pub virtual_client: bool,
@@ -49,14 +49,12 @@ pub struct ClientAppData {
 /// App data describing a group, stored in its group context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupAppData {
-    /// Fixed at creation
+    /// Fixed at creation.
     pub is_self_group: bool,
     /// Components whose SafeAAD is required.
     ///
     /// None if the group does not use SafeAAD.
     pub safe_aad_components: Option<Vec<ComponentId>>,
-    // LATER
-    // pub group_profile: Option<GroupProfileComponent>,
 }
 
 impl ClientAppData {
@@ -100,9 +98,6 @@ impl ClientAppData {
     }
 
     /// Same as [`Self::refresh`], but advertises `features` instead of the current ones.
-    ///
-    /// Whether the leaf is operated by a virtual client is preserved. Entries not owned by Air are
-    /// left untouched.
     pub fn refresh_features(dict: &mut AppDataDictionary, features: AirFeatures) {
         Self {
             features,
@@ -197,7 +192,6 @@ impl GroupAppData {
         insert_air_component(
             &mut dict,
             &AirComponent {
-                // TODO: What is actually the meaning of this feature matrix in the group context?
                 features: AirFeatures::default_leaf_or_key_package_features(),
                 is_self_group: self.is_self_group,
             },

--- a/protos/src/client/component.rs
+++ b/protos/src/client/component.rs
@@ -2,18 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use aircommon::{
-    codec::{self, PersistenceCodec},
-    mls_group_config::AppComponent,
-};
+use aircommon::codec::{self, PersistenceCodec};
 use airmacros::{DeserializeTaggedMap, SerializeTaggedMap};
-use mls_assist::openmls::{component::ComponentId, group::GroupContext, prelude::Extensions};
+use mls_assist::openmls::component::ComponentId;
 
 /// The component id of the Air component.
 pub const AIR_COMPONENT_ID: ComponentId = 0x8000;
-
-/// List of components supported by this client.
-pub const SUPPORTED_COMPONENTS: &[ComponentId] = &[AIR_COMPONENT_ID];
 
 /// Custom component storing client-specific features and data.
 ///
@@ -60,26 +54,6 @@ impl AirComponent {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, codec::Error> {
         PersistenceCodec::from_slice(bytes)
     }
-
-    /// Reads the component from a group context's extensions.
-    ///
-    /// Returns `None` if the app data dictionary, the component entry, or a decodable component is
-    /// missing.
-    pub fn from_group_context_extensions(extensions: &Extensions<GroupContext>) -> Option<Self> {
-        let data = extensions
-            .app_data_dictionary()?
-            .dictionary()
-            .get(&AIR_COMPONENT_ID)?;
-        Self::from_bytes(data).ok()
-    }
-
-    /// Whether the group context extensions mark the group as a self-group.
-    ///
-    /// A missing or undecodable component counts as not a self-group.
-    pub fn is_self_group_context(extensions: &Extensions<GroupContext>) -> bool {
-        Self::from_group_context_extensions(extensions)
-            .is_some_and(|component| component.is_self_group)
-    }
 }
 
 impl AirFeatures {
@@ -96,38 +70,8 @@ impl AirFeatures {
     }
 }
 
-impl AppComponent for AirComponent {
-    const COMPONENT_ID: ComponentId = AIR_COMPONENT_ID;
-
-    fn default_for_leaf_or_key_package() -> Self {
-        Self {
-            features: AirFeatures::default_leaf_or_key_package_features(),
-            is_self_group: false,
-        }
-    }
-
-    fn default_for_self_group() -> Self {
-        Self {
-            features: AirFeatures::default_leaf_or_key_package_features(),
-            is_self_group: true,
-        }
-    }
-
-    fn to_bytes(&self) -> Vec<u8> {
-        AirComponent::to_bytes(self).expect("invalid component")
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use aircommon::{
-        codec::PersistenceCodec,
-        mls_group_config::{
-            default_app_data_dictionary_extension,
-            default_group_context_app_data_dictionary_extension, default_key_package_extensions,
-            default_leaf_node_extensions,
-        },
-    };
     use mls_assist::openmls::component::PrivateComponentId;
 
     use super::*;
@@ -135,50 +79,5 @@ mod test {
     #[test]
     fn air_component_id_is_private() {
         PrivateComponentId::new(AIR_COMPONENT_ID).expect("Should be private");
-    }
-
-    #[test]
-    fn default_extensions_are_valid() {
-        // Checks that the function below never panic
-        let _ = default_app_data_dictionary_extension::<AirComponent>();
-        let _ = default_leaf_node_extensions::<AirComponent>();
-        let _ = default_key_package_extensions::<AirComponent>();
-    }
-
-    #[test]
-    fn self_group_flag_is_read_from_group_context_extensions() {
-        let group_context_extensions = |component| {
-            Extensions::from_vec(vec![default_group_context_app_data_dictionary_extension(
-                component, None,
-            )])
-            .unwrap()
-        };
-
-        let self_group = group_context_extensions(AirComponent::default_for_self_group());
-        assert!(AirComponent::is_self_group_context(&self_group));
-
-        let regular_group =
-            group_context_extensions(AirComponent::default_for_leaf_or_key_package());
-        assert!(!AirComponent::is_self_group_context(&regular_group));
-
-        // A missing component counts as not a self-group.
-        assert!(!AirComponent::is_self_group_context(&Extensions::empty()));
-    }
-
-    /// Default extensions can be extended by must be backwards compatible.
-    #[test]
-    fn default_extensions_stability() {
-        let leaf_node_extensions = default_leaf_node_extensions::<AirComponent>();
-        let key_package_extensions = default_key_package_extensions::<AirComponent>();
-        for (a, b) in leaf_node_extensions
-            .iter()
-            .zip(key_package_extensions.iter())
-        {
-            assert_eq!(a, b);
-        }
-
-        let bytes = PersistenceCodec::to_vec(&leaf_node_extensions).unwrap();
-        let diag = cbor_diag::parse_bytes(&bytes[1..]).unwrap().to_hex();
-        insta::assert_snapshot!(diag);
     }
 }

--- a/protos/src/client/mod.rs
+++ b/protos/src/client/mod.rs
@@ -4,6 +4,7 @@
 
 //! Protocol types used in client to client communication.
 
+pub mod app_data;
 pub mod component;
 pub mod group;
 pub mod group_bootstrap;

--- a/protos/src/client/snapshots/airprotos__client__app_data__test__default_extensions_stability.snap
+++ b/protos/src/client/snapshots/airprotos__client__app_data__test__default_extensions_stability.snap
@@ -1,5 +1,5 @@
 ---
-source: protos/src/client/component.rs
+source: protos/src/client/app_data.rs
 expression: diag
 ---
 a1                                               # map(1)

--- a/server/tests/tests/connection.rs
+++ b/server/tests/tests/connection.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use aircommon::time::TimeStamp;
 use aircoreclient::{ChatId, EventMessage, Message, SystemMessage, clients::CoreUser};
-use airprotos::client::component::{AirComponent, AirFeatures};
+use airprotos::client::component::AirFeatures;
 use airserver_test_harness::utils::setup::TestBackend;
 use chrono::{DateTime, TimeZone};
 use tokio::task::spawn_blocking;
@@ -503,16 +503,13 @@ async fn erase_connection_group_data_mixed_feature_support() {
 
     // Simulate Bob being an old client: downgrade his leaf node to advertise
     // empty_connection_group_attributes = false.
-    let old_air_component = AirComponent {
-        features: AirFeatures {
-            encrypted_group_profiles: true,
-            empty_connection_group_attributes: false,
-            pq_groups: setup.apq_groups,
-        },
-        is_self_group: false,
+    let old_features = AirFeatures {
+        encrypted_group_profiles: true,
+        empty_connection_group_attributes: false,
+        pq_groups: setup.apq_groups,
     };
     bob_user
-        .set_group_air_component(chat_id, old_air_component)
+        .set_group_features(chat_id, old_features)
         .await
         .unwrap();
 
@@ -577,16 +574,13 @@ async fn erase_connection_group_data_mixed_feature_support() {
     );
 
     // Bob "upgrades": commit a leaf node that sets empty_connection_group_attributes = true.
-    let new_air_component = AirComponent {
-        features: AirFeatures {
-            encrypted_group_profiles: true,
-            empty_connection_group_attributes: true,
-            pq_groups: setup.apq_groups,
-        },
-        is_self_group: false,
+    let new_features = AirFeatures {
+        encrypted_group_profiles: true,
+        empty_connection_group_attributes: true,
+        pq_groups: setup.apq_groups,
     };
     bob_user
-        .set_group_air_component(chat_id, new_air_component)
+        .set_group_features(chat_id, new_features)
         .await
         .unwrap();
 


### PR DESCRIPTION
The views are split into two: `AppClientData` and `GroupAppData`. The
former is a view of the leaf node and key package, the latter of the
group context app data dictionary.

This centralizes the dictionary logic, simplifies the call sites and
removes the technical dependency inversion.