### PR TITLE
feat: revamp multi-device linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "mimi-room-policy",
  "mls-assist",
  "semver",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -137,7 +137,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -185,7 +185,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -207,6 +207,7 @@ dependencies = [
  "argon2",
  "cbor-diag",
  "chrono",
+ "cpace",
  "criterion",
  "digest-io",
  "displaydoc",
@@ -214,6 +215,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf 0.13.0",
+ "hmac 0.13.0",
  "insta",
  "mimi-room-policy",
  "mimi_content",
@@ -228,7 +230,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -279,7 +281,7 @@ dependencies = [
  "sqlx",
  "strum",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -329,7 +331,7 @@ dependencies = [
  "serde_bytes",
  "sha2 0.11.0",
  "strum",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tonic",
  "tonic-prost",
@@ -375,7 +377,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "tokio",
  "tokio-stream",
@@ -564,7 +566,7 @@ dependencies = [
  "openmls_traits",
  "serde",
  "tap",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
 ]
 
@@ -890,7 +892,7 @@ dependencies = [
  "num-traits",
  "pastey 0.1.1",
  "rayon",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -1497,6 +1499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1628,7 +1631,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1983,6 +1986,19 @@ dependencies = [
  "hax-lib",
  "pastey 0.2.3",
  "rand 0.10.2",
+]
+
+[[package]]
+name = "cpace"
+version = "0.1.0"
+source = "git+https://github.com/phnx-im/cpace?rev=1882fad3b58ffbb27a82c78418826727b72b8bac#1882fad3b58ffbb27a82c78418826727b72b8bac"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -2447,6 +2463,7 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -4518,7 +4535,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4561,7 +4578,7 @@ source = "git+https://github.com/phnx-im/mimi-room-policy?rev=603f3e07372119560c
 dependencies = [
  "ciborium",
  "serde",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
 ]
 
@@ -4576,7 +4593,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.9",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4686,7 +4703,7 @@ dependencies = [
  "openmls_traits",
  "serde",
  "serde_bytes",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
 ]
 
@@ -5098,7 +5115,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "wasm-bindgen-test",
  "zeroize",
@@ -5153,7 +5170,7 @@ dependencies = [
  "openmls_traits",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5180,7 +5197,7 @@ dependencies = [
  "rand_core 0.10.1",
  "rand_core 0.6.4",
  "sha2 0.11.0",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
 ]
 
@@ -5192,7 +5209,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5669,7 +5686,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "subtle",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tls_codec",
  "trait-variant",
  "typenum",
@@ -5990,7 +6007,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6012,7 +6029,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6196,7 +6213,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -6283,7 +6300,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "siphasher",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "time",
  "toml 1.1.4+spec-1.1.0",
  "url",
@@ -6865,7 +6882,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -6998,7 +7015,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml 0.8.23",
@@ -7042,7 +7059,7 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.119",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -7070,7 +7087,7 @@ dependencies = [
  "sha1",
  "sha2 0.11.0",
  "sqlx-core",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
@@ -7106,7 +7123,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -7132,7 +7149,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -7253,7 +7270,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "windows",
  "windows-version",
 ]
@@ -7288,11 +7305,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.20",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7308,13 +7325,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.20"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7753,7 +7770,7 @@ dependencies = [
  "governor",
  "http 1.5.0",
  "pin-project",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tonic",
  "tower",
  "tracing",
@@ -8775,7 +8792,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix",
- "thiserror 2.0.20",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ cbor-diag = "0.1.12"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 config = { version = "0.15", default-features = false, features = ["yaml"] }
+cpace = { git = "https://github.com/phnx-im/cpace", rev = "1882fad3b58ffbb27a82c78418826727b72b8bac" }
 criterion = { version = "0.8.2", features = ["html_reports", "async", "async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.1.1", features = ["from", "display"] }
@@ -67,7 +68,7 @@ futures-util = "0.3.31"
 h2 = "0.4.12"
 hex = "0.4.3"
 hkdf = "0.13"
-hmac = "0.13"
+hmac = { version = "0.13", features = ["zeroize"] }
 ignore = "0.4"
 # default formats minus avif and exr, which pull in the unmaintained paste
 # crate (RUSTSEC-2024-0436) via ravif and exr

--- a/apiclient/src/rs_api.rs
+++ b/apiclient/src/rs_api.rs
@@ -6,8 +6,9 @@ use aircommon::{
     crypto::signatures::{keys::QsUserSigningKey, signable::Signable},
     identifiers::QsUserId,
 };
-use airprotos::relay_service::v1::{
-    LinkClientRequest, LinkClientRequestPayload, LinkingSessionId, RelayFrame,
+use airprotos::relay_service::{
+    mdl::{MDL_PROTOCOL_VERSION, MdlMessage, ProvisionRequest},
+    v1::{LinkClientRequest, LinkClientRequestPayload, RelayFrame, RendezvousId},
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -43,6 +44,13 @@ impl ApiClient {
     ) -> Result<(mpsc::Sender<RelayFrame>, tonic::Streaming<RelayFrame>), RsRequestError> {
         // don't buffer frames: we expect the peer to consume what we send before we move forward
         let (tx, rx) = mpsc::channel::<RelayFrame>(1);
+
+        let provision_request = MdlMessage::ProvisionRequest(ProvisionRequest {
+            version: MDL_PROTOCOL_VERSION,
+        })
+        .into_frame()?;
+        tx.send(provision_request).await?;
+
         let request = tonic::Request::new(ReceiverStream::new(rx));
 
         let response: tonic::Response<tonic::Streaming<RelayFrame>> = self
@@ -57,7 +65,7 @@ impl ApiClient {
         &self,
         qs_user_id: QsUserId,
         qs_user_signing_key: &QsUserSigningKey,
-        linking_session_id: LinkingSessionId,
+        rendezvous_id: RendezvousId,
     ) -> Result<(mpsc::Sender<RelayFrame>, tonic::Streaming<RelayFrame>), RsRequestError> {
         // don't buffer frames: we expect the peer to consume what we send before we move forward
         let (tx, rx) = mpsc::channel::<RelayFrame>(1);
@@ -65,7 +73,7 @@ impl ApiClient {
         let payload = LinkClientRequestPayload {
             client_metadata: Some(self.metadata()),
             sender: Some(qs_user_id.into()),
-            session_id: Some(linking_session_id),
+            rendezvous_id: Some(rendezvous_id),
         };
 
         let link_client_request: LinkClientRequest = payload.sign(qs_user_signing_key)?;

--- a/applogic/src/api/multi_device.rs
+++ b/applogic/src/api/multi_device.rs
@@ -11,7 +11,6 @@ use aircoreclient::clients::{
     CoreUser,
     multi_device::{MultiDeviceLinkClientError, MultiDeviceProvisionStep},
 };
-use airprotos::relay_service::v1::LinkingSessionId;
 use anyhow::{Context, Result};
 use flutter_rust_bridge::frb;
 use qrcode::QrCode;
@@ -28,11 +27,10 @@ const LINKING_URL_SCHEME: &str = "air";
 const LINKING_URL_PATH: &str = "multiDeviceLinkingCode";
 const LINKING_URL_SESSION_ID: &str = "sessionId";
 
-/// Builds the QR-code URL that a fresh device displays for an existing device to scan.
-fn multi_device_linking_url(domain: &Fqdn, session_id: &LinkingSessionId) -> String {
-    format!(
-        "{LINKING_URL_SCHEME}://{domain}/{LINKING_URL_PATH}?{LINKING_URL_SESSION_ID}={session_id}"
-    )
+/// Builds the QR-code URL that a fresh device displays for an existing device
+/// to scan. The query parameter carries the full linking code.
+fn multi_device_linking_url(domain: &Fqdn, code: &str) -> String {
+    format!("{LINKING_URL_SCHEME}://{domain}/{LINKING_URL_PATH}?{LINKING_URL_SESSION_ID}={code}")
 }
 
 /// Extracts the linking code from a QR payload produced by [`multi_device_linking_url`].
@@ -116,24 +114,22 @@ pub async fn multi_device_provision_client(
     let forward_code = async {
         while let Some(msg) = session_rx.recv().await {
             match msg {
-                MultiDeviceProvisionStep::SessionId(session_id) => {
-                    let qrcode_svg =
-                        QrCode::new(multi_device_linking_url(&qrcode_domain, &session_id))
-                            .map(|code| {
-                                use qrcode::render::svg;
-                                code.render::<svg::Color>()
-                                    .min_dimensions(200, 200)
-                                    .dark_color(svg::Color("#000000"))
-                                    .light_color(svg::Color("#FFFFFF"))
-                                    .quiet_zone(false)
-                                    .build()
-                            })
-                            .ok();
+                MultiDeviceProvisionStep::Code(code) => {
+                    let qrcode_svg = QrCode::new(multi_device_linking_url(&qrcode_domain, &code))
+                        .map(|code| {
+                            use qrcode::render::svg;
+                            code.render::<svg::Color>()
+                                .min_dimensions(200, 200)
+                                .dark_color(svg::Color("#000000"))
+                                .light_color(svg::Color("#FFFFFF"))
+                                .quiet_zone(false)
+                                .build()
+                        })
+                        .ok();
 
-                    if let Err(error) = sink.add(MultiDeviceProvisionEvent::Code {
-                        code: session_id.to_string(),
-                        qrcode_svg,
-                    }) {
+                    if let Err(error) =
+                        sink.add(MultiDeviceProvisionEvent::Code { code, qrcode_svg })
+                    {
                         error!(%error, "failed to forward MultiDeviceProvisionEvent to the Dart side");
                     }
                 }
@@ -225,7 +221,6 @@ pub async fn multi_device_link_client(
     let confirmation_rx = confirmation
         .take_receiver()
         .context("multi-device link confirmation already used")?;
-    let session_id = LinkingSessionId { value: session_id };
     let (connected_tx, connected_rx) = oneshot::channel();
 
     let forward_connected = async {
@@ -245,9 +240,10 @@ pub async fn multi_device_link_client(
         .await
         {
             Ok(Ok(())) => MultiDeviceLinkEvent::Linked,
-            Ok(Err(MultiDeviceLinkClientError::SessionNotFound)) => {
-                MultiDeviceLinkEvent::SessionNotFound
-            }
+            Ok(Err(
+                MultiDeviceLinkClientError::SessionNotFound
+                | MultiDeviceLinkClientError::InvalidCode,
+            )) => MultiDeviceLinkEvent::SessionNotFound,
             Err(error) => {
                 error!(%error, "multi-device linking failed");
                 MultiDeviceLinkEvent::Failed(error.to_string())

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -57,6 +57,7 @@ cbor-diag.workspace = true
 insta.workspace = true
 mockall.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 
 [features]

--- a/backend/src/rate_limiter/mod.rs
+++ b/backend/src/rate_limiter/mod.rs
@@ -64,6 +64,12 @@ impl Allowance {
         self.valid_until = Utc::now() + config.time_window;
     }
 
+    /// Whether the window this allowance counts over has passed, so nothing
+    /// is lost by forgetting it.
+    pub(crate) fn is_stale(&self) -> bool {
+        self.valid_until < Utc::now()
+    }
+
     fn allowed(&mut self, config: &RlConfig) -> bool {
         // Check if the time window has passed
         if self.valid_until < Utc::now() {

--- a/backend/src/rate_limiter/mod.rs
+++ b/backend/src/rate_limiter/mod.rs
@@ -70,7 +70,7 @@ impl Allowance {
         self.valid_until < Utc::now()
     }
 
-    fn allowed(&mut self, config: &RlConfig) -> bool {
+    pub(crate) fn allowed(&mut self, config: &RlConfig) -> bool {
         // Check if the time window has passed
         if self.valid_until < Utc::now() {
             self.reset(config);

--- a/backend/src/rate_limiter/provider.rs
+++ b/backend/src/rate_limiter/provider.rs
@@ -2,9 +2,48 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, PoisonError},
+};
+
 use sqlx::PgPool;
 
 use super::{Allowance, RlKey, StorageProvider};
+
+/// Allowances kept in process memory.
+///
+/// Suitable for a service whose state is in memory anyway, where a restart
+/// resetting the counters costs nothing an attacker could not get by waiting
+/// out the window.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RlMemoryStorage {
+    allowances: Arc<Mutex<HashMap<Vec<u8>, Allowance>>>,
+}
+
+impl RlMemoryStorage {
+    /// Forgets allowances whose window has passed, so the map does not grow
+    /// with every address that ever connected.
+    pub(crate) fn prune(&self) {
+        self.lock().retain(|_, allowance| !allowance.is_stale());
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Vec<u8>, Allowance>> {
+        self.allowances
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+impl StorageProvider for RlMemoryStorage {
+    async fn get(&self, key: &RlKey) -> Option<Allowance> {
+        self.lock().get(key.serialize()).cloned()
+    }
+
+    async fn set(&self, key: RlKey, allowance: Allowance) {
+        self.lock().insert(key.serialize().to_owned(), allowance);
+    }
+}
 
 pub(crate) struct RlPostgresStorage {
     pool: PgPool,

--- a/backend/src/rate_limiter/provider.rs
+++ b/backend/src/rate_limiter/provider.rs
@@ -9,19 +9,24 @@ use std::{
 
 use sqlx::PgPool;
 
-use super::{Allowance, RlKey, StorageProvider};
+use super::{Allowance, RlConfig, RlKey, StorageProvider};
 
 /// Allowances kept in process memory.
-///
-/// Suitable for a service whose state is in memory anyway, where a restart
-/// resetting the counters costs nothing an attacker could not get by waiting
-/// out the window.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RlMemoryStorage {
     allowances: Arc<Mutex<HashMap<Vec<u8>, Allowance>>>,
 }
 
 impl RlMemoryStorage {
+    /// Charges one request against `key` and reports whether it is allowed.
+    pub(crate) fn charge(&self, config: &RlConfig, key: &RlKey) -> bool {
+        let mut allowances = self.lock();
+        allowances
+            .entry(key.serialize().to_owned())
+            .or_insert_with(|| Allowance::new(config))
+            .allowed(config)
+    }
+
     /// Forgets allowances whose window has passed, so the map does not grow
     /// with every address that ever connected.
     pub(crate) fn prune(&self) {
@@ -32,16 +37,6 @@ impl RlMemoryStorage {
         self.allowances
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-    }
-}
-
-impl StorageProvider for RlMemoryStorage {
-    async fn get(&self, key: &RlKey) -> Option<Allowance> {
-        self.lock().get(key.serialize()).cloned()
-    }
-
-    async fn set(&self, key: RlKey, allowance: Allowance) {
-        self.lock().insert(key.serialize().to_owned(), allowance);
     }
 }
 
@@ -208,5 +203,70 @@ pub(crate) mod persistence {
 
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::*;
+
+    /// Concurrent requests for one key must not all read the same allowance
+    /// and pass together.
+    #[tokio::test]
+    async fn concurrent_charges_spend_the_allowance_once_each() {
+        const REQUESTS: usize = 20;
+        const LIMIT: u64 = 5;
+
+        let storage = RlMemoryStorage::default();
+        let config = RlConfig {
+            max_requests: LIMIT,
+            time_window: TimeDelta::hours(1),
+        };
+        let key = RlKey::new(b"test_service", b"test_rpc", &[]);
+
+        let mut charges = Vec::with_capacity(REQUESTS);
+        for _ in 0..REQUESTS {
+            let storage = storage.clone();
+            let config = config.clone();
+            let key = key.clone();
+            charges.push(tokio::spawn(async move { storage.charge(&config, &key) }));
+        }
+
+        let mut allowed: u64 = 0;
+        for charge in charges {
+            if charge.await.expect("charge task panicked") {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, LIMIT);
+    }
+
+    #[tokio::test]
+    async fn pruning_forgets_only_stale_allowances() {
+        let storage = RlMemoryStorage::default();
+        let live = RlKey::new(b"test_service", b"live", &[]);
+        let stale = RlKey::new(b"test_service", b"stale", &[]);
+
+        assert!(storage.charge(
+            &RlConfig {
+                max_requests: 1,
+                time_window: TimeDelta::hours(1),
+            },
+            &live
+        ));
+        assert!(storage.charge(
+            &RlConfig {
+                max_requests: 1,
+                time_window: TimeDelta::milliseconds(-1),
+            },
+            &stale
+        ));
+
+        storage.prune();
+        let allowances = storage.lock();
+        assert!(allowances.contains_key(live.serialize()));
+        assert!(!allowances.contains_key(stale.serialize()));
     }
 }

--- a/backend/src/relay_service/grpc.rs
+++ b/backend/src/relay_service/grpc.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::{
+    client_ip::{ClientIp, IpBucket},
     qs::QsConnector,
     relay_service::{Rs, sessions::Outbound},
 };
@@ -41,6 +42,22 @@ impl<Qep: QsConnector> GrpcRs<Qep> {
     pub fn new(rs: Rs, qs_connector: Qep) -> Self {
         Self { rs, qs_connector }
     }
+}
+
+/// The address bucket a request counts under.
+fn ip_bucket<T>(request: &Request<T>) -> Result<IpBucket, Status> {
+    request
+        .extensions()
+        .get::<ClientIp>()
+        .map(ClientIp::bucket)
+        .ok_or_else(|| {
+            error!("no client address on a relay request");
+            Status::internal("failed to resolve the client address")
+        })
+}
+
+fn too_many_requests() -> Status {
+    Status::resource_exhausted("Too many requests, please try again later")
 }
 
 /// Pipes one peer's inbound frames to the other peer.
@@ -72,6 +89,11 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
         &self,
         request: Request<Streaming<RelayFrame>>,
     ) -> Result<Response<Self::MultiDeviceProvisionClientStream>, Status> {
+        let ip = ip_bucket(&request)?;
+        if !self.rs.allow_provision(ip).await {
+            return Err(too_many_requests());
+        }
+
         let mut inbound = request.into_inner();
 
         let frame = inbound.message().await?.ok_or_else(|| {
@@ -149,6 +171,7 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
         &self,
         request: Request<Streaming<RelayFrame>>,
     ) -> Result<Response<Self::MultiDeviceLinkClientStream>, Status> {
+        let ip = ip_bucket(&request)?;
         let mut inbound = request.into_inner();
 
         // The first frame is the signed request, so only a registered user
@@ -175,9 +198,14 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
             .ok_or_missing_field("uuid value")?
             .into();
 
+        let qs_user_id = aircommon::identifiers::QsUserId::from(qs_user_id);
+        if !self.rs.allow_link(ip, qs_user_id).await {
+            return Err(too_many_requests());
+        }
+
         let qs_user_signature_key: QsUserVerifyingKey = self
             .qs_connector
-            .user_verifying_key(aircommon::identifiers::QsUserId::from(qs_user_id))
+            .user_verifying_key(qs_user_id)
             .await
             .map_err(|error| {
                 error!(%error, "failed to load QS user signing key");

--- a/backend/src/relay_service/grpc.rs
+++ b/backend/src/relay_service/grpc.rs
@@ -90,7 +90,7 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
         request: Request<Streaming<RelayFrame>>,
     ) -> Result<Response<Self::MultiDeviceProvisionClientStream>, Status> {
         let ip = ip_bucket(&request)?;
-        if !self.rs.allow_provision(ip).await {
+        if !self.rs.allow_provision(ip) {
             return Err(too_many_requests());
         }
 
@@ -172,6 +172,9 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
         request: Request<Streaming<RelayFrame>>,
     ) -> Result<Response<Self::MultiDeviceLinkClientStream>, Status> {
         let ip = ip_bucket(&request)?;
+        if !self.rs.allow_link_from(ip) {
+            return Err(too_many_requests());
+        }
         let mut inbound = request.into_inner();
 
         // The first frame is the signed request, so only a registered user
@@ -199,10 +202,6 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
             .into();
 
         let qs_user_id = aircommon::identifiers::QsUserId::from(qs_user_id);
-        if !self.rs.allow_link(ip, qs_user_id).await {
-            return Err(too_many_requests());
-        }
-
         let qs_user_signature_key: QsUserVerifyingKey = self
             .qs_connector
             .user_verifying_key(qs_user_id)
@@ -216,6 +215,13 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
         let payload: LinkClientRequestPayload = request
             .verify(&qs_user_signature_key)
             .map_err(|_| Status::invalid_argument("invalid signature"))?;
+
+        // Charged only now that the sender proved it owns the account.
+        // Charging it off the unverified `sender` field would let anyone who
+        // knows a `QsUserId` lock that user out of linking.
+        if !self.rs.allow_link_by(qs_user_id) {
+            return Err(too_many_requests());
+        }
 
         let rendezvous_id = payload.rendezvous_id.ok_or_missing_field("rendezvous_id")?;
         if !rendezvous_id.is_well_formed() {

--- a/backend/src/relay_service/grpc.rs
+++ b/backend/src/relay_service/grpc.rs
@@ -6,19 +6,18 @@ use std::pin::Pin;
 
 use aircommon::crypto::signatures::{keys::QsUserVerifyingKey, signable::Verifiable};
 use airprotos::{
-    relay_service::v1::{
-        LinkClientRequest, LinkClientRequestPayload, LinkingSessionId, RelayFrame,
-        relay_service_server::RelayService,
+    relay_service::{
+        mdl::{MDL_PROTOCOL_VERSION, MdlMessage, ProvisionRequest, SessionAssigned},
+        v1::{
+            LinkClientRequest, LinkClientRequestPayload, RelayFrame,
+            relay_service_server::RelayService,
+        },
     },
     signed::SignedRequest,
     validation::MissingFieldExt,
 };
 use futures_util::Stream;
-use prost::bytes::Bytes;
-use tokio::{
-    sync::{mpsc, oneshot},
-    time::timeout,
-};
+use tokio::sync::mpsc;
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::{Request, Response, Status, Streaming, async_trait};
 use tracing::{error, info, warn};
@@ -26,8 +25,12 @@ use uuid::Uuid;
 
 use crate::{
     qs::QsConnector,
-    relay_service::{Pending, Rs, SESSION_TIMEOUT},
+    relay_service::{Rs, sessions::Outbound},
 };
+
+/// Frames a peer may fall behind by before its sender blocks. The protocol
+/// is a ping-pong, so anything beyond a couple of frames is slack.
+const CHANNEL_CAPACITY: usize = 8;
 
 pub struct GrpcRs<Qep: QsConnector> {
     rs: Rs,
@@ -40,26 +43,24 @@ impl<Qep: QsConnector> GrpcRs<Qep> {
     }
 }
 
-async fn pipe_inbound_to_peer_outbound(
-    session_id: LinkingSessionId,
-    mut inbound: Streaming<RelayFrame>,
-    peer_outbound: mpsc::Sender<Result<RelayFrame, Status>>,
-) {
-    while let Some(msg) = inbound.next().await {
-        match msg {
+/// Pipes one peer's inbound frames to the other peer.
+///
+/// Frames are opaque here: the relay never inspects a linking payload.
+async fn forward(rendezvous_id: &str, mut inbound: Streaming<RelayFrame>, peer: Outbound) {
+    while let Some(frame) = inbound.next().await {
+        match frame {
             Ok(frame) => {
-                if peer_outbound.send(Ok(frame)).await.is_err() {
+                if peer.send(Ok(frame)).await.is_err() {
                     break;
                 }
             }
             Err(status) => {
-                warn!(%session_id, %status, "inbound error");
+                warn!(%rendezvous_id, %status, "inbound stream failed");
                 break;
             }
         }
     }
-
-    info!(session_id = %session_id, "client disconnected");
+    info!(%rendezvous_id, "peer disconnected");
 }
 
 #[async_trait]
@@ -73,82 +74,71 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
     ) -> Result<Response<Self::MultiDeviceProvisionClientStream>, Status> {
         let mut inbound = request.into_inner();
 
-        let (outbound_tx, outbound_rx) = mpsc::channel::<Result<RelayFrame, Status>>(8);
-        let first_frame_outbound_tx = outbound_tx.clone();
+        let frame = inbound.message().await?.ok_or_else(|| {
+            Status::invalid_argument("stream closed before the provisioning request")
+        })?;
+        let message = MdlMessage::from_frame(&frame).map_err(|error| {
+            warn!(%error, "malformed linking frame");
+            Status::invalid_argument("malformed linking message")
+        })?;
+        let MdlMessage::ProvisionRequest(ProvisionRequest { version }) = message else {
+            return Err(Status::invalid_argument("expected a provisioning request"));
+        };
+        if version != MDL_PROTOCOL_VERSION {
+            return Err(Status::failed_precondition(
+                "unsupported linking protocol version",
+            ));
+        }
 
-        let relay_sessions = self.rs.sessions.clone();
-        tokio::spawn(self.rs.stop.clone().run_until_cancelled_owned(async move {
-            // Expect a KeyPackage as the first frame; its SHA256 digest becomes the session ID.
-            let Some(Ok(key_package_bytes)) = inbound.next().await else {
-                error!("failed to receive KeyPackage");
-                return;
-            };
+        let (outbound_tx, outbound_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let (rendezvous_id, responder_ready_rx, cancel) = self
+            .rs
+            .open(outbound_tx.clone())
+            .ok_or_else(|| Status::resource_exhausted("no rendezvous id available"))?;
 
-            // Lock sessions for all clients because we might check many buckets.
-            let mut sessions = relay_sessions.lock().await;
-            let Some(truncated_session_id) =
-                LinkingSessionId::generate(key_package_bytes.as_slice(), |session_id| {
-                    sessions.contains_key(session_id)
-                })
-            else {
-                error!("linking session ID collision");
-                return;
-            };
+        let assigned = MdlMessage::SessionAssigned(SessionAssigned {
+            rendezvous_id: rendezvous_id.clone(),
+        })
+        .into_frame()
+        .map_err(|error| {
+            error!(%error, "failed to encode the session assignment");
+            Status::internal("encoding failure")
+        })?;
+        if outbound_tx.send(Ok(assigned)).await.is_err() {
+            self.rs.end(&rendezvous_id);
+            return Err(Status::aborted("provisioner disconnected"));
+        }
 
-            info!(%truncated_session_id, "starting new linking session");
-
-            let (peer_ready_tx, peer_ready_rx) = oneshot::channel();
-
-            sessions.insert(
-                truncated_session_id.clone(),
-                Pending {
-                    outbound_tx,
-                    peer_ready_tx,
-                },
-            );
-
-            // Release the lock.
-            drop(sessions);
-
-            // Report the session ID length to the peer.
-            if let Err(error) = first_frame_outbound_tx
-                .send(Ok(RelayFrame {
-                    payload: Bytes::from_owner(truncated_session_id.digits().to_be_bytes()),
-                }))
-                .await
-            {
-                error!(%error, "failed to send session ID length");
-                return;
-            };
-
-            // Wait for the peer to connect.
-            let peer_outbound = match timeout(SESSION_TIMEOUT, peer_ready_rx).await {
-                Ok(Ok(tx)) => tx,
-                Ok(Err(error)) => {
-                    relay_sessions.lock().await.remove(&truncated_session_id);
-                    info!(%error, "peer disconnected before sending outbound channel");
+        let rs = self.rs.clone();
+        tokio::spawn(cancel.run_until_cancelled_owned(async move {
+            // Hold the provisioner's PAKE share until a responder attaches,
+            // then hand it over as that peer's first frame.
+            let buffered = match inbound.next().await {
+                Some(Ok(frame)) => frame,
+                Some(Err(status)) => {
+                    warn!(%rendezvous_id, %status, "provisioner stream failed");
+                    rs.end(&rendezvous_id);
                     return;
                 }
-                Err(_) => {
-                    relay_sessions.lock().await.remove(&truncated_session_id);
-                    info!(%truncated_session_id, "timed out waiting for peer");
+                None => {
+                    rs.end(&rendezvous_id);
                     return;
                 }
             };
 
-            // Forward the key package to the peer.
-            if let Err(error) = peer_outbound.send(Ok(key_package_bytes)).await {
-                error!(%error, "failed to send key package");
+            let Ok(responder) = responder_ready_rx.await else {
+                rs.end(&rendezvous_id);
                 return;
             };
 
-            // Pipe inbound relay frames to the peer.
-            pipe_inbound_to_peer_outbound(truncated_session_id, inbound, peer_outbound).await;
+            if responder.send(Ok(buffered)).await.is_ok() {
+                forward(&rendezvous_id, inbound, responder).await;
+            }
+            rs.end(&rendezvous_id);
         }));
 
-        let out_stream = ReceiverStream::new(outbound_rx);
         Ok(Response::new(
-            Box::pin(out_stream) as Self::MultiDeviceProvisionClientStream
+            Box::pin(ReceiverStream::new(outbound_rx)) as Self::MultiDeviceProvisionClientStream
         ))
     }
 
@@ -161,7 +151,8 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
     ) -> Result<Response<Self::MultiDeviceLinkClientStream>, Status> {
         let mut inbound = request.into_inner();
 
-        // The first frame is the initial request payload.
+        // The first frame is the signed request, so only a registered user
+        // can consume a session's single authentication attempt.
         let first_frame = inbound
             .message()
             .await?
@@ -198,31 +189,26 @@ impl<Qep: QsConnector> RelayService for GrpcRs<Qep> {
             .verify(&qs_user_signature_key)
             .map_err(|_| Status::invalid_argument("invalid signature"))?;
 
-        let session_id = payload.session_id.ok_or_missing_field("session_id")?;
-        info!(%session_id, "linking with existing session");
-
-        // Outbound channel: messages we will send back to *this* client.
-        let (outbound_tx, outbound_rx) = mpsc::channel::<Result<RelayFrame, Status>>(8);
-
-        if let Some(pending) = self.rs.sessions.lock().await.remove(&session_id) {
-            // Fire the peer's oneshot with our outbound sender so they can start forwarding to us.
-            if pending.peer_ready_tx.send(outbound_tx).is_err() {
-                warn!("failed to signal that peer is ready (initiator disconnected)");
-                return Err(Status::aborted(
-                    "peer disconnected before establishing relay pipe",
-                ));
-            }
-
-            tokio::spawn(self.rs.stop.clone().run_until_cancelled_owned(
-                pipe_inbound_to_peer_outbound(session_id, inbound, pending.outbound_tx),
-            ));
-        } else {
+        let rendezvous_id = payload.rendezvous_id.ok_or_missing_field("rendezvous_id")?;
+        if !rendezvous_id.is_well_formed() {
             return Err(Status::not_found("session not found"));
         }
+        let rendezvous_id = rendezvous_id.value;
 
-        let out_stream = ReceiverStream::new(outbound_rx);
+        let (outbound_tx, outbound_rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let Some((provisioner, cancel)) = self.rs.claim(&rendezvous_id, outbound_tx) else {
+            return Err(Status::not_found("session not found"));
+        };
+        info!(%rendezvous_id, "attached the responder to a linking session");
+
+        let rs = self.rs.clone();
+        tokio::spawn(cancel.run_until_cancelled_owned(async move {
+            forward(&rendezvous_id, inbound, provisioner).await;
+            rs.end(&rendezvous_id);
+        }));
+
         Ok(Response::new(
-            Box::pin(out_stream) as Self::MultiDeviceLinkClientStream
+            Box::pin(ReceiverStream::new(outbound_rx)) as Self::MultiDeviceLinkClientStream
         ))
     }
 }

--- a/backend/src/relay_service/mod.rs
+++ b/backend/src/relay_service/mod.rs
@@ -2,38 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! The rendezvous relay of the multi-device linking protocol.
+//!
+//! The relay routes opaque frames between a provisioning device and the
+//! single existing device that answers its code. It parses only the
+//! provisioning request and produces the session's rendezvous ID.
+//!
+//! State is in memory. Sessions are short lived and a lost session costs a user
+//! one retry.
+
 pub mod grpc;
+pub(crate) mod sessions;
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
-
-use airprotos::relay_service::v1::{LinkingSessionId, RelayFrame};
-use tokio::sync::{Mutex, mpsc, oneshot};
-use tokio_util::sync::CancellationToken;
-use tonic::Status;
-
-const SESSION_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// A "pending" half of a session: someone joined but their peer hasn't yet.
-#[derive(Debug)]
-pub(crate) struct Pending {
-    /// Send a clone of this to the peer's outbound channel when they arrive.
-    outbound_tx: mpsc::Sender<Result<RelayFrame, Status>>,
-    /// Fires when the peer connects, delivering the peer's outbound sender
-    /// so this side can forward inbound traffic to them.
-    peer_ready_tx: oneshot::Sender<mpsc::Sender<Result<RelayFrame, Status>>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Rs {
-    sessions: Arc<Mutex<HashMap<LinkingSessionId, Pending>>>,
-    stop: CancellationToken,
-}
-
-impl Rs {
-    pub fn new(stop: CancellationToken) -> Self {
-        Self {
-            sessions: Arc::new(Mutex::new(HashMap::new())),
-            stop,
-        }
-    }
-}
+pub use sessions::{Rs, SessionId};

--- a/backend/src/relay_service/sessions.rs
+++ b/backend/src/relay_service/sessions.rs
@@ -25,7 +25,7 @@ use tracing::{info, warn};
 
 use crate::{
     client_ip::IpBucket,
-    rate_limiter::{RateLimiter, RlConfig, RlKey, provider::RlMemoryStorage},
+    rate_limiter::{RlConfig, RlKey, provider::RlMemoryStorage},
     settings::RelaySettings,
 };
 
@@ -173,46 +173,39 @@ impl Rs {
     }
 
     /// Whether this address may open another linking session.
-    pub(crate) async fn allow_provision(&self, ip: IpBucket) -> bool {
+    pub(crate) fn allow_provision(&self, ip: IpBucket) -> bool {
         self.allow(
             self.settings.perip,
             RlKey::new(RL_SERVICE, RL_PROVISION, &[b"ip", &ip]),
         )
-        .await
     }
 
-    /// Whether this address and this user may make another link attempt.
-    ///
-    /// Both allowances are charged, the address first, so an attacker cannot
-    /// spread attempts over accounts or over addresses alone.
-    pub(crate) async fn allow_link(&self, ip: IpBucket, qs_user_id: QsUserId) -> bool {
-        let by_ip = self
-            .allow(
-                self.settings.perip,
-                RlKey::new(RL_SERVICE, RL_LINK, &[b"ip", &ip]),
-            )
-            .await;
-        let by_user = self
-            .allow(
-                self.settings.peruser,
-                RlKey::new(
-                    RL_SERVICE,
-                    RL_LINK,
-                    &[b"qs_user", qs_user_id.as_uuid().as_bytes()],
-                ),
-            )
-            .await;
-        by_ip && by_user
+    /// Whether this address may make another link attempt.
+    pub(crate) fn allow_link_from(&self, ip: IpBucket) -> bool {
+        self.allow(
+            self.settings.perip,
+            RlKey::new(RL_SERVICE, RL_LINK, &[b"ip", &ip]),
+        )
     }
 
-    async fn allow(&self, max_requests: u64, key: RlKey) -> bool {
+    /// Whether this user may make another link attempt.
+    pub(crate) fn allow_link_by(&self, qs_user_id: QsUserId) -> bool {
+        self.allow(
+            self.settings.peruser,
+            RlKey::new(
+                RL_SERVICE,
+                RL_LINK,
+                &[b"qs_user", qs_user_id.as_uuid().as_bytes()],
+            ),
+        )
+    }
+
+    fn allow(&self, max_requests: u64, key: RlKey) -> bool {
         let config = RlConfig {
             max_requests,
             time_window: TimeDelta::hours(1),
         };
-        RateLimiter::new(config, self.allowances.clone())
-            .allowed(key)
-            .await
+        self.allowances.charge(&config, &key)
     }
 
     /// Opens a session for a provisioning device.
@@ -388,6 +381,14 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn ids_start_at_three_digits_and_count_up() {
+        let rs = relay(long(), long());
+        let sessions: Vec<Opened> = (0..3).map(|_| open(&rs)).collect();
+        let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["000", "001", "002"]);
+    }
+
     /// Moves the paused clock past `deadline` and lets the reaper sweep.
     ///
     /// The reaper registers its timer on its first poll, so it has to run
@@ -399,14 +400,6 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn ids_start_at_three_digits_and_count_up() {
-        let rs = relay(long(), long());
-        let sessions: Vec<Opened> = (0..3).map(|_| open(&rs)).collect();
-        let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
-        assert_eq!(ids, vec!["000", "001", "002"]);
-    }
-
-    #[tokio::test]
     async fn an_ended_id_is_reused_only_after_quarantine() {
         let rs = relay(long(), long());
         let first = open(&rs);
@@ -491,14 +484,14 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn claiming_an_unknown_id_fails() {
         let rs = relay(long(), long());
         let (responder, _rx) = mpsc::channel(8);
         assert!(rs.claim("999", responder).is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn the_reaper_expires_and_quarantines_a_session() {
         let rs = relay(long(), long());
         let session = open(&rs);
@@ -540,11 +533,11 @@ mod rate_limit_tests {
     #[tokio::test]
     async fn provisioning_is_capped_per_address() {
         let rs = relay(2, 100);
-        assert!(rs.allow_provision(bucket(1)).await);
-        assert!(rs.allow_provision(bucket(1)).await);
-        assert!(!rs.allow_provision(bucket(1)).await);
+        assert!(rs.allow_provision(bucket(1)));
+        assert!(rs.allow_provision(bucket(1)));
+        assert!(!rs.allow_provision(bucket(1)));
         assert!(
-            rs.allow_provision(bucket(2)).await,
+            rs.allow_provision(bucket(2)),
             "another address has its own allowance"
         );
     }
@@ -553,11 +546,11 @@ mod rate_limit_tests {
     async fn link_attempts_are_capped_per_user() {
         let rs = relay(100, 2);
         let user = QsUserId::random();
-        assert!(rs.allow_link(bucket(1), user).await);
-        assert!(rs.allow_link(bucket(1), user).await);
-        assert!(!rs.allow_link(bucket(2), user).await);
+        assert!(rs.allow_link_by(user));
+        assert!(rs.allow_link_by(user));
+        assert!(!rs.allow_link_by(user));
         assert!(
-            rs.allow_link(bucket(1), QsUserId::random()).await,
+            rs.allow_link_by(QsUserId::random()),
             "another user has its own allowance"
         );
     }
@@ -565,15 +558,34 @@ mod rate_limit_tests {
     #[tokio::test]
     async fn link_attempts_are_capped_per_address() {
         let rs = relay(2, 100);
-        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
-        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
-        assert!(!rs.allow_link(bucket(1), QsUserId::random()).await);
+        assert!(rs.allow_link_from(bucket(1)));
+        assert!(rs.allow_link_from(bucket(1)));
+        assert!(!rs.allow_link_from(bucket(1)));
+        assert!(
+            rs.allow_link_from(bucket(2)),
+            "another address has its own allowance"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_address_charge_does_not_touch_the_user_allowance() {
+        let rs = relay(100, 1);
+        let user = QsUserId::random();
+
+        for _ in 0..10 {
+            assert!(rs.allow_link_from(bucket(1)));
+        }
+
+        assert!(
+            rs.allow_link_by(user),
+            "the user's single attempt must survive unverified requests"
+        );
     }
 
     #[tokio::test]
     async fn the_two_rpcs_do_not_share_an_allowance() {
         let rs = relay(1, 100);
-        assert!(rs.allow_provision(bucket(1)).await);
-        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
+        assert!(rs.allow_provision(bucket(1)));
+        assert!(rs.allow_link_from(bucket(1)));
     }
 }

--- a/backend/src/relay_service/sessions.rs
+++ b/backend/src/relay_service/sessions.rs
@@ -12,7 +12,9 @@ use std::{
     time::Duration,
 };
 
+use aircommon::identifiers::QsUserId;
 use airprotos::relay_service::v1::RelayFrame;
+use chrono::TimeDelta;
 use tokio::{
     sync::{mpsc, oneshot},
     time::Instant,
@@ -21,7 +23,16 @@ use tokio_util::sync::CancellationToken;
 use tonic::Status;
 use tracing::{info, warn};
 
-use crate::settings::RelaySettings;
+use crate::{
+    client_ip::IpBucket,
+    rate_limiter::{RateLimiter, RlConfig, RlKey, provider::RlMemoryStorage},
+    settings::RelaySettings,
+};
+
+/// Service name the relay's rate-limiter keys are scoped under.
+const RL_SERVICE: &[u8] = b"rs";
+const RL_PROVISION: &[u8] = b"multi_device_provision_client";
+const RL_LINK: &[u8] = b"multi_device_link_client";
 
 /// Frames going out to one peer of a session.
 pub(crate) type Outbound = mpsc::Sender<Result<RelayFrame, Status>>;
@@ -117,11 +128,23 @@ impl fmt::Debug for Table {
 }
 
 /// The relay's shared state.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Rs {
     table: Arc<Mutex<Table>>,
+    /// Allowances live in memory alongside the sessions they guard. A
+    /// restart forgets them, which buys an attacker no more than waiting the
+    /// window out would.
+    allowances: RlMemoryStorage,
     settings: RelaySettings,
     stop: CancellationToken,
+}
+
+impl fmt::Debug for Rs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Rs")
+            .field("settings", &self.settings)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Rs {
@@ -141,11 +164,55 @@ impl Rs {
                 width: INITIAL_WIDTH,
                 ..Table::default()
             })),
+            allowances: RlMemoryStorage::default(),
             settings,
             stop,
         };
         rs.spawn_reaper();
         rs
+    }
+
+    /// Whether this address may open another linking session.
+    pub(crate) async fn allow_provision(&self, ip: IpBucket) -> bool {
+        self.allow(
+            self.settings.perip,
+            RlKey::new(RL_SERVICE, RL_PROVISION, &[b"ip", &ip]),
+        )
+        .await
+    }
+
+    /// Whether this address and this user may make another link attempt.
+    ///
+    /// Both allowances are charged, the address first, so an attacker cannot
+    /// spread attempts over accounts or over addresses alone.
+    pub(crate) async fn allow_link(&self, ip: IpBucket, qs_user_id: QsUserId) -> bool {
+        let by_ip = self
+            .allow(
+                self.settings.perip,
+                RlKey::new(RL_SERVICE, RL_LINK, &[b"ip", &ip]),
+            )
+            .await;
+        let by_user = self
+            .allow(
+                self.settings.peruser,
+                RlKey::new(
+                    RL_SERVICE,
+                    RL_LINK,
+                    &[b"qs_user", qs_user_id.as_uuid().as_bytes()],
+                ),
+            )
+            .await;
+        by_ip && by_user
+    }
+
+    async fn allow(&self, max_requests: u64, key: RlKey) -> bool {
+        let config = RlConfig {
+            max_requests,
+            time_window: TimeDelta::hours(1),
+        };
+        RateLimiter::new(config, self.allowances.clone())
+            .allowed(key)
+            .await
     }
 
     /// Opens a session for a provisioning device.
@@ -258,6 +325,9 @@ impl Rs {
         }
 
         table.quarantine.retain(|_, until| *until > now);
+        drop(table);
+
+        self.allowances.prune();
     }
 
     fn spawn_reaper(&self) {
@@ -290,6 +360,7 @@ mod tests {
             RelaySettings {
                 sessionttl: ttl,
                 idquarantine: quarantine,
+                ..RelaySettings::default()
             },
         )
     }
@@ -440,5 +511,69 @@ mod tests {
 
         let (responder, _rx) = mpsc::channel(8);
         assert!(rs.claim(&session.id, responder).is_none());
+    }
+}
+
+#[cfg(test)]
+mod rate_limit_tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use crate::client_ip::ClientIp;
+
+    use super::*;
+
+    fn relay(perip: u64, peruser: u64) -> Rs {
+        Rs::new(
+            CancellationToken::new(),
+            RelaySettings {
+                perip,
+                peruser,
+                ..RelaySettings::default()
+            },
+        )
+    }
+
+    fn bucket(last: u8) -> IpBucket {
+        ClientIp::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, last))).bucket()
+    }
+
+    #[tokio::test]
+    async fn provisioning_is_capped_per_address() {
+        let rs = relay(2, 100);
+        assert!(rs.allow_provision(bucket(1)).await);
+        assert!(rs.allow_provision(bucket(1)).await);
+        assert!(!rs.allow_provision(bucket(1)).await);
+        assert!(
+            rs.allow_provision(bucket(2)).await,
+            "another address has its own allowance"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_attempts_are_capped_per_user() {
+        let rs = relay(100, 2);
+        let user = QsUserId::random();
+        assert!(rs.allow_link(bucket(1), user).await);
+        assert!(rs.allow_link(bucket(1), user).await);
+        assert!(!rs.allow_link(bucket(2), user).await);
+        assert!(
+            rs.allow_link(bucket(1), QsUserId::random()).await,
+            "another user has its own allowance"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_attempts_are_capped_per_address() {
+        let rs = relay(2, 100);
+        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
+        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
+        assert!(!rs.allow_link(bucket(1), QsUserId::random()).await);
+    }
+
+    #[tokio::test]
+    async fn the_two_rpcs_do_not_share_an_allowance() {
+        let rs = relay(1, 100);
+        assert!(rs.allow_provision(bucket(1)).await);
+        assert!(rs.allow_link(bucket(1), QsUserId::random()).await);
     }
 }

--- a/backend/src/relay_service/sessions.rs
+++ b/backend/src/relay_service/sessions.rs
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The relay's session table: rendezvous ID assignment, quarantine and the
+//! time-to-live reaper.
+
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+    time::Duration,
+};
+
+use airprotos::relay_service::v1::RelayFrame;
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
+use tokio_util::sync::CancellationToken;
+use tonic::Status;
+use tracing::{info, warn};
+
+use crate::settings::RelaySettings;
+
+/// Frames going out to one peer of a session.
+pub(crate) type Outbound = mpsc::Sender<Result<RelayFrame, Status>>;
+
+/// A session's rendezvous ID: a decimal string the relay assigns.
+pub type SessionId = String;
+
+/// Digits the relay starts assigning rendezvous IDs at.
+const INITIAL_WIDTH: u32 = 3;
+
+/// Widest rendezvous ID the relay assigns. A billion concurrent sessions is
+/// far past what a single replica serves, so reaching this means something
+/// else is wrong.
+const MAX_WIDTH: u32 = 9;
+
+/// The reaper sweeps a few times per session lifetime, so an idle session
+/// is torn down at most a fraction of its lifetime late. The lower bound
+/// only keeps a degenerate lifetime from turning the sweep into a busy loop.
+const REAP_DIVISOR: u32 = 4;
+const MIN_REAP_INTERVAL: Duration = Duration::from_millis(20);
+const MAX_REAP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How far a session has got.
+enum State {
+    /// The provisioner is waiting for an existing device to answer its code.
+    AwaitingResponder(oneshot::Sender<Outbound>),
+    /// Both peers are attached.
+    Connected,
+}
+
+struct Session {
+    /// Frames going to the provisioning device.
+    provisioner: Outbound,
+    state: State,
+    /// When the reaper tears this session down.
+    expires_at: Instant,
+    /// Cancels both peers' forwarding tasks.
+    cancel: CancellationToken,
+}
+
+#[derive(Default)]
+struct Table {
+    live: HashMap<SessionId, Session>,
+    /// Ended IDs and the instant they may be assigned again. A user typing a
+    /// stale code must not consume an unrelated fresh session.
+    quarantine: HashMap<SessionId, Instant>,
+    /// Digits currently being assigned. It only ever grows, and clients never
+    /// parse structure out of an ID.
+    width: u32,
+}
+
+impl Table {
+    /// The lowest ID at the current width that is neither live nor
+    /// quarantined, widening when the current width is more than half full.
+    fn assign(&mut self) -> Option<SessionId> {
+        while self.width <= MAX_WIDTH {
+            let capacity = 10u64.pow(self.width);
+            if self.occupancy() * 2 > capacity {
+                self.width += 1;
+                continue;
+            }
+            let width = self.width as usize;
+            for n in 0..capacity {
+                let candidate = format!("{n:0width$}");
+                if !self.live.contains_key(&candidate) && !self.quarantine.contains_key(&candidate)
+                {
+                    return Some(candidate);
+                }
+            }
+            self.width += 1;
+        }
+        None
+    }
+
+    /// IDs of the current width that are unavailable.
+    fn occupancy(&self) -> u64 {
+        let width = self.width as usize;
+        let of_width = |id: &&SessionId| id.len() == width;
+        let live = self.live.keys().filter(of_width).count();
+        let quarantined = self.quarantine.keys().filter(of_width).count();
+        (live + quarantined) as u64
+    }
+}
+
+impl fmt::Debug for Table {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Table")
+            .field("live", &self.live.len())
+            .field("quarantine", &self.quarantine.len())
+            .field("width", &self.width)
+            .finish()
+    }
+}
+
+/// The relay's shared state.
+#[derive(Debug, Clone)]
+pub struct Rs {
+    table: Arc<Mutex<Table>>,
+    settings: RelaySettings,
+    stop: CancellationToken,
+}
+
+impl Rs {
+    /// Creates the relay and starts its reaper.
+    pub fn new(stop: CancellationToken, mut settings: RelaySettings) -> Self {
+        if settings.idquarantine < settings.sessionttl {
+            warn!(
+                configured = ?settings.idquarantine,
+                raised_to = ?settings.sessionttl,
+                "the rendezvous id quarantine was shorter than the session lifetime"
+            );
+            settings.idquarantine = settings.sessionttl;
+        }
+
+        let rs = Self {
+            table: Arc::new(Mutex::new(Table {
+                width: INITIAL_WIDTH,
+                ..Table::default()
+            })),
+            settings,
+            stop,
+        };
+        rs.spawn_reaper();
+        rs
+    }
+
+    /// Opens a session for a provisioning device.
+    ///
+    /// Returns the assigned rendezvous ID, the receiver that fires with the
+    /// responder's outbound channel once one attaches, and the token that
+    /// cancels the session.
+    pub(crate) fn open(
+        &self,
+        provisioner: Outbound,
+    ) -> Option<(SessionId, oneshot::Receiver<Outbound>, CancellationToken)> {
+        let (responder_ready_tx, responder_ready_rx) = oneshot::channel();
+        let cancel = self.stop.child_token();
+
+        let mut table = self.lock();
+        let id = table.assign()?;
+        table.live.insert(
+            id.clone(),
+            Session {
+                provisioner,
+                state: State::AwaitingResponder(responder_ready_tx),
+                expires_at: Instant::now() + self.settings.sessionttl,
+                cancel: cancel.clone(),
+            },
+        );
+        info!(rendezvous_id = %id, "opened a linking session");
+        Some((id, responder_ready_rx, cancel))
+    }
+
+    /// Attaches the single responder a session accepts.
+    ///
+    /// Returns the provisioner's outbound channel and the session's cancel
+    /// token. `None` means there is no such session, or it already has a
+    /// responder, or the provisioner is gone.
+    pub(crate) fn claim(
+        &self,
+        id: &str,
+        responder: Outbound,
+    ) -> Option<(Outbound, CancellationToken)> {
+        let mut table = self.lock();
+        let session = table.live.get_mut(id)?;
+
+        // The reaper runs on an interval, so a session can outlive its
+        // deadline by a little.
+        if session.expires_at <= Instant::now() {
+            drop(table);
+            self.end(id);
+            return None;
+        }
+
+        let State::AwaitingResponder(responder_ready_tx) =
+            std::mem::replace(&mut session.state, State::Connected)
+        else {
+            return None;
+        };
+        if responder_ready_tx.send(responder).is_err() {
+            // The provisioner went away, so nothing would forward to us.
+            drop(table);
+            self.end(id);
+            return None;
+        }
+        Some((session.provisioner.clone(), session.cancel.clone()))
+    }
+
+    /// Ends a session and puts its ID into quarantine.
+    pub(crate) fn end(&self, id: &str) {
+        let quarantine_until = Instant::now() + self.settings.idquarantine;
+        let mut table = self.lock();
+        if let Some(session) = table.live.remove(id) {
+            session.cancel.cancel();
+            info!(rendezvous_id = %id, "ended a linking session");
+        }
+        table.quarantine.insert(id.to_owned(), quarantine_until);
+    }
+
+    /// Whether `id` currently names a live session.
+    pub fn is_live(&self, id: &str) -> bool {
+        self.lock().live.contains_key(id)
+    }
+
+    /// Whether `id` is held back from reuse.
+    pub fn is_quarantined(&self, id: &str) -> bool {
+        self.lock().quarantine.contains_key(id)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Table> {
+        // A poisoned lock would mean a panic inside one of these short
+        // critical sections, none of which can leave the table inconsistent.
+        self.table.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Drops expired sessions and releases quarantined IDs.
+    fn reap(&self) {
+        let now = Instant::now();
+        let quarantine_until = now + self.settings.idquarantine;
+        let mut table = self.lock();
+
+        let expired: Vec<SessionId> = table
+            .live
+            .iter()
+            .filter(|(_, session)| session.expires_at <= now)
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in expired {
+            if let Some(session) = table.live.remove(&id) {
+                session.cancel.cancel();
+                warn!(rendezvous_id = %id, "linking session expired");
+            }
+            table.quarantine.insert(id, quarantine_until);
+        }
+
+        table.quarantine.retain(|_, until| *until > now);
+    }
+
+    fn spawn_reaper(&self) {
+        let interval = self
+            .settings
+            .sessionttl
+            .min(self.settings.idquarantine)
+            .checked_div(REAP_DIVISOR)
+            .unwrap_or(MIN_REAP_INTERVAL)
+            .clamp(MIN_REAP_INTERVAL, MAX_REAP_INTERVAL);
+
+        let rs = self.clone();
+        tokio::spawn(self.stop.clone().run_until_cancelled_owned(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                rs.reap();
+            }
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A relay whose deadlines are short enough for a test to wait them out.
+    fn relay(ttl: Duration, quarantine: Duration) -> Rs {
+        Rs::new(
+            CancellationToken::new(),
+            RelaySettings {
+                sessionttl: ttl,
+                idquarantine: quarantine,
+            },
+        )
+    }
+
+    fn long() -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// Opens a session and keeps both channel ends alive for the caller.
+    struct Opened {
+        id: SessionId,
+        cancel: CancellationToken,
+        _provisioner_rx: mpsc::Receiver<Result<RelayFrame, Status>>,
+        _responder_ready_rx: oneshot::Receiver<Outbound>,
+    }
+
+    fn open(rs: &Rs) -> Opened {
+        let (tx, rx) = mpsc::channel(8);
+        let (id, responder_ready_rx, cancel) = rs.open(tx).expect("no rendezvous id available");
+        Opened {
+            id,
+            cancel,
+            _provisioner_rx: rx,
+            _responder_ready_rx: responder_ready_rx,
+        }
+    }
+
+    /// Moves the paused clock past `deadline` and lets the reaper sweep.
+    ///
+    /// The reaper registers its timer on its first poll, so it has to run
+    /// once before the clock moves, or the advance passes it by.
+    async fn advance_past(deadline: Duration) {
+        tokio::task::yield_now().await;
+        tokio::time::advance(deadline + MAX_REAP_INTERVAL).await;
+        tokio::task::yield_now().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ids_start_at_three_digits_and_count_up() {
+        let rs = relay(long(), long());
+        let sessions: Vec<Opened> = (0..3).map(|_| open(&rs)).collect();
+        let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["000", "001", "002"]);
+    }
+
+    #[tokio::test]
+    async fn an_ended_id_is_reused_only_after_quarantine() {
+        let rs = relay(long(), long());
+        let first = open(&rs);
+        assert_eq!(first.id, "000");
+
+        rs.end(&first.id);
+        assert!(!rs.is_live(&first.id));
+        assert!(rs.is_quarantined(&first.id));
+
+        let second = open(&rs);
+        assert_eq!(second.id, "001", "a quarantined id must not be handed out");
+
+        advance_past(long()).await;
+        assert!(!rs.is_quarantined(&first.id));
+    }
+
+    #[tokio::test]
+    async fn the_width_grows_past_half_occupancy() {
+        let rs = relay(long(), long());
+        {
+            let mut table = rs.lock();
+            let until = Instant::now() + long();
+            for n in 0..501 {
+                table.quarantine.insert(format!("{n:03}"), until);
+            }
+        }
+        assert_eq!(open(&rs).id.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn only_the_first_responder_is_attached() {
+        let rs = relay(long(), long());
+        let session = open(&rs);
+
+        let (first, _first_rx) = mpsc::channel(8);
+        assert!(rs.claim(&session.id, first).is_some());
+
+        let (second, _second_rx) = mpsc::channel(8);
+        assert!(rs.claim(&session.id, second).is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn an_expired_session_cannot_be_claimed() {
+        let rs = relay(long(), long());
+        let session = open(&rs);
+
+        // Reach past the deadline before the reaper has armed its first sweep,
+        // so nothing but the claim itself can notice the expiry.
+        tokio::time::advance(long() + Duration::from_secs(1)).await;
+        assert!(rs.is_live(&session.id), "the reaper must not have run yet");
+
+        let (responder, _rx) = mpsc::channel(8);
+        assert!(rs.claim(&session.id, responder).is_none());
+        assert!(!rs.is_live(&session.id));
+        assert!(rs.is_quarantined(&session.id));
+    }
+
+    #[tokio::test]
+    async fn the_quarantine_is_raised_to_the_session_lifetime() {
+        let rs = Rs::new(
+            CancellationToken::new(),
+            RelaySettings {
+                sessionttl: Duration::from_secs(600),
+                idquarantine: Duration::from_secs(1),
+                ..RelaySettings::default()
+            },
+        );
+        assert_eq!(rs.settings.idquarantine, Duration::from_secs(600));
+
+        let rs = Rs::new(
+            CancellationToken::new(),
+            RelaySettings {
+                sessionttl: Duration::from_secs(600),
+                idquarantine: Duration::from_secs(3600),
+                ..RelaySettings::default()
+            },
+        );
+        assert_eq!(
+            rs.settings.idquarantine,
+            Duration::from_secs(3600),
+            "a longer quarantine must be left alone"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn claiming_an_unknown_id_fails() {
+        let rs = relay(long(), long());
+        let (responder, _rx) = mpsc::channel(8);
+        assert!(rs.claim("999", responder).is_none());
+    }
+
+    #[tokio::test]
+    async fn the_reaper_expires_and_quarantines_a_session() {
+        let rs = relay(long(), long());
+        let session = open(&rs);
+
+        advance_past(long()).await;
+
+        assert!(!rs.is_live(&session.id));
+        assert!(rs.is_quarantined(&session.id));
+        assert!(session.cancel.is_cancelled());
+
+        let (responder, _rx) = mpsc::channel(8);
+        assert!(rs.claim(&session.id, responder).is_none());
+    }
+}

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -30,6 +30,8 @@ pub struct Settings {
     pub ratelimits: RateLimitsSettings,
     #[serde(default)]
     pub registration: RegistrationSettings,
+    #[serde(default)]
+    pub relay: RelaySettings,
 }
 
 /// Configuration for the application.
@@ -237,6 +239,39 @@ impl Default for RateLimitsSettings {
             burst: 100,
         }
     }
+}
+
+/// Lifetime and reuse policy of a device-linking rendezvous session.
+///
+/// Field names carry no underscores, because environment overrides split on
+/// them (`AIR_RELAY_SESSIONTTL`).
+#[derive(Debug, Deserialize, Clone)]
+pub struct RelaySettings {
+    /// How long a session lives after its rendezvous ID is assigned.
+    #[serde(with = "duration_millis", default = "default_session_ttl")]
+    pub sessionttl: std::time::Duration,
+    /// How long an ended session's rendezvous ID is held back from reuse. A
+    /// user typing a stale code must not consume an unrelated fresh session,
+    /// so this is never shorter than the session lifetime in practice.
+    #[serde(with = "duration_millis", default = "default_id_quarantine")]
+    pub idquarantine: std::time::Duration,
+}
+
+impl Default for RelaySettings {
+    fn default() -> Self {
+        Self {
+            sessionttl: default_session_ttl(),
+            idquarantine: default_id_quarantine(),
+        }
+    }
+}
+
+fn default_session_ttl() -> std::time::Duration {
+    std::time::Duration::from_secs(10 * 60)
+}
+
+fn default_id_quarantine() -> std::time::Duration {
+    std::time::Duration::from_secs(10 * 60)
 }
 
 /// How registration is gated.

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -255,6 +255,15 @@ pub struct RelaySettings {
     /// so this is never shorter than the session lifetime in practice.
     #[serde(with = "duration_millis", default = "default_id_quarantine")]
     pub idquarantine: std::time::Duration,
+    /// Sessions one client address may open, and link attempts it may make,
+    /// per hour.
+    #[serde(default = "default_relay_attempts")]
+    pub perip: u64,
+    /// Link attempts one registered user may make per hour. Every attempt
+    /// against a live session consumes it, so this caps what a compromised
+    /// account can guess.
+    #[serde(default = "default_relay_attempts")]
+    pub peruser: u64,
 }
 
 impl Default for RelaySettings {
@@ -262,6 +271,8 @@ impl Default for RelaySettings {
         Self {
             sessionttl: default_session_ttl(),
             idquarantine: default_id_quarantine(),
+            perip: default_relay_attempts(),
+            peruser: default_relay_attempts(),
         }
     }
 }
@@ -272,6 +283,10 @@ fn default_session_ttl() -> std::time::Duration {
 
 fn default_id_quarantine() -> std::time::Duration {
     std::time::Duration::from_secs(10 * 60)
+}
+
+fn default_relay_attempts() -> u64 {
+    10
 }
 
 /// How registration is gated.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,12 +17,14 @@ airmacros.workspace = true
 apqmls.workspace = true
 argon2 = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["serde"] }
+cpace.workspace = true
 digest-io.workspace = true
 displaydoc.workspace = true
 ed25519 = { workspace = true, features = ["serde"] }
 futures-util.workspace = true
 hex.workspace = true
 hkdf.workspace = true
+hmac.workspace = true
 mimi-room-policy.workspace = true
 mimi_content.workspace = true
 minicbor.workspace = true
@@ -44,7 +46,7 @@ url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [package.metadata.cargo-machete]
-ignored = ["serde_bytes"]
+ignored = ["hmac", "serde_bytes"]
 
 [dev-dependencies]
 cbor-diag.workspace = true

--- a/common/src/crypto/aead/keys.rs
+++ b/common/src/crypto/aead/keys.rs
@@ -107,17 +107,6 @@ impl RandomlyGeneratable for AttachmentEarKeyType {}
 
 impl AeadKey for AttachmentEarKey {}
 
-#[derive(Debug)]
-pub struct MultiDeviceLinkingKeyType;
-
-impl RawKey for MultiDeviceLinkingKeyType {}
-
-pub type MultiDeviceLinkingKey = Key<MultiDeviceLinkingKeyType>;
-
-impl RandomlyGeneratable for MultiDeviceLinkingKeyType {}
-
-impl AeadKey for MultiDeviceLinkingKey {}
-
 // Self-group message key
 
 /// Key that encrypts `SelfGroupMessages` payloads carried in self-group

--- a/common/src/crypto/mdl/code.rs
+++ b/common/src/crypto/mdl/code.rs
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The user-visible code of the multi-device linking protocol.
+//!
+//! A code is the decimal string `rendezvous_id || password || check_digit`.
+//! The rendezvous ID is public and assigned by the relay. The 16-digit
+//! password carries the whole security of the exchange. The Damm check
+//! digit catches the typos that would otherwise burn a session, which is
+//! why the existing device verifies it before it contacts the relay.
+
+use std::fmt;
+
+use rand::RngExt;
+use secrecy::zeroize::Zeroize;
+
+/// Digits of the secret half of a linking code.
+pub const PASSWORD_DIGITS: usize = 16;
+
+/// Digits of the shortest rendezvous ID the relay assigns.
+pub const MIN_RENDEZVOUS_DIGITS: usize = 3;
+
+/// Digits a linking code has at the very least.
+pub const MIN_CODE_DIGITS: usize = MIN_RENDEZVOUS_DIGITS + PASSWORD_DIGITS + 1;
+
+/// The order-10 quasigroup of the Damm algorithm, which is totally
+/// antisymmetric and weakly totally antisymmetric. That is what makes the
+/// check digit catch every single-digit error and every transposition of
+/// two adjacent digits.
+const DAMM_TABLE: [[u8; 10]; 10] = [
+    [0, 3, 1, 7, 5, 9, 8, 6, 4, 2],
+    [7, 0, 9, 2, 1, 5, 4, 8, 6, 3],
+    [4, 2, 0, 6, 8, 7, 1, 3, 5, 9],
+    [1, 7, 5, 0, 9, 8, 3, 4, 2, 6],
+    [6, 1, 2, 3, 0, 4, 5, 9, 7, 8],
+    [3, 6, 7, 4, 2, 0, 9, 5, 8, 1],
+    [5, 8, 6, 9, 7, 2, 0, 1, 3, 4],
+    [8, 9, 4, 5, 3, 6, 2, 0, 1, 7],
+    [9, 4, 3, 8, 6, 1, 7, 2, 0, 5],
+    [2, 5, 8, 1, 4, 3, 6, 7, 9, 0],
+];
+
+/// The Damm interim digit of a run of ASCII decimal digits.
+///
+/// Over a bare payload this is its check digit. Over a payload with its
+/// check digit appended it is zero exactly when the code is intact.
+///
+/// Returns `None` if `digits` holds anything but ASCII decimal digits.
+fn damm(digits: &str) -> Option<u8> {
+    let mut interim = 0usize;
+    for byte in digits.bytes() {
+        let digit = usize::from(byte.checked_sub(b'0').filter(|d| *d < 10)?);
+        interim = usize::from(DAMM_TABLE[interim][digit]);
+    }
+    u8::try_from(interim).ok()
+}
+
+/// Why a typed linking code could not be used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum LinkingCodeError {
+    /// The rendezvous ID is not a run of decimal digits.
+    #[error("rendezvous id is not decimal")]
+    InvalidRendezvousId,
+    /// Fewer than [`MIN_CODE_DIGITS`] digits were entered.
+    #[error("linking code is too short")]
+    TooShort,
+    /// The Damm check digit does not match, so the code was mistyped.
+    #[error("linking code check digit does not match")]
+    CheckDigitMismatch,
+}
+
+/// The secret half of a linking code.
+///
+/// Sixteen decimal digits, each drawn uniformly at random, which is about
+/// 53.1 bits. It is the CPace password-related string, used once and never
+/// stored.
+#[derive(Clone, PartialEq, Eq)]
+pub struct LinkingPassword(String);
+
+impl Drop for LinkingPassword {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl LinkingPassword {
+    /// Draws a fresh password from the thread CSPRNG.
+    pub fn generate() -> Self {
+        let mut rng = rand::rng();
+        let digits = (0..PASSWORD_DIGITS)
+            .map(|_| char::from(b'0' + rng.random_range(0..10u8)))
+            .collect();
+        Self(digits)
+    }
+
+    /// The digits, which are what CPace takes as its `PRS`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for LinkingPassword {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("LinkingPassword(<redacted>)")
+    }
+}
+
+/// A linking code, either freshly generated or parsed from user input.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LinkingCode {
+    rendezvous_id: String,
+    password: LinkingPassword,
+}
+
+impl LinkingCode {
+    /// A code for `rendezvous_id` with a fresh password.
+    pub fn generate(rendezvous_id: &str) -> Result<Self, LinkingCodeError> {
+        Self::new(rendezvous_id, LinkingPassword::generate())
+    }
+
+    /// A code pairing `rendezvous_id` with an existing password.
+    pub fn new(rendezvous_id: &str, password: LinkingPassword) -> Result<Self, LinkingCodeError> {
+        if damm(rendezvous_id).is_none() {
+            return Err(LinkingCodeError::InvalidRendezvousId);
+        }
+        Ok(Self {
+            rendezvous_id: rendezvous_id.to_owned(),
+            password,
+        })
+    }
+
+    pub fn rendezvous_id(&self) -> &str {
+        &self.rendezvous_id
+    }
+
+    pub fn password(&self) -> &LinkingPassword {
+        &self.password
+    }
+
+    /// The canonical digit string the user carries to the other device.
+    pub fn to_digits(&self) -> String {
+        let mut digits = self.rendezvous_id.clone();
+        digits.push_str(self.password.as_str());
+        let check = damm(&digits).unwrap_or_default();
+        digits.push(char::from(b'0' + check));
+        digits
+    }
+
+    /// Parses user input into a code.
+    ///
+    /// Non-digit characters are ignored, so grouping into blocks and any
+    /// separators the user copied along do not matter. The check digit is
+    /// verified here, before the caller contacts the relay, because a
+    /// mistyped password would otherwise burn the session.
+    pub fn parse(input: &str) -> Result<Self, LinkingCodeError> {
+        let digits: String = input.chars().filter(char::is_ascii_digit).collect();
+        if digits.len() < MIN_CODE_DIGITS {
+            return Err(LinkingCodeError::TooShort);
+        }
+        if damm(&digits) != Some(0) {
+            return Err(LinkingCodeError::CheckDigitMismatch);
+        }
+
+        // The password has a fixed length, so the rendezvous ID can grow
+        // without a delimiter as long as the split happens from the end.
+        let password_start = digits.len() - PASSWORD_DIGITS - 1;
+        let check_start = digits.len() - 1;
+        Ok(Self {
+            rendezvous_id: digits[..password_start].to_owned(),
+            password: LinkingPassword(digits[password_start..check_start].to_owned()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code(rendezvous_id: &str, password: &str) -> String {
+        LinkingCode::new(rendezvous_id, LinkingPassword(password.to_owned()))
+            .unwrap()
+            .to_digits()
+    }
+
+    #[test]
+    fn generated_passwords_are_sixteen_digits() {
+        let password = LinkingPassword::generate();
+        assert_eq!(password.as_str().len(), PASSWORD_DIGITS);
+        assert!(password.as_str().bytes().all(|b| b.is_ascii_digit()));
+    }
+
+    #[test]
+    fn a_generated_code_round_trips() {
+        let generated = LinkingCode::generate("417").unwrap();
+        let parsed = LinkingCode::parse(&generated.to_digits()).unwrap();
+        assert_eq!(parsed, generated);
+    }
+
+    #[test]
+    fn separators_and_grouping_are_ignored() {
+        let generated = LinkingCode::generate("417").unwrap();
+        let digits = generated.to_digits();
+        let spaced = format!(
+            "{} - {} {} {} {} - {}",
+            &digits[..3],
+            &digits[3..7],
+            &digits[7..11],
+            &digits[11..15],
+            &digits[15..19],
+            &digits[19..],
+        );
+        assert_eq!(LinkingCode::parse(&spaced).unwrap(), generated);
+    }
+
+    #[test]
+    fn the_split_runs_from_the_end() {
+        let generated = LinkingCode::generate("1234567").unwrap();
+        let parsed = LinkingCode::parse(&generated.to_digits()).unwrap();
+        assert_eq!(parsed.rendezvous_id(), "1234567");
+        assert_eq!(parsed.password().as_str().len(), PASSWORD_DIGITS);
+    }
+
+    #[test]
+    fn short_input_is_rejected_before_the_check_digit() {
+        let short = "1".repeat(MIN_CODE_DIGITS - 1);
+        assert_eq!(LinkingCode::parse(&short), Err(LinkingCodeError::TooShort));
+    }
+
+    #[test]
+    fn a_non_decimal_rendezvous_id_is_rejected() {
+        assert_eq!(
+            LinkingCode::generate("41a"),
+            Err(LinkingCodeError::InvalidRendezvousId)
+        );
+    }
+
+    #[test]
+    fn every_single_digit_error_is_caught() {
+        let digits = code("417", "5093184726109958");
+        for position in 0..digits.len() {
+            for replacement in b'0'..=b'9' {
+                let mut typo = digits.clone().into_bytes();
+                if typo[position] == replacement {
+                    continue;
+                }
+                typo[position] = replacement;
+                let typo = String::from_utf8(typo).unwrap();
+                assert_eq!(
+                    LinkingCode::parse(&typo),
+                    Err(LinkingCodeError::CheckDigitMismatch),
+                    "single-digit error at {position} slipped through"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_adjacent_transposition_is_caught() {
+        let digits = code("417", "5093184726109958");
+        for position in 0..digits.len() - 1 {
+            let mut swapped = digits.clone().into_bytes();
+            if swapped[position] == swapped[position + 1] {
+                continue;
+            }
+            swapped.swap(position, position + 1);
+            let swapped = String::from_utf8(swapped).unwrap();
+            assert_eq!(
+                LinkingCode::parse(&swapped),
+                Err(LinkingCodeError::CheckDigitMismatch),
+                "transposition at {position} slipped through"
+            );
+        }
+    }
+
+    #[test]
+    fn the_check_digit_follows_the_damm_definition() {
+        // The Damm run over payload plus check digit lands on zero.
+        let digits = code("417", "5093184726109958");
+        assert_eq!(damm(&digits), Some(0));
+        assert_eq!(
+            damm(&digits[..digits.len() - 1]).map(|d| char::from(b'0' + d)),
+            digits.chars().next_back()
+        );
+    }
+}

--- a/common/src/crypto/mdl/mod.rs
+++ b/common/src/crypto/mdl/mod.rs
@@ -6,3 +6,4 @@
 //! wire types live in `airprotos`, the protocol flow in `aircoreclient`.
 
 pub mod code;
+pub mod pake;

--- a/common/src/crypto/mdl/mod.rs
+++ b/common/src/crypto/mdl/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Client-side building blocks of the multi-device linking protocol. The
+//! wire types live in `airprotos`, the protocol flow in `aircoreclient`.
+
+pub mod code;

--- a/common/src/crypto/mdl/pake.rs
+++ b/common/src/crypto/mdl/pake.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The CPace exchange and key schedule of the multi-device linking
+//! protocol.
+//!
+//! The new device is the initiator, the existing device the responder.
+//! Both feed the linking password, the serialized channel identifier and
+//! the session id into CPace, and post-process the resulting intermediate
+//! session key into the pairing group's external PSK.
+
+use cpace::{Context, InitiatorState, Msg};
+use hkdf::Hkdf;
+use secrecy::zeroize::Zeroize;
+use sha2::{Digest, Sha256};
+
+use super::code::LinkingPassword;
+
+/// Salt of the HKDF extraction over the CPace intermediate session key.
+const KEY_SCHEDULE_SALT: &[u8] = b"air-mdl-v1 key schedule";
+
+/// Info prefix under which the external PSK secret is expanded.
+const PSK_SECRET_LABEL: &[u8] = b"mls external psk";
+
+/// Prefix of the PSK ID hash.
+const PSK_ID_LABEL: &[u8] = b"air-mdl-v1 psk id";
+
+/// Length of the pairing group's external PSK.
+pub const PSK_SECRET_LEN: usize = 32;
+
+/// Length of the pairing group's PSK ID.
+pub const PSK_ID_LEN: usize = 32;
+
+/// A CPace message that failed to parse, or a peer element that failed to
+/// decode. Both are terminal for the session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("invalid cpace message from the peer")]
+pub struct InvalidPakeMessage;
+
+impl From<cpace::Error> for InvalidPakeMessage {
+    fn from(_: cpace::Error) -> Self {
+        Self
+    }
+}
+
+impl From<cpace::MsgError> for InvalidPakeMessage {
+    fn from(_: cpace::MsgError) -> Self {
+        Self
+    }
+}
+
+/// The pairing group's external PSK.
+pub struct MdlPsk {
+    secret: [u8; PSK_SECRET_LEN],
+    id: [u8; PSK_ID_LEN],
+}
+
+impl MdlPsk {
+    pub fn secret(&self) -> &[u8; PSK_SECRET_LEN] {
+        &self.secret
+    }
+
+    pub fn id(&self) -> &[u8; PSK_ID_LEN] {
+        &self.id
+    }
+}
+
+impl Drop for MdlPsk {
+    fn drop(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+impl std::fmt::Debug for MdlPsk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MdlPsk")
+            .field("id", &hex::encode(self.id))
+            .finish_non_exhaustive()
+    }
+}
+
+/// The intermediate session key of a finished CPace exchange.
+pub struct MdlIsk(cpace::Isk);
+
+impl MdlIsk {
+    /// Derives the pairing group's PSK over the session transcript.
+    pub fn derive_psk(&self, kdf_ctx: &[u8]) -> MdlPsk {
+        let kdf = Hkdf::<Sha256>::new(Some(KEY_SCHEDULE_SALT), self.0.as_ref());
+        let mut info = Vec::with_capacity(PSK_SECRET_LABEL.len() + kdf_ctx.len());
+        info.extend_from_slice(PSK_SECRET_LABEL);
+        info.extend_from_slice(kdf_ctx);
+
+        let mut secret = [0u8; PSK_SECRET_LEN];
+        // The output is one hash block, which HKDF always accepts.
+        let expanded = kdf.expand(&info, &mut secret);
+        debug_assert!(expanded.is_ok(), "psk secret expansion failed");
+
+        MdlPsk {
+            secret,
+            id: psk_id(kdf_ctx),
+        }
+    }
+}
+
+impl std::fmt::Debug for MdlIsk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MdlIsk(<redacted>)")
+    }
+}
+
+/// The pairing group's PSK ID, which depends on public values only.
+fn psk_id(kdf_ctx: &[u8]) -> [u8; PSK_ID_LEN] {
+    let mut hasher = Sha256::new();
+    hasher.update(PSK_ID_LABEL);
+    hasher.update(kdf_ctx);
+    hasher.finalize().into()
+}
+
+/// The new device's half of the exchange, between sending `MSGa` and
+/// receiving `MSGb`.
+pub struct MdlInitiator {
+    state: InitiatorState,
+    msg_a: Vec<u8>,
+}
+
+impl MdlInitiator {
+    /// Starts the exchange.
+    pub fn start(password: &LinkingPassword, ci: &[u8], sid: &[u8], ad_a: &[u8]) -> Self {
+        let ctx = Context {
+            prs: password.as_str().as_bytes(),
+            ci,
+            sid,
+        };
+        let (state, msg) = cpace::initiate(&ctx, ad_a, &mut rand::rng());
+        Self {
+            state,
+            msg_a: msg.as_bytes().to_vec(),
+        }
+    }
+
+    /// `MSGa`, which goes on the wire verbatim.
+    pub fn msg_a(&self) -> &[u8] {
+        &self.msg_a
+    }
+
+    /// Completes the exchange with the responder's `MSGb`.
+    pub fn finish(self, msg_b: &[u8]) -> Result<MdlIsk, InvalidPakeMessage> {
+        let msg_b = Msg::from_bytes(msg_b)?;
+        let output = self.state.finish(&msg_b)?;
+        Ok(MdlIsk(output.isk))
+    }
+}
+
+impl std::fmt::Debug for MdlInitiator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MdlInitiator(<redacted>)")
+    }
+}
+
+/// The existing device's output.
+#[derive(Debug)]
+pub struct MdlResponse {
+    /// `MSGb`, which goes on the wire verbatim.
+    pub msg_b: Vec<u8>,
+    /// The initiator's associated data, its serialized KeyPackage.
+    pub key_package: Vec<u8>,
+    pub isk: MdlIsk,
+}
+
+/// Runs the existing device's half of the exchange over the received
+/// `MSGa`.
+pub fn respond(
+    password: &LinkingPassword,
+    ci: &[u8],
+    sid: &[u8],
+    msg_a: &[u8],
+) -> Result<MdlResponse, InvalidPakeMessage> {
+    let msg_a = Msg::from_bytes(msg_a)?;
+    let ctx = Context {
+        prs: password.as_str().as_bytes(),
+        ci,
+        sid,
+    };
+    let (msg_b, output) = cpace::respond(&ctx, b"", &msg_a, &mut rand::rng())?;
+    Ok(MdlResponse {
+        msg_b: msg_b.as_bytes().to_vec(),
+        key_package: msg_a.associated_data().to_vec(),
+        isk: MdlIsk(output.isk),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SID: &[u8] = b"0123456789abcdef";
+    const KEY_PACKAGE: &[u8] = b"a serialized key package";
+
+    /// Runs a full exchange and returns both sides' PSKs. The KDF context
+    /// stands in for the wire structure, which is defined a layer up.
+    fn exchange(
+        password_a: &LinkingPassword,
+        password_b: &LinkingPassword,
+        ci_a: &[u8],
+        ci_b: &[u8],
+    ) -> (MdlPsk, MdlPsk) {
+        let initiator = MdlInitiator::start(password_a, ci_a, SID, KEY_PACKAGE);
+        let msg_a = initiator.msg_a().to_vec();
+
+        let response = respond(password_b, ci_b, SID, &msg_a).unwrap();
+        assert_eq!(response.key_package, KEY_PACKAGE);
+
+        let kdf_ctx_b = kdf_ctx(ci_b, &msg_a, &response.msg_b);
+        let psk_b = response.isk.derive_psk(&kdf_ctx_b);
+
+        let kdf_ctx_a = kdf_ctx(ci_a, &msg_a, &response.msg_b);
+        let psk_a = initiator
+            .finish(&response.msg_b)
+            .unwrap()
+            .derive_psk(&kdf_ctx_a);
+
+        (psk_a, psk_b)
+    }
+
+    fn kdf_ctx(ci: &[u8], msg_a: &[u8], msg_b: &[u8]) -> Vec<u8> {
+        [ci, SID, msg_a, msg_b].concat()
+    }
+
+    #[test]
+    fn both_sides_agree() {
+        let password = LinkingPassword::generate();
+        let (a, b) = exchange(&password, &password, b"ci", b"ci");
+        assert_eq!(a.secret(), b.secret());
+        assert_eq!(a.id(), b.id());
+    }
+
+    #[test]
+    fn a_wrong_password_keeps_the_psk_id_but_not_the_secret() {
+        let (a, b) = exchange(
+            &LinkingPassword::generate(),
+            &LinkingPassword::generate(),
+            b"ci",
+            b"ci",
+        );
+        assert_eq!(a.id(), b.id());
+        assert_ne!(a.secret(), b.secret());
+    }
+
+    #[test]
+    fn a_different_channel_identifier_breaks_the_secret() {
+        let password = LinkingPassword::generate();
+        let (a, b) = exchange(&password, &password, b"ci-417", b"ci-418");
+        assert_ne!(a.secret(), b.secret());
+    }
+
+    #[test]
+    fn the_psk_id_covers_the_channel_identifier() {
+        let password = LinkingPassword::generate();
+        let initiator = MdlInitiator::start(&password, b"ci-417", SID, KEY_PACKAGE);
+        let response = respond(&password, b"ci-417", SID, initiator.msg_a()).unwrap();
+        let isk = initiator.finish(&response.msg_b).unwrap();
+
+        let here = isk.derive_psk(&kdf_ctx(b"ci-417", &[], &response.msg_b));
+        let elsewhere = isk.derive_psk(&kdf_ctx(b"ci-418", &[], &response.msg_b));
+        assert_ne!(here.id(), elsewhere.id());
+        assert_ne!(here.secret(), elsewhere.secret());
+    }
+
+    #[test]
+    fn a_corrupted_share_is_rejected() {
+        let password = LinkingPassword::generate();
+        let initiator = MdlInitiator::start(&password, b"ci", SID, KEY_PACKAGE);
+        let mut msg_a = initiator.msg_a().to_vec();
+        msg_a.truncate(msg_a.len() - 1);
+        assert_eq!(
+            respond(&password, b"ci", SID, &msg_a).unwrap_err(),
+            InvalidPakeMessage
+        );
+
+        let response = respond(&password, b"ci", SID, initiator.msg_a()).unwrap();
+        let mut msg_b = response.msg_b.clone();
+        msg_b[1] ^= 0xff;
+        // A flipped element either fails to decode or yields a different
+        // secret. Only the first is an error, so accept either outcome.
+        if let Ok(isk) = initiator.finish(&msg_b) {
+            let theirs = response.isk.derive_psk(b"ctx");
+            assert_ne!(isk.derive_psk(b"ctx").secret(), theirs.secret());
+        }
+    }
+
+    #[test]
+    fn the_responder_reads_the_key_package_from_the_transcript() {
+        let password = LinkingPassword::generate();
+        let initiator = MdlInitiator::start(&password, b"ci", SID, KEY_PACKAGE);
+        let response = respond(&password, b"ci", SID, initiator.msg_a()).unwrap();
+        assert_eq!(response.key_package, KEY_PACKAGE);
+    }
+}

--- a/common/src/crypto/mod.rs
+++ b/common/src/crypto/mod.rs
@@ -35,6 +35,7 @@ pub mod hash;
 pub mod hpke;
 pub mod indexed_aead;
 pub mod kdf;
+pub mod mdl;
 pub mod ratchet;
 pub mod secrets;
 pub mod signatures;

--- a/coreclient/src/clients/multi_device/mod.rs
+++ b/coreclient/src/clients/multi_device/mod.rs
@@ -2,50 +2,52 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! The multi-device linking protocol.
+//!
+//! A new device opens a rendezvous session at the relay, shows the user a
+//! linking code, and runs a CPace exchange over that code with the existing
+//! device the user types it into. The exchange yields an external PSK that
+//! goes into the key schedule of an ephemeral two-member MLS group, and the
+//! account material travels as application messages inside that group.
+
+mod pairing;
+mod payloads;
+#[cfg(test)]
+mod tests;
+
 use airapiclient::rs_api::RsRequestError;
 use aircommon::codec::PersistenceCodec;
-use aircommon::credentials::keys::{SelfGroupSigningKey, UserSigningKey};
+use aircommon::credentials::keys::SelfGroupSigningKey;
 use aircommon::crypto::RatchetDecryptionKey;
-use aircommon::crypto::aead::keys::{
-    GroupStateEarKey, IdentityLinkWrapperKey, PushTokenEarKey, WelcomeAttributionInfoEarKey,
-};
-use aircommon::crypto::aead::{
-    AeadDecryptable, AeadEncryptable, Ciphertext, keys::MultiDeviceLinkingKey,
-};
-use aircommon::crypto::hpke::ClientIdEncryptionKey;
 use aircommon::crypto::indexed_aead::keys::UserProfileKey;
 use aircommon::crypto::kdf::keys::RatchetSecret;
-use aircommon::crypto::signatures::keys::{QsClientSigningKey, QsUserSigningKey};
-use aircommon::identifiers::{Fqdn, QsClientId, QsUserId, UserId};
-use aircommon::messages::{FriendshipToken, QueueMessage};
+use aircommon::crypto::mdl::code::LinkingCode;
+use aircommon::crypto::mdl::pake::{self, MdlInitiator};
+use aircommon::crypto::signatures::keys::QsClientSigningKey;
+use aircommon::identifiers::Fqdn;
+use aircommon::messages::QueueMessage;
 use aircommon::mls_group_config::{
     APQ_CIPHERSUITE, QS_CLIENT_REFERENCE_EXTENSION_TYPE, self_group_leaf_node_capabilities,
 };
 use airprotos::client::app_data::ClientAppData;
-use airprotos::client::self_group::{LinkedDevice, SettingsUpdate, TokenSeed};
-use airprotos::relay_service::v1::{LinkingSessionId, RelayFrame};
-use anyhow::{Context, anyhow, bail};
+use airprotos::client::self_group::SettingsUpdate;
+use airprotos::relay_service::mdl::{
+    Abort, AbortCode, LinkingPayloadType, MDL_INITIATOR_LABEL, MDL_PROTOCOL_VERSION, MdlContext,
+    MdlKdfContext, MdlMessage, PakeShareA, PakeShareB, SessionAssigned,
+};
+use airprotos::relay_service::v1::{RelayFrame, RendezvousId};
+use anyhow::{Context, anyhow};
 use apqmls::authentication::ApqCredentialWithKey;
 use apqmls::messages::ApqKeyPackage;
 use chrono::Utc;
-use openmls::group::GroupId;
 use openmls::prelude::{Credential, CredentialType, SignaturePublicKey};
-use openmls::{
-    group::{MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig, StagedWelcome},
-    prelude::{
-        BasicCredential, CredentialWithKey, Extension, KeyPackage, MlsMessageBodyIn, MlsMessageIn,
-        MlsMessageOut, ProtocolVersion, UnknownExtension,
-    },
-};
-use openmls_basic_credential::SignatureKeyPair;
-use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::OpenMlsProvider;
-use serde::{Serialize, de::DeserializeOwned};
-use sha2::{Digest, Sha256};
+use openmls::prelude::{CredentialWithKey, Extension, UnknownExtension};
+use rand::TryRng;
 use std::time::Duration;
-use tls_codec::{Deserialize, DeserializeBytes, Serialize as _};
-use tokio::sync::oneshot;
+use tls_codec::{Serialize as _, VLByteSlice};
+use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
+use tonic::Streaming;
 use tracing::{debug, error, info, warn};
 use url::Url;
 use uuid::Uuid;
@@ -53,7 +55,7 @@ use uuid::Uuid;
 use crate::{
     Chat, ChatId, ChatStatus, ChatType, Contact,
     clients::{
-        CIPHERSUITE, CoreUser,
+        CoreUser,
         api_clients::ApiClients,
         create_user::QsRegisteredUserState,
         listen_response,
@@ -74,161 +76,218 @@ use crate::{
     utils::persistence::{open_air_db, open_client_db, open_lock_file},
 };
 
-const EXPORTER_LABEL: &str = "multi-device-linking";
+use pairing::{PairingGroup, PairingIdentity};
 
-/// Everything the old (existing) device hands to the new device over the
-/// secure linking channel so the new device can bootstrap a working
-/// [`CoreUser`] and join the user's self group.
-#[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct ProvisioningPackage {
-    // Identity + AS user credential (shared across devices for the MVP).
-    pub(crate) user_id: UserId,
-    pub(crate) user_signing_key: UserSigningKey,
-    // User-level QS key material (shared by all of the user's devices).
-    pub(crate) qs_user_id: QsUserId,
-    pub(crate) qs_user_signing_key: QsUserSigningKey,
-    pub(crate) friendship_token: FriendshipToken,
-    pub(crate) push_token_ear_key: PushTokenEarKey,
-    pub(crate) wai_ear_key: WelcomeAttributionInfoEarKey,
-    pub(crate) qs_client_id_encryption_key: ClientIdEncryptionKey,
-    // Freshly created queue for the new device (created by the old device).
-    pub(crate) qs_client_id: QsClientId,
-    pub(crate) qs_client_signing_key: QsClientSigningKey,
-    pub(crate) qs_queue_decryption_key: RatchetDecryptionKey,
-    pub(crate) qs_initial_ratchet_secret: RatchetSecret,
-    // User profile.
-    pub(crate) user_profile_key: UserProfileKey,
-    // Self-group metadata not carried by the Welcome.
-    pub(crate) self_group_id: GroupId,
-    pub(crate) identity_link_wrapper_key: IdentityLinkWrapperKey,
-    // Synced user settings snapshot so the new device starts with the
-    // provisioner's values.
-    pub(crate) synced_settings: SettingsUpdate,
-    // The agreed Privacy Pass token seeds, so the new device derives the same
-    // token requests as its sibling instead of running an agreement round for a
-    // key whose allowance epoch the sibling has already locked.
-    pub(crate) token_seeds: Vec<TokenSeed>,
-    // The name the confirming user gave this device. Empty means "no choice
-    // made", and the new device falls back to its own platform label.
-    pub(crate) device_name: String,
-    // The higher-level groups the virtual client is already a member of, which
-    // the new emulator client onboards itself into.
-    pub(crate) groups: Vec<HigherLevelGroup>,
-}
+pub(crate) use payloads::{ConnectionContact, HigherLevelGroup};
+use payloads::{ProvisioningPackage, SelfGroupJoinRequest};
 
-/// What the new device sends back over the secure linking channel.
-///
-/// The metadata entry travels with the key package so the old device can publish
-/// it on the very same self-group commit that adds the new leaf. Sending it as a
-/// settings commit of its own would advance the self-group epoch behind the back
-/// of the device performing the add, breaking the next link with a wrong-epoch
-/// rejection.
-#[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct SelfGroupJoinRequest {
-    pub(crate) key_package: ApqKeyPackage,
-    pub(crate) device: LinkedDevice,
-}
+/// Bytes of the CPace session id the new device draws per session.
+const SID_LEN: usize = 16;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct HigherLevelGroup {
-    pub(crate) group_id: GroupId,
-    pub(crate) pq_group_id: Option<GroupId>,
-    pub(crate) group_state_ear_key: GroupStateEarKey,
-    pub(crate) identity_link_wrapper_key: IdentityLinkWrapperKey,
-    pub(crate) vc_leaf_index: u32,
-    /// Set if the group backs a connection chat rather than a group chat.
-    pub(crate) connection: Option<ConnectionContact>,
-}
+/// How long a device waits for the relay to let go of the call after the
+/// device's last frame, before giving up on it.
+const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub(crate) struct ConnectionContact {
-    pub(crate) user_id: UserId,
-    pub(crate) wai_ear_key: WelcomeAttributionInfoEarKey,
-    pub(crate) friendship_token: FriendshipToken,
-}
-
-#[derive(Debug)]
-pub struct EncryptedLinkingMessageCtype;
-pub type EncryptedLinkingMessage = Ciphertext<EncryptedLinkingMessageCtype>;
-
-#[derive(
-    Debug, Clone, tls_codec::TlsSerialize, tls_codec::TlsSize, tls_codec::TlsDeserializeBytes,
-)]
-struct LinkingMessage {
-    bytes: Vec<u8>,
-}
-
-impl AeadEncryptable<MultiDeviceLinkingKey, EncryptedLinkingMessageCtype> for LinkingMessage {}
-impl AeadDecryptable<MultiDeviceLinkingKey, EncryptedLinkingMessageCtype> for LinkingMessage {}
-
-impl LinkingMessage {
-    /// Serialize and Encrypt `value` under the linking key into a serialized relay frame.
-    fn seal<T>(value: T, cipher: &MultiDeviceLinkingKey) -> anyhow::Result<RelayFrame>
-    where
-        T: Serialize,
-    {
-        let bytes = PersistenceCodec::to_vec(&value)?;
-        let frame = LinkingMessage { bytes }
-            .encrypt(cipher)?
-            .tls_serialize_detached()?;
-        Ok(frame.into())
-    }
-
-    /// Decrypt a relay frame's bytes and deserialize it into the payload.
-    fn open<T: DeserializeOwned>(
-        frame: &[u8],
-        cipher: &MultiDeviceLinkingKey,
-    ) -> anyhow::Result<T> {
-        let message = LinkingMessage::decrypt(
-            cipher,
-            &EncryptedLinkingMessage::tls_deserialize_exact_bytes(frame)?,
-        )?;
-        Ok(PersistenceCodec::from_slice(&message.bytes)?)
-    }
-}
-
-fn make_provider_and_credential(
-    identity: &[u8],
-) -> anyhow::Result<(OpenMlsRustCrypto, CredentialWithKey, SignatureKeyPair)> {
-    let provider = OpenMlsRustCrypto::default();
-    let credential = BasicCredential::new(identity.to_vec());
-    let signature_keys =
-        SignatureKeyPair::new(CIPHERSUITE.signature_algorithm()).context("keygen")?;
-    signature_keys
-        .store(provider.storage())
-        .map_err(|e| anyhow!("store keys: {e}"))?;
-    let credential_with_key = CredentialWithKey {
-        credential: credential.into(),
-        signature_key: signature_keys.to_public_vec().into(),
-    };
-    Ok((provider, credential_with_key, signature_keys))
-}
-
-// Consumes the group and provider by value; they can't be used after export.
-fn export_aead_key(
-    group: MlsGroup,
-    provider: OpenMlsRustCrypto,
-) -> anyhow::Result<MultiDeviceLinkingKey> {
-    let key_bytes = group
-        .export_secret(provider.crypto(), EXPORTER_LABEL, &[], 32)
-        .context("export_secret")?
-        .try_into()
-        .map_err(|_| anyhow!("invalid key length"))?;
-    Ok(MultiDeviceLinkingKey::from_bytes(key_bytes))
-}
-
+/// A step of the new device's provisioning run, reported to the UI.
 #[derive(Debug)]
 pub enum MultiDeviceProvisionStep {
-    /// When the session is open and the server acknowledges it, we can use the session ID.
-    SessionId(LinkingSessionId),
-    /// When the existing client has connected on the other side.
+    /// The relay assigned a session. The string is the full linking code the
+    /// user carries over to their existing device.
+    Code(String),
+    /// The existing device answered the code and linking is under way.
     Linking,
 }
 
+/// Why the existing device could not start linking.
 #[derive(Debug, thiserror::Error)]
 pub enum MultiDeviceLinkClientError {
     #[error("session ID not found")]
     SessionNotFound,
+    /// The code was too short or its check digit did not match, so the relay
+    /// was never contacted and no session was burned.
+    #[error("the linking code is malformed")]
+    InvalidCode,
+}
+
+/// Why a linking session ended badly.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LinkingError {
+    /// The pairing group's Welcome did not open, so the two devices derived
+    /// different PSKs. Either the code was mistyped past the check digit, or
+    /// somebody tried to intercept the linking.
+    #[error("authentication failed, the linking code was wrong or the session was intercepted")]
+    AuthenticationFailed,
+    #[error("linking protocol error")]
+    Protocol(#[source] anyhow::Error),
+    #[error("linking validation failed: {0}")]
+    Validation(String),
+    #[error("the user declined the link")]
+    UserRejected,
+    #[error("the peer aborted the link: {0:?}")]
+    PeerAborted(AbortCode),
+    /// The new device speaks a version this device does not.
+    #[error("unsupported linking protocol version {0}")]
+    UnsupportedVersion(u16),
+    /// The relay call ended under us, so there is nobody left to tell.
+    #[error("the linking session closed")]
+    SessionClosed(#[source] anyhow::Error),
+}
+
+impl LinkingError {
+    pub(crate) fn validation(reason: impl Into<String>) -> Self {
+        Self::Validation(reason.into())
+    }
+
+    /// The code to send the peer, or `None` when the peer ended the session
+    /// itself and there is nobody left to tell.
+    fn abort_code(&self) -> Option<AbortCode> {
+        match self {
+            Self::AuthenticationFailed => Some(AbortCode::AuthenticationFailed),
+            Self::Protocol(_) => Some(AbortCode::ProtocolError),
+            Self::Validation(_) => Some(AbortCode::ValidationFailed),
+            Self::UserRejected => Some(AbortCode::UserRejected),
+            Self::PeerAborted(_) => None,
+            Self::UnsupportedVersion(_) => Some(AbortCode::UnsupportedVersion),
+            Self::SessionClosed(_) => None,
+        }
+    }
+}
+
+impl From<anyhow::Error> for LinkingError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+/// Reads the next linking message off the relay stream.
+async fn next_message(rx: &mut Streaming<RelayFrame>) -> Result<MdlMessage, LinkingError> {
+    let frame = match rx.next().await {
+        Some(Ok(frame)) => frame,
+        Some(Err(status)) => {
+            return Err(LinkingError::SessionClosed(
+                anyhow::Error::from(status).context("the linking stream failed"),
+            ));
+        }
+        None => {
+            return Err(LinkingError::SessionClosed(anyhow!(
+                "the relay closed the linking session"
+            )));
+        }
+    };
+    Ok(MdlMessage::from_frame(&frame).context("malformed linking message")?)
+}
+
+/// Hands a frame to the relay call. A refused frame means the call is over.
+async fn send_frame(
+    tx: &mpsc::Sender<RelayFrame>,
+    frame: RelayFrame,
+    what: &'static str,
+) -> Result<(), LinkingError> {
+    tx.send(frame)
+        .await
+        .map_err(|_| LinkingError::SessionClosed(anyhow!("could not {what}")))
+}
+
+/// Looks for the peer's abort in what is left of a call that ended under us.
+///
+/// The relay ends both streams once one peer closes, so a refused send or a
+/// closed stream can hide an abort the peer sent just before. The call is
+/// already over, so draining is short, and bounded regardless.
+async fn pending_abort(rx: &mut Streaming<RelayFrame>) -> Option<AbortCode> {
+    let drain = async {
+        while let Some(Ok(frame)) = rx.next().await {
+            if let Ok(MdlMessage::Abort(Abort { code })) = MdlMessage::from_frame(&frame) {
+                return Some(code);
+            }
+        }
+        None
+    };
+    tokio::time::timeout(TEARDOWN_TIMEOUT, drain)
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Turns a session that ended under us into the peer's abort when there is
+/// one, otherwise leaves the error alone.
+async fn resolve_closed_session(
+    error: LinkingError,
+    rx: &mut Streaming<RelayFrame>,
+) -> LinkingError {
+    match error {
+        LinkingError::SessionClosed(_) => match pending_abort(rx).await {
+            Some(code) => LinkingError::PeerAborted(code),
+            None => error,
+        },
+        other => other,
+    }
+}
+
+/// Rejects a new device that speaks another version before any PAKE work is
+/// done on its share.
+fn check_version(version: u16) -> Result<(), LinkingError> {
+    if version == MDL_PROTOCOL_VERSION {
+        Ok(())
+    } else {
+        Err(LinkingError::UnsupportedVersion(version))
+    }
+}
+
+/// Turns a message that does not belong at this point of the flow into the
+/// error the caller should abort with.
+fn unexpected(message: &MdlMessage) -> LinkingError {
+    match message {
+        MdlMessage::Abort(Abort { code }) => LinkingError::PeerAborted(*code),
+        other => LinkingError::Protocol(anyhow!("unexpected linking message {}", other.kind())),
+    }
+}
+
+/// Closes the request stream and waits for the relay to end the call.
+async fn close_and_drain(tx: mpsc::Sender<RelayFrame>, rx: &mut Streaming<RelayFrame>) {
+    drop(tx);
+    let drained = async { while rx.next().await.is_some() {} };
+    if tokio::time::timeout(TEARDOWN_TIMEOUT, drained)
+        .await
+        .is_err()
+    {
+        debug!("the relay did not end the linking call in time");
+    }
+}
+
+/// Tells the peer why the session ended, then waits for the relay to let go
+/// of the call.
+async fn send_abort(tx: mpsc::Sender<RelayFrame>, rx: &mut Streaming<RelayFrame>, code: AbortCode) {
+    let Ok(frame) = MdlMessage::Abort(Abort { code }).into_frame() else {
+        return;
+    };
+    if tokio::time::timeout(TEARDOWN_TIMEOUT, tx.send(frame))
+        .await
+        .is_ok_and(|sent| sent.is_ok())
+    {
+        close_and_drain(tx, rx).await;
+    } else {
+        debug!(?code, "the linking abort could not be delivered");
+    }
+}
+
+/// Reads one linking payload of the expected type out of the pairing group.
+async fn receive_payload(
+    pairing: &mut PairingGroup,
+    rx: &mut Streaming<RelayFrame>,
+    expected: LinkingPayloadType,
+) -> Result<Vec<u8>, LinkingError> {
+    let message = next_message(rx).await?;
+    let MdlMessage::GroupMessage(group_message) = message else {
+        return Err(unexpected(&message));
+    };
+    let payload = pairing.receive(&group_message)?;
+    if payload.payload_type != expected {
+        return Err(LinkingError::Protocol(anyhow!(
+            "expected the linking payload {expected:?}, got {:?}",
+            payload.payload_type
+        )));
+    }
+    Ok(payload.payload)
 }
 
 impl CoreUser {
@@ -240,78 +299,108 @@ impl CoreUser {
         db_path: &str,
         domain: Fqdn,
         server_url: Option<Url>,
-        session_tx: tokio::sync::mpsc::Sender<MultiDeviceProvisionStep>,
+        session_tx: mpsc::Sender<MultiDeviceProvisionStep>,
     ) -> anyhow::Result<CoreUser> {
-        let (provider, credential_with_key, signature_keys) =
-            make_provider_and_credential(b"initiator")?;
-
-        let key_package_bundle = KeyPackage::builder()
-            .build(CIPHERSUITE, &provider, &signature_keys, credential_with_key)
-            .context("build key package")?;
-        let key_package_bytes = MlsMessageOut::from(key_package_bundle)
-            .to_bytes()
-            .context("serialize key package")?;
-        let key_package_checksum: [u8; 32] = Sha256::digest(&key_package_bytes).into();
-
-        let api_clients = ApiClients::new(domain, server_url);
-
+        let api_clients = ApiClients::new(domain.clone(), server_url);
         let (tx, mut rx) = api_clients
             .default_client()?
             .rs_multi_device_provision_client()
             .await?;
 
-        // Send the key package to the server.
-        tx.send(key_package_bytes.into()).await?;
+        let session =
+            Self::provision_session(api_clients, db_path, &domain, &tx, &mut rx, &session_tx);
+        match Box::pin(session).await {
+            Ok(core_user) => {
+                // The completion frame is still queued. Let it out before the
+                // call goes away, or the existing device sees a dropped
+                // stream where linking in fact succeeded.
+                close_and_drain(tx, &mut rx).await;
+                Ok(core_user)
+            }
+            Err(error) => {
+                let error = resolve_closed_session(error, &mut rx).await;
+                if let Some(code) = error.abort_code() {
+                    send_abort(tx, &mut rx, code).await;
+                }
+                Err(error.into())
+            }
+        }
+    }
 
-        // The relay echoes back the session ID as the first frame
-        let session_id_length = rx
-            .next()
-            .await
-            .context("relay connection closed")??
-            .as_u32()
-            .context("unexpected format for first frame")?;
+    async fn provision_session(
+        api_clients: ApiClients,
+        db_path: &str,
+        domain: &Fqdn,
+        tx: &mpsc::Sender<RelayFrame>,
+        rx: &mut Streaming<RelayFrame>,
+        session_tx: &mpsc::Sender<MultiDeviceProvisionStep>,
+    ) -> Result<CoreUser, LinkingError> {
+        let message = next_message(rx).await?;
+        let MdlMessage::SessionAssigned(SessionAssigned { rendezvous_id }) = message else {
+            return Err(unexpected(&message));
+        };
 
-        // we recompose the session ID from our key package digest and the session ID length
-        let session_id = LinkingSessionId::from_digest(&key_package_checksum, session_id_length)
-            .context("invalid session ID")?;
+        let code = LinkingCode::generate(&rendezvous_id).map_err(|_| {
+            LinkingError::validation("the relay assigned a malformed rendezvous id")
+        })?;
+        let ci = MdlContext::new(domain.to_string(), rendezvous_id)
+            .tls_serialize_detached()
+            .context("serialize the linking context")?;
+
+        let mut sid = [0u8; SID_LEN];
+        rand::rng().try_fill_bytes(&mut sid);
+
+        let identity = PairingIdentity::new(MDL_INITIATOR_LABEL)?;
+        let key_package = identity.key_package()?;
+        let initiator = MdlInitiator::start(code.password(), &ci, &sid, &key_package);
+        let msg_a = initiator.msg_a().to_vec();
+
+        let share = MdlMessage::PakeShareA(PakeShareA {
+            version: MDL_PROTOCOL_VERSION,
+            sid: sid.to_vec(),
+            msg_a: msg_a.clone(),
+        })
+        .into_frame()
+        .context("frame the pake share")?;
+        send_frame(tx, share, "send the pake share").await?;
 
         session_tx
-            .send(MultiDeviceProvisionStep::SessionId(session_id))
+            .send(MultiDeviceProvisionStep::Code(code.to_digits()))
             .await
-            .map_err(|_| anyhow!("reporting stream dropped"))?;
+            .map_err(|_| anyhow!("the provisioning reporting stream was dropped"))?;
 
-        // wait for the existing (old) client to send us the welcome
-        let welcome_bytes = rx.next().await.context("relay connection closed")??;
+        let message = next_message(rx).await?;
+        let MdlMessage::PakeShareB(PakeShareB { msg_b, welcome }) = message else {
+            return Err(unexpected(&message));
+        };
 
         session_tx
             .send(MultiDeviceProvisionStep::Linking)
             .await
-            .map_err(|_| anyhow!("reporting stream dropped"))?;
+            .map_err(|_| anyhow!("the provisioning reporting stream was dropped"))?;
 
-        let welcome_msg = MlsMessageIn::tls_deserialize_exact(welcome_bytes.as_slice())
-            .context("failed to deserialize welcome")?;
-        let welcome = match welcome_msg.extract() {
-            MlsMessageBodyIn::Welcome(w) => w,
-            _ => bail!("expected a Welcome message"),
-        };
+        let isk = initiator
+            .finish(&msg_b)
+            .map_err(|error| LinkingError::Protocol(error.into()))?;
+        let kdf_ctx = MdlKdfContext {
+            ci: VLByteSlice(&ci),
+            sid: VLByteSlice(&sid),
+            msg_a: VLByteSlice(&msg_a),
+            msg_b: VLByteSlice(&msg_b),
+        }
+        .tls_serialize_detached()
+        .context("serialize the linking kdf context")?;
+        let psk = isk.derive_psk(&kdf_ctx);
 
-        let join_config = MlsGroupJoinConfig::builder()
-            .use_ratchet_tree_extension(true)
-            .build();
+        let mut pairing = PairingGroup::join(identity, &psk, &welcome)?;
+        drop(psk);
+        info!("joined the pairing group");
 
-        let group = StagedWelcome::new_from_welcome(&provider, &join_config, welcome, None)
-            .context("stage welcome")?
-            .into_group(&provider)
-            .context("join group")?;
-
-        let cipher = export_aead_key(group, provider)?;
-        info!("secure linking channel established, AEAD key exported");
-
-        // The old device creates our queue and sends us everything we need to
-        // bootstrap a working client.
-        let frame = rx.next().await.context("relay connection closed")??;
-        let package: ProvisioningPackage = LinkingMessage::open(frame.as_slice(), &cipher)?;
-        info!("received provisioning package");
+        let package =
+            receive_payload(&mut pairing, rx, LinkingPayloadType::ProvisioningPackage).await?;
+        let package: ProvisioningPackage =
+            PersistenceCodec::from_slice(&package).context("decode the provisioning package")?;
+        info!("received the provisioning package");
 
         // Join the self group:
         // 1. mint a new signing key to use for self-group commits
@@ -324,141 +413,165 @@ impl CoreUser {
         let core_user = Self::link_new_device(api_clients, db_path, package).await?;
         info!("bootstrapped linked client");
 
-        // Prepare a key-package for the old device to add us to its self-group.
         let key_package = core_user.generate_self_group_key_package().await?;
-
         // Store our own entry locally and hand a copy to the old device, which
         // publishes it on the add commit.
         let device = core_user
             .store_own_device_entry(Utc::now(), Some(&device_name))
             .await?;
-
-        tx.send(LinkingMessage::seal(
-            SelfGroupJoinRequest {
-                key_package,
-                device,
-            },
-            &cipher,
-        )?)
-        .await
-        .context("send self-group join request")?;
+        let request = PersistenceCodec::to_vec(&SelfGroupJoinRequest {
+            key_package,
+            device,
+        })
+        .context("encode the self-group join request")?;
+        let frame = pairing.send(LinkingPayloadType::SelfGroupJoinRequest, request)?;
+        send_frame(tx, frame, "send the self-group join request").await?;
         info!("sent self-group key package and device entry to old device");
 
         core_user.join_self_group_from_queue().await?;
         info!("joined self group");
+
+        let frame = pairing.send(LinkingPayloadType::LinkingComplete, Vec::new())?;
+        send_frame(tx, frame, "signal that linking is done").await?;
 
         core_user.outbound_service().notify_vc_onboarding();
 
         Ok(core_user)
     }
 
-    /// Establishes a session with a new device (with the given `session_id`). The `connected_tx` and `confirmation_rx` are
-    /// channels to report established connection and wait for the user's confirmation (with a device name).
+    /// Answers a new device's linking `code` on this (existing) device.
     pub async fn multi_device_link_client(
         &self,
-        session_id: LinkingSessionId,
+        code: String,
         connected_tx: oneshot::Sender<()>,
         confirmation_rx: oneshot::Receiver<String>,
     ) -> anyhow::Result<Result<(), MultiDeviceLinkClientError>> {
+        // The check digit is verified before the relay is contacted. A
+        // mistyped code would otherwise burn the session for good.
+        let code = match LinkingCode::parse(&code) {
+            Ok(code) => code,
+            Err(error) => {
+                warn!(%error, "rejected a malformed linking code");
+                return Ok(Err(MultiDeviceLinkClientError::InvalidCode));
+            }
+        };
+
         let client = self.api_client()?;
         let qs_user_id = self.inner.qs_user_id;
         let qs_user_signing_key = self.key_store().qs_user_signing_key.clone();
+        let rendezvous_id = RendezvousId::new(code.rendezvous_id().to_owned());
 
         let (tx, mut rx) = match client
-            .rs_multi_device_link_client(qs_user_id, &qs_user_signing_key, session_id.clone())
+            .rs_multi_device_link_client(qs_user_id, &qs_user_signing_key, rendezvous_id)
             .await
         {
-            Ok((tx, rx)) => (tx, rx),
+            Ok(streams) => streams,
             Err(RsRequestError::SessionNotFound) => {
                 return Ok(Err(MultiDeviceLinkClientError::SessionNotFound));
             }
-            Err(e) => return Err(e.into()),
+            Err(error) => return Err(error.into()),
         };
 
-        // Signal that we're connected to the relay
+        let session = self.link_session(&code, &tx, &mut rx, connected_tx, confirmation_rx);
+        match Box::pin(session).await {
+            Ok(()) => Ok(Ok(())),
+            Err(error) => {
+                let error = resolve_closed_session(error, &mut rx).await;
+                if let Some(code) = error.abort_code() {
+                    send_abort(tx, &mut rx, code).await;
+                }
+                Err(error.into())
+            }
+        }
+    }
+
+    async fn link_session(
+        &self,
+        code: &LinkingCode,
+        tx: &mpsc::Sender<RelayFrame>,
+        rx: &mut Streaming<RelayFrame>,
+        connected_tx: oneshot::Sender<()>,
+        confirmation_rx: oneshot::Receiver<String>,
+    ) -> Result<(), LinkingError> {
+        let message = next_message(rx).await?;
+        let MdlMessage::PakeShareA(PakeShareA {
+            version,
+            sid,
+            msg_a,
+        }) = message
+        else {
+            return Err(unexpected(&message));
+        };
+        check_version(version)?;
+
+        let domain = self.user_id().domain().to_string();
+        let ci = MdlContext::new(domain, code.rendezvous_id().to_owned())
+            .tls_serialize_detached()
+            .context("serialize the linking context")?;
+
+        let response = pake::respond(code.password(), &ci, &sid, &msg_a)
+            .map_err(|error| LinkingError::Protocol(error.into()))?;
+        let kdf_ctx = MdlKdfContext {
+            ci: VLByteSlice(&ci),
+            sid: VLByteSlice(&sid),
+            msg_a: VLByteSlice(&msg_a),
+            msg_b: VLByteSlice(&response.msg_b),
+        }
+        .tls_serialize_detached()
+        .context("serialize the linking kdf context")?;
+        let psk = response.isk.derive_psk(&kdf_ctx);
+
+        let key_package = pairing::validate_key_package(&response.key_package)?;
         let _ = connected_tx.send(());
 
-        let key_package_bytes = rx.next().await.context("relay connection closed")??;
+        let device_name = tokio::select! {
+            confirmation = confirmation_rx => {
+                confirmation.map_err(|_| LinkingError::UserRejected)?
+            }
+            message = next_message(rx) => {
+                return Err(match message {
+                    Ok(message) => unexpected(&message),
+                    Err(error) => error,
+                });
+            }
+        };
 
-        if !session_id.validate(key_package_bytes.as_slice()) {
-            bail!("key package does not match session ID");
-        }
+        let (mut pairing, welcome) = PairingGroup::create(&psk, key_package)?;
+        drop(psk);
 
-        let (provider, credential_with_key, signature_keys) =
-            make_provider_and_credential(b"existing-client")?;
+        let share = MdlMessage::PakeShareB(PakeShareB {
+            msg_b: response.msg_b,
+            welcome,
+        })
+        .into_frame()
+        .context("frame the pake share")?;
+        send_frame(tx, share, "send the pake share").await?;
+        info!("created the pairing group and sent the welcome");
 
-        let candidate_key_package =
-            match MlsMessageIn::tls_deserialize_exact(key_package_bytes.as_slice())
-                .context("deserialize key package")?
-                .extract()
-            {
-                MlsMessageBodyIn::KeyPackage(kp) => {
-                    kp.validate(provider.crypto(), ProtocolVersion::Mls10)?
-                }
-                _ => bail!("expected a KeyPackage in first relay frame"),
-            };
-
-        let group_config = MlsGroupCreateConfig::builder()
-            .use_ratchet_tree_extension(true)
-            .ciphersuite(CIPHERSUITE)
-            .build();
-
-        let mut group = MlsGroup::new(
-            &provider,
-            &signature_keys,
-            &group_config,
-            credential_with_key,
-        )
-        .context("create group")?;
-
-        let (_commit, welcome, _group_info) = group
-            .commit_builder()
-            .propose_adds([candidate_key_package])
-            .load_psks(provider.storage())?
-            .build(provider.rand(), provider.crypto(), &signature_keys, |_| {
-                true
-            })?
-            .stage_commit(&provider)?
-            .into_messages();
-        let welcome = welcome.context("no welcome after add")?;
-
-        group
-            .merge_pending_commit(&provider)
-            .context("merge pending commit")?;
-
-        let welcome_bytes = welcome.to_bytes().context("serialize welcome")?;
-        tx.send(welcome_bytes.into())
-            .await
-            .context("send welcome")?;
-
-        // Wait for the user to approve the link on this (existing) device.
-        let device_name = confirmation_rx
-            .await
-            .context("confirmation channel closed")?;
-
-        let cipher = export_aead_key(group, provider)?;
-        info!("secure linking channel established, AEAD key exported");
-
-        // Build the provisioning package (creates a fresh queue for the new
-        // device) and hand it over the secure channel.
+        // Build the provisioning package (this creates a fresh queue for the
+        // new device) and hand it over inside the pairing group.
         let package = self.build_provisioning_package(device_name).await?;
-        tx.send(LinkingMessage::seal(package, &cipher)?)
-            .await
-            .context("send provisioning package")?;
+        let package =
+            PersistenceCodec::to_vec(&package).context("encode the provisioning package")?;
+        let frame = pairing.send(LinkingPayloadType::ProvisioningPackage, package)?;
+        send_frame(tx, frame, "send the provisioning package").await?;
         info!("sent provisioning package to new device");
 
-        // Receive the new device's self-group KeyPackage and its metadata entry,
-        // and add it to the self group via the DS.
-        let frame = rx.next().await.context("relay connection closed")??;
-        let request: SelfGroupJoinRequest = LinkingMessage::open(frame.as_slice(), &cipher)?;
+        // Receive the new device's self-group KeyPackage and its metadata
+        // entry, and add it to the self group via the DS.
+        let request =
+            receive_payload(&mut pairing, rx, LinkingPayloadType::SelfGroupJoinRequest).await?;
+        let request: SelfGroupJoinRequest =
+            PersistenceCodec::from_slice(&request).context("decode the self-group join request")?;
         self.add_client_to_self_group(request).await?;
         info!("added new device to self group");
 
-        // Keep the RPC alive until the relay closes our stream, which happens
-        // once the new device has finished and disconnected.
-        while rx.next().await.is_some() {}
+        // The new device reports that it joined, and both sides tear the
+        // pairing group down.
+        receive_payload(&mut pairing, rx, LinkingPayloadType::LinkingComplete).await?;
+        info!("linking completed");
 
-        Ok(Ok(()))
+        Ok(())
     }
 
     /// Create a fresh QS queue for a new device and gather all the key material
@@ -896,89 +1009,5 @@ impl CoreUser {
     /// Whether a sibling device removed this device from the self group.
     pub async fn is_account_unlinked(&self) -> anyhow::Result<bool> {
         OwnClientInfo::is_account_unlinked(self.db().read().await?).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use aircommon::credentials::test_utils::create_test_credentials;
-    use aircommon::crypto::hpke::ClientIdDecryptionKey;
-    use aircommon::identifiers::QualifiedGroupId;
-    use uuid::Uuid;
-
-    use super::*;
-
-    /// Builds a [`ProvisioningPackage`] with the given synced-settings snapshot
-    /// and token seeds, and otherwise freshly generated key material.
-    fn sample_package(
-        synced_settings: SettingsUpdate,
-        token_seeds: Vec<TokenSeed>,
-    ) -> anyhow::Result<ProvisioningPackage> {
-        let user_id = UserId::random("example.com".parse()?);
-        let (_as_key, user_signing_key) = create_test_credentials(user_id.clone());
-        let self_group_id = GroupId::from(QualifiedGroupId::new(
-            Uuid::new_v4(),
-            "example.com".parse()?,
-        ));
-        Ok(ProvisioningPackage {
-            user_signing_key,
-            qs_user_id: QsUserId::random(),
-            qs_user_signing_key: QsUserSigningKey::generate()?,
-            friendship_token: FriendshipToken::random()?,
-            push_token_ear_key: PushTokenEarKey::random()?,
-            wai_ear_key: WelcomeAttributionInfoEarKey::random()?,
-            qs_client_id_encryption_key: ClientIdDecryptionKey::generate()?
-                .encryption_key()
-                .clone(),
-            qs_client_id: QsClientId::random(&mut rand::rng()),
-            qs_client_signing_key: QsClientSigningKey::generate()?,
-            qs_queue_decryption_key: RatchetDecryptionKey::generate()?,
-            qs_initial_ratchet_secret: RatchetSecret::random()?,
-            user_profile_key: UserProfileKey::random(&user_id)?,
-            self_group_id,
-            identity_link_wrapper_key: IdentityLinkWrapperKey::random()?,
-            synced_settings,
-            token_seeds,
-            device_name: "Work laptop".to_owned(),
-            groups: Vec::new(),
-            user_id,
-        })
-    }
-
-    /// A full package roundtrips through the linking channel with its synced
-    /// settings and token seeds intact.
-    #[test]
-    fn synced_state_roundtrips_through_linking_channel() -> anyhow::Result<()> {
-        let seeds = vec![TokenSeed {
-            operation_type: 1,
-            key_fingerprint: [0x11; 32],
-            seed: [0x22; 32],
-        }];
-        let package = sample_package(
-            SettingsUpdate {
-                send_read_receipts: Some(false),
-                linked_devices: None,
-            },
-            seeds.clone(),
-        )?;
-        let user_id = package.user_id.clone();
-
-        let key = MultiDeviceLinkingKey::random()?;
-        let frame = LinkingMessage::seal(package, &key)?;
-        let decoded: ProvisioningPackage = LinkingMessage::open(frame.as_slice(), &key)?;
-
-        assert_eq!(
-            decoded.synced_settings,
-            SettingsUpdate {
-                send_read_receipts: Some(false),
-                linked_devices: None,
-            }
-        );
-        assert_eq!(decoded.token_seeds, seeds);
-        assert_eq!(decoded.user_id, user_id);
-        // The confirming user's device name rides along in the same package.
-        assert_eq!(decoded.device_name, "Work laptop");
-
-        Ok(())
     }
 }

--- a/coreclient/src/clients/multi_device/pairing.rs
+++ b/coreclient/src/clients/multi_device/pairing.rs
@@ -1,0 +1,422 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The ephemeral MLS pairing group of the multi-device linking protocol.
+//!
+//! The group is created fresh per linking session, holds exactly two
+//! members and lives only in memory. Its authenticity comes from the
+//! external PSK that the CPace exchange produced, not from the basic
+//! credentials, which are minted per session and carry no account
+//! information.
+
+use aircommon::crypto::mdl::pake::MdlPsk;
+use airprotos::relay_service::mdl::{
+    GroupMessage, LinkingPayload, LinkingPayloadType, MDL_RESPONDER_LABEL, MdlMessage,
+};
+use airprotos::relay_service::v1::RelayFrame;
+use anyhow::{Context as _, anyhow, bail};
+use openmls::{
+    group::{MlsGroup, MlsGroupCreateConfig, MlsGroupJoinConfig, ProcessedWelcome, WelcomeError},
+    messages::group_info::GroupInfoError,
+    prelude::{
+        BasicCredential, CredentialWithKey, GroupSecretsError, KeyPackage, MlsMessageBodyIn,
+        MlsMessageIn, MlsMessageOut, PreSharedKeyProposal, ProcessedMessageContent, Proposal,
+        ProtocolVersion,
+    },
+    schedule::{ExternalPsk, PreSharedKeyId, Psk, errors::PskError},
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::OpenMlsProvider;
+use tls_codec::{Deserialize as _, DeserializeBytes as _, Serialize as _};
+use tracing::warn;
+
+use crate::clients::CIPHERSUITE;
+
+use super::LinkingError;
+
+/// Members the pairing group must have once it is up.
+const PAIRING_GROUP_SIZE: usize = 2;
+
+/// A per-session MLS identity: an in-memory provider, a fresh signature key
+/// pair and a basic credential naming the role.
+pub(super) struct PairingIdentity {
+    provider: OpenMlsRustCrypto,
+    signature_keys: SignatureKeyPair,
+    credential_with_key: CredentialWithKey,
+}
+
+impl PairingIdentity {
+    pub(super) fn new(identity: &str) -> anyhow::Result<Self> {
+        let provider = OpenMlsRustCrypto::default();
+        let signature_keys = SignatureKeyPair::new(CIPHERSUITE.signature_algorithm())
+            .context("generate the pairing signature key")?;
+        signature_keys
+            .store(provider.storage())
+            .map_err(|error| anyhow!("store the pairing signature key: {error}"))?;
+        let credential_with_key = CredentialWithKey {
+            credential: BasicCredential::new(identity.as_bytes().to_vec()).into(),
+            signature_key: signature_keys.to_public_vec().into(),
+        };
+        Ok(Self {
+            provider,
+            signature_keys,
+            credential_with_key,
+        })
+    }
+
+    /// A fresh KeyPackage for this identity, serialized as an `MLSMessage`.
+    ///
+    /// The private material stays in this identity's provider, so the same
+    /// value must later process the Welcome.
+    pub(super) fn key_package(&self) -> anyhow::Result<Vec<u8>> {
+        let bundle = KeyPackage::builder()
+            .build(
+                CIPHERSUITE,
+                &self.provider,
+                &self.signature_keys,
+                self.credential_with_key.clone(),
+            )
+            .context("build the pairing key package")?;
+        MlsMessageOut::from(bundle)
+            .to_bytes()
+            .context("serialize the pairing key package")
+    }
+}
+
+/// A live pairing group.
+pub(super) struct PairingGroup {
+    identity: PairingIdentity,
+    group: MlsGroup,
+}
+
+impl PairingGroup {
+    /// Creates the group on the existing device and adds the new device.
+    ///
+    /// The single commit carries the `Add` and the `PreSharedKey` proposal,
+    /// so the Welcome the new device receives already has the PAKE-derived
+    /// secret in its key schedule.
+    pub(super) fn create(
+        psk: &MdlPsk,
+        key_package: KeyPackage,
+    ) -> Result<(Self, Vec<u8>), LinkingError> {
+        let identity = PairingIdentity::new(MDL_RESPONDER_LABEL).map_err(LinkingError::Protocol)?;
+        let (group, welcome) =
+            Self::create_inner(&identity, psk, key_package).map_err(LinkingError::Protocol)?;
+        Ok((Self { identity, group }, welcome))
+    }
+
+    fn create_inner(
+        identity: &PairingIdentity,
+        psk: &MdlPsk,
+        key_package: KeyPackage,
+    ) -> anyhow::Result<(MlsGroup, Vec<u8>)> {
+        let provider = &identity.provider;
+        let psk_id = PreSharedKeyId::new(
+            CIPHERSUITE,
+            provider.rand(),
+            Psk::External(ExternalPsk::new(psk.id().to_vec())),
+        )
+        .context("build the pairing psk id")?;
+        // The copy the provider keeps lives exactly as long as this
+        // per-session in-memory provider.
+        psk_id
+            .store(provider, psk.secret())
+            .context("store the pairing psk")?;
+
+        let group_config = MlsGroupCreateConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .ciphersuite(CIPHERSUITE)
+            .build();
+        let mut group = MlsGroup::new(
+            provider,
+            &identity.signature_keys,
+            &group_config,
+            identity.credential_with_key.clone(),
+        )
+        .context("create the pairing group")?;
+
+        let (_commit, welcome, _group_info) = group
+            .commit_builder()
+            .propose_adds([key_package])
+            .add_proposal(Proposal::PreSharedKey(Box::new(PreSharedKeyProposal::new(
+                psk_id,
+            ))))
+            .load_psks(provider.storage())?
+            .build(
+                provider.rand(),
+                provider.crypto(),
+                &identity.signature_keys,
+                |_| true,
+            )?
+            .stage_commit(provider)?
+            .into_messages();
+        group
+            .merge_pending_commit(provider)
+            .context("merge the pairing commit")?;
+
+        let welcome = welcome
+            .context("the pairing commit produced no welcome")?
+            .to_bytes()
+            .context("serialize the pairing welcome")?;
+        Ok((group, welcome))
+    }
+
+    /// Joins the group on the new device.
+    ///
+    /// This is the session's single authentication check: the key schedule
+    /// includes the PAKE-derived PSK, so a wrong password shows up as a
+    /// Welcome decryption failure and never as a mismatching PSK ID.
+    pub(super) fn join(
+        identity: PairingIdentity,
+        psk: &MdlPsk,
+        welcome: &[u8],
+    ) -> Result<Self, LinkingError> {
+        let provider = &identity.provider;
+
+        let welcome = MlsMessageIn::tls_deserialize_exact(welcome)
+            .context("deserialize the pairing welcome")
+            .map_err(LinkingError::Protocol)?;
+        let MlsMessageBodyIn::Welcome(welcome) = welcome.extract() else {
+            return Err(LinkingError::Protocol(anyhow!(
+                "expected a welcome in pake_share_b"
+            )));
+        };
+
+        // OpenMLS resolves the referenced PSKs while it decrypts the group
+        // secrets, so the secret has to be in storage first. Only the PSK ID
+        // keys that storage, which is why the nonce here does not matter.
+        // The copy the provider keeps lives exactly as long as this
+        // per-session in-memory provider.
+        PreSharedKeyId::external(psk.id().to_vec(), Vec::new())
+            .store(provider, psk.secret())
+            .context("store the pairing psk")
+            .map_err(LinkingError::Protocol)?;
+
+        let join_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+        let processed = ProcessedWelcome::new_from_welcome(provider, &join_config, welcome)
+            .map_err(classify_welcome_error)?;
+
+        // A welcome without our PSK would be an unauthenticated group, so it
+        // has to be rejected even though it decrypted.
+        let [psk_id] = processed.psks() else {
+            return Err(LinkingError::validation(
+                "the pairing welcome does not carry exactly one psk",
+            ));
+        };
+        let Psk::External(external) = psk_id.psk() else {
+            return Err(LinkingError::validation(
+                "the pairing welcome's psk is not external",
+            ));
+        };
+        if external.psk_id() != psk.id() {
+            return Err(LinkingError::validation(
+                "the pairing welcome references a different psk",
+            ));
+        }
+
+        let group = processed
+            .into_staged_welcome(provider, None)
+            .context("stage the pairing welcome")
+            .map_err(LinkingError::Protocol)?
+            .into_group(provider)
+            .context("join the pairing group")
+            .map_err(LinkingError::Protocol)?;
+
+        if group.members().count() != PAIRING_GROUP_SIZE {
+            return Err(LinkingError::validation(
+                "the pairing group does not have exactly two members",
+            ));
+        }
+        if group.ciphersuite() != CIPHERSUITE {
+            return Err(LinkingError::validation(
+                "the pairing group uses an unexpected ciphersuite",
+            ));
+        }
+
+        Ok(Self { identity, group })
+    }
+
+    /// Wraps `payload` into an application message and frames it.
+    pub(super) fn send(
+        &mut self,
+        payload_type: LinkingPayloadType,
+        payload: Vec<u8>,
+    ) -> anyhow::Result<RelayFrame> {
+        let plaintext = LinkingPayload {
+            payload_type,
+            payload,
+        }
+        .tls_serialize_detached()
+        .context("serialize the linking payload")?;
+
+        let provider = &self.identity.provider;
+        let unconfirmed = self
+            .group
+            .create_unconfirmed_message(provider, &self.identity.signature_keys, &plaintext)
+            .context("encrypt the linking payload")?;
+        // There is no delivery service behind the pairing group, so the
+        // message is confirmed as soon as it is built.
+        self.group
+            .confirm_application_message(
+                provider.storage(),
+                unconfirmed.epoch,
+                unconfirmed.generation,
+            )
+            .context("confirm the linking payload")?;
+
+        let mls_message = unconfirmed
+            .message
+            .to_bytes()
+            .context("serialize the linking payload message")?;
+        MdlMessage::GroupMessage(GroupMessage { mls_message })
+            .into_frame()
+            .context("frame the linking payload")
+    }
+
+    /// Decrypts an application message of the pairing group.
+    pub(super) fn receive(&mut self, message: &GroupMessage) -> anyhow::Result<LinkingPayload> {
+        let message = MlsMessageIn::tls_deserialize_exact(message.mls_message.as_slice())
+            .context("deserialize the pairing group message")?;
+        let protocol_message = message
+            .try_into_protocol_message()
+            .context("expected a pairing group protocol message")?;
+        let processed = self
+            .group
+            .process_message(&self.identity.provider, protocol_message)
+            .context("process the pairing group message")?;
+        let ProcessedMessageContent::ApplicationMessage(application) = processed.into_content()
+        else {
+            bail!("expected an application message in the pairing group");
+        };
+        LinkingPayload::tls_deserialize_exact_bytes(&application.into_bytes())
+            .context("deserialize the linking payload")
+    }
+}
+
+/// Checks the new device's KeyPackage before anything is built on it.
+pub(super) fn validate_key_package(bytes: &[u8]) -> Result<KeyPackage, LinkingError> {
+    let message = MlsMessageIn::tls_deserialize_exact(bytes)
+        .context("deserialize the pairing key package")
+        .map_err(LinkingError::Protocol)?;
+    let MlsMessageBodyIn::KeyPackage(key_package) = message.extract() else {
+        return Err(LinkingError::Protocol(anyhow!(
+            "expected a key package in pake_share_a"
+        )));
+    };
+    // Verifies the MLS signature, the protocol version and the lifetime.
+    let key_package = key_package
+        .validate(
+            &openmls_rust_crypto::RustCrypto::default(),
+            ProtocolVersion::Mls10,
+        )
+        .map_err(|error| {
+            LinkingError::validation(format!("the pairing key package is invalid: {error}"))
+        })?;
+    if key_package.ciphersuite() != CIPHERSUITE {
+        return Err(LinkingError::validation(
+            "the pairing key package uses an unexpected ciphersuite",
+        ));
+    }
+    Ok(key_package)
+}
+
+/// Tells apart the ways a pairing Welcome can fail.
+///
+/// A wrong linking code shows up as a decryption or key-schedule failure,
+/// because the group's key schedule mixes in the PAKE-derived secret. A
+/// Welcome that names PSKs the two devices never agreed on is a validation
+/// failure. Anything else is the peer or the relay not following the
+/// protocol.
+fn classify_welcome_error<StorageError: std::fmt::Display>(
+    error: WelcomeError<StorageError>,
+) -> LinkingError {
+    match error {
+        WelcomeError::GroupSecrets(GroupSecretsError::DecryptionFailed)
+        | WelcomeError::GroupInfo(GroupInfoError::DecryptionFailed)
+        | WelcomeError::JoinerSecretNotFound
+        | WelcomeError::UnableToDecrypt
+        | WelcomeError::KeySchedule(_) => {
+            warn!("the pairing welcome did not open");
+            LinkingError::AuthenticationFailed
+        }
+        // The PSK set is public, so a mismatch here is the peer naming keys
+        // we never agreed on rather than evidence about the code.
+        WelcomeError::Psk(
+            error @ (PskError::KeyNotFound
+            | PskError::TooManyKeys
+            | PskError::TypeMismatch { .. }
+            | PskError::UsageMismatch { .. }
+            | PskError::UsageConflict { .. }
+            | PskError::UsageDuplicate { .. }
+            | PskError::NonceLengthMismatch { .. }),
+        ) => LinkingError::validation(format!("the pairing welcome's psks are wrong: {error}")),
+        // Anything left over is malformed input, an unsupported group, or our
+        // own storage failing, none of which says anything about the code.
+        other => LinkingError::Protocol(anyhow!("the pairing welcome failed: {other}")),
+    }
+}
+
+/// A pairing group whose commit carries the `Add` but no `PreSharedKey`
+/// proposal, which is what an unauthenticated relay could hand a joiner.
+#[cfg(test)]
+pub(super) fn welcome_without_psk(key_package: KeyPackage) -> anyhow::Result<Vec<u8>> {
+    welcome_for_psk(key_package, None)
+}
+
+/// A pairing group whose commit names a PSK the joiner never agreed on.
+#[cfg(test)]
+pub(super) fn welcome_with_a_foreign_psk(key_package: KeyPackage) -> anyhow::Result<Vec<u8>> {
+    let mut psk_id = [0u8; 32];
+    rand::TryRng::try_fill_bytes(&mut rand::rng(), &mut psk_id);
+    welcome_for_psk(key_package, Some(psk_id))
+}
+
+/// Builds a pairing group and its Welcome, optionally referencing
+/// `psk_id` with a secret only the creator knows.
+#[cfg(test)]
+fn welcome_for_psk(key_package: KeyPackage, psk_id: Option<[u8; 32]>) -> anyhow::Result<Vec<u8>> {
+    let identity = PairingIdentity::new(MDL_RESPONDER_LABEL)?;
+    let provider = &identity.provider;
+    let group_config = MlsGroupCreateConfig::builder()
+        .use_ratchet_tree_extension(true)
+        .ciphersuite(CIPHERSUITE)
+        .build();
+    let mut group = MlsGroup::new(
+        provider,
+        &identity.signature_keys,
+        &group_config,
+        identity.credential_with_key.clone(),
+    )?;
+
+    let mut builder = group.commit_builder().propose_adds([key_package]);
+    if let Some(psk_id) = psk_id {
+        let psk_id = PreSharedKeyId::new(
+            CIPHERSUITE,
+            provider.rand(),
+            Psk::External(ExternalPsk::new(psk_id.to_vec())),
+        )?;
+        psk_id.store(provider, &[0x5a; 32])?;
+        builder = builder.add_proposal(Proposal::PreSharedKey(Box::new(
+            PreSharedKeyProposal::new(psk_id),
+        )));
+    }
+
+    let (_commit, welcome, _group_info) = builder
+        .load_psks(provider.storage())?
+        .build(
+            provider.rand(),
+            provider.crypto(),
+            &identity.signature_keys,
+            |_| true,
+        )?
+        .stage_commit(provider)?
+        .into_messages();
+    group.merge_pending_commit(provider)?;
+    Ok(welcome
+        .context("the pairing commit produced no welcome")?
+        .to_bytes()?)
+}

--- a/coreclient/src/clients/multi_device/payloads.rs
+++ b/coreclient/src/clients/multi_device/payloads.rs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! What the two devices hand each other inside the pairing group.
+//!
+//! These travel as CBOR blobs inside a `LinkingPayload`, whose type
+//! registry lives with the wire types in `airprotos`.
+
+use aircommon::credentials::keys::UserSigningKey;
+use aircommon::crypto::RatchetDecryptionKey;
+use aircommon::crypto::aead::keys::{
+    GroupStateEarKey, IdentityLinkWrapperKey, PushTokenEarKey, WelcomeAttributionInfoEarKey,
+};
+use aircommon::crypto::hpke::ClientIdEncryptionKey;
+use aircommon::crypto::indexed_aead::keys::UserProfileKey;
+use aircommon::crypto::kdf::keys::RatchetSecret;
+use aircommon::crypto::signatures::keys::{QsClientSigningKey, QsUserSigningKey};
+use aircommon::identifiers::{QsClientId, QsUserId, UserId};
+use aircommon::messages::FriendshipToken;
+use airprotos::client::self_group::{LinkedDevice, SettingsUpdate, TokenSeed};
+use apqmls::messages::ApqKeyPackage;
+use openmls::group::GroupId;
+
+/// Everything the existing device hands to the new device so the new device
+/// can bootstrap a working [`CoreUser`] and join the user's self group.
+///
+/// [`CoreUser`]: crate::clients::CoreUser
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct ProvisioningPackage {
+    // Identity + AS user credential (shared across devices for the MVP).
+    pub(crate) user_id: UserId,
+    pub(crate) user_signing_key: UserSigningKey,
+    // User-level QS key material (shared by all of the user's devices).
+    pub(crate) qs_user_id: QsUserId,
+    pub(crate) qs_user_signing_key: QsUserSigningKey,
+    pub(crate) friendship_token: FriendshipToken,
+    pub(crate) push_token_ear_key: PushTokenEarKey,
+    pub(crate) wai_ear_key: WelcomeAttributionInfoEarKey,
+    pub(crate) qs_client_id_encryption_key: ClientIdEncryptionKey,
+    // Freshly created queue for the new device (created by the old device).
+    pub(crate) qs_client_id: QsClientId,
+    pub(crate) qs_client_signing_key: QsClientSigningKey,
+    pub(crate) qs_queue_decryption_key: RatchetDecryptionKey,
+    pub(crate) qs_initial_ratchet_secret: RatchetSecret,
+    // User profile.
+    pub(crate) user_profile_key: UserProfileKey,
+    // Self-group metadata not carried by the Welcome.
+    pub(crate) self_group_id: GroupId,
+    pub(crate) identity_link_wrapper_key: IdentityLinkWrapperKey,
+    // Synced user settings snapshot so the new device starts with the
+    // provisioner's values.
+    pub(crate) synced_settings: SettingsUpdate,
+    // The agreed Privacy Pass token seeds, so the new device derives the same
+    // token requests as its sibling instead of running an agreement round for a
+    // key whose allowance epoch the sibling has already locked.
+    pub(crate) token_seeds: Vec<TokenSeed>,
+    // The name the confirming user gave this device. Empty means "no choice
+    // made", and the new device falls back to its own platform label.
+    pub(crate) device_name: String,
+    // The higher-level groups the virtual client is already a member of, which
+    // the new emulator client onboards itself into.
+    pub(crate) groups: Vec<HigherLevelGroup>,
+}
+
+/// What the new device sends back inside the pairing group.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct SelfGroupJoinRequest {
+    pub(crate) key_package: ApqKeyPackage,
+    pub(crate) device: LinkedDevice,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct HigherLevelGroup {
+    pub(crate) group_id: GroupId,
+    pub(crate) pq_group_id: Option<GroupId>,
+    pub(crate) group_state_ear_key: GroupStateEarKey,
+    pub(crate) identity_link_wrapper_key: IdentityLinkWrapperKey,
+    pub(crate) vc_leaf_index: u32,
+    /// Set if the group backs a connection chat rather than a group chat.
+    pub(crate) connection: Option<ConnectionContact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ConnectionContact {
+    pub(crate) user_id: UserId,
+    pub(crate) wai_ear_key: WelcomeAttributionInfoEarKey,
+    pub(crate) friendship_token: FriendshipToken,
+}

--- a/coreclient/src/clients/multi_device/tests.rs
+++ b/coreclient/src/clients/multi_device/tests.rs
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use aircommon::credentials::test_utils::create_test_credentials;
+use aircommon::crypto::aead::keys::{
+    IdentityLinkWrapperKey, PushTokenEarKey, WelcomeAttributionInfoEarKey,
+};
+use aircommon::crypto::hpke::ClientIdDecryptionKey;
+use aircommon::crypto::mdl::pake::MdlPsk;
+use aircommon::identifiers::{QsClientId, QsUserId, QualifiedGroupId, UserId};
+use aircommon::messages::FriendshipToken;
+use airprotos::client::self_group::TokenSeed;
+use airprotos::relay_service::mdl::MDL_INITIATOR_LABEL;
+use openmls::group::GroupId;
+use uuid::Uuid;
+
+use super::*;
+
+const DOMAIN: &str = "example.com";
+
+/// One side's view of a finished CPace exchange plus everything the pairing
+/// group needs from it.
+struct Handshake {
+    new_device: PairingIdentity,
+    key_package: Vec<u8>,
+    new_psk: MdlPsk,
+    existing_psk: MdlPsk,
+}
+
+/// Runs the exchange the way the two flows do, with real contexts. The two
+/// codes are the same in the happy case and differ when a wrong code is
+/// under test.
+fn handshake(new_code: &LinkingCode, existing_code: &LinkingCode) -> Handshake {
+    let ci_new = MdlContext::new(DOMAIN.to_owned(), new_code.rendezvous_id().to_owned())
+        .tls_serialize_detached()
+        .unwrap();
+    let ci_existing = MdlContext::new(DOMAIN.to_owned(), existing_code.rendezvous_id().to_owned())
+        .tls_serialize_detached()
+        .unwrap();
+    let sid = [7u8; SID_LEN];
+
+    let new_device = PairingIdentity::new(MDL_INITIATOR_LABEL).unwrap();
+    let key_package = new_device.key_package().unwrap();
+    let initiator = MdlInitiator::start(new_code.password(), &ci_new, &sid, &key_package);
+    let msg_a = initiator.msg_a().to_vec();
+
+    let response = pake::respond(existing_code.password(), &ci_existing, &sid, &msg_a).unwrap();
+    assert_eq!(
+        response.key_package, key_package,
+        "the key package must travel as the cpace associated data"
+    );
+
+    let kdf_ctx = |ci: &[u8], msg_b: &[u8]| {
+        MdlKdfContext {
+            ci: VLByteSlice(ci),
+            sid: VLByteSlice(&sid),
+            msg_a: VLByteSlice(&msg_a),
+            msg_b: VLByteSlice(msg_b),
+        }
+        .tls_serialize_detached()
+        .unwrap()
+    };
+
+    let existing_psk = response
+        .isk
+        .derive_psk(&kdf_ctx(&ci_existing, &response.msg_b));
+    let new_psk = initiator
+        .finish(&response.msg_b)
+        .unwrap()
+        .derive_psk(&kdf_ctx(&ci_new, &response.msg_b));
+
+    Handshake {
+        new_device,
+        key_package,
+        new_psk,
+        existing_psk,
+    }
+}
+
+/// Builds a [`ProvisioningPackage`] with the given synced-settings snapshot
+/// and token seeds, and otherwise freshly generated key material.
+fn sample_package(
+    synced_settings: SettingsUpdate,
+    token_seeds: Vec<TokenSeed>,
+) -> anyhow::Result<ProvisioningPackage> {
+    let user_id = UserId::random(DOMAIN.parse()?);
+    let (_as_key, user_signing_key) = create_test_credentials(user_id.clone());
+    let self_group_id = GroupId::from(QualifiedGroupId::new(Uuid::new_v4(), DOMAIN.parse()?));
+    Ok(ProvisioningPackage {
+        user_signing_key,
+        qs_user_id: QsUserId::random(),
+        qs_user_signing_key: aircommon::crypto::signatures::keys::QsUserSigningKey::generate()?,
+        friendship_token: FriendshipToken::random()?,
+        push_token_ear_key: PushTokenEarKey::random()?,
+        wai_ear_key: WelcomeAttributionInfoEarKey::random()?,
+        qs_client_id_encryption_key: ClientIdDecryptionKey::generate()?.encryption_key().clone(),
+        qs_client_id: QsClientId::random(&mut rand::rng()),
+        qs_client_signing_key: QsClientSigningKey::generate()?,
+        qs_queue_decryption_key: RatchetDecryptionKey::generate()?,
+        qs_initial_ratchet_secret: RatchetSecret::random()?,
+        user_profile_key: UserProfileKey::random(&user_id)?,
+        self_group_id,
+        identity_link_wrapper_key: IdentityLinkWrapperKey::random()?,
+        synced_settings,
+        token_seeds,
+        device_name: "Work laptop".to_owned(),
+        groups: Vec::new(),
+        user_id,
+    })
+}
+
+/// Unwraps a frame the pairing group produced back into its group message.
+fn group_message(frame: RelayFrame) -> airprotos::relay_service::mdl::GroupMessage {
+    match MdlMessage::from_frame(&frame).unwrap() {
+        MdlMessage::GroupMessage(message) => message,
+        other => panic!("expected a group message, got {}", other.kind()),
+    }
+}
+
+#[test]
+fn the_context_wiring_produces_one_psk() -> anyhow::Result<()> {
+    let code = LinkingCode::generate("417")?;
+    let handshake = handshake(&code, &code);
+    assert_eq!(handshake.new_psk.id(), handshake.existing_psk.id());
+    assert_eq!(handshake.new_psk.secret(), handshake.existing_psk.secret());
+    Ok(())
+}
+
+#[test]
+fn a_full_session_carries_payloads_both_ways() -> anyhow::Result<()> {
+    let code = LinkingCode::generate("417")?;
+    let handshake = handshake(&code, &code);
+
+    let key_package = pairing::validate_key_package(&handshake.key_package)?;
+    let (mut existing, welcome) = PairingGroup::create(&handshake.existing_psk, key_package)?;
+    let mut new = PairingGroup::join(handshake.new_device, &handshake.new_psk, &welcome)?;
+
+    let seeds = vec![TokenSeed {
+        operation_type: 1,
+        key_fingerprint: [0x11; 32],
+        seed: [0x22; 32],
+    }];
+    let package = sample_package(
+        SettingsUpdate {
+            send_read_receipts: Some(false),
+            linked_devices: None,
+        },
+        seeds.clone(),
+    )?;
+    let user_id = package.user_id.clone();
+
+    let frame = existing.send(
+        LinkingPayloadType::ProvisioningPackage,
+        PersistenceCodec::to_vec(&package)?,
+    )?;
+    let payload = new.receive(&group_message(frame))?;
+    assert_eq!(
+        payload.payload_type,
+        LinkingPayloadType::ProvisioningPackage
+    );
+    let decoded: ProvisioningPackage = PersistenceCodec::from_slice(&payload.payload)?;
+    assert_eq!(decoded.user_id, user_id);
+    assert_eq!(decoded.token_seeds, seeds);
+    assert_eq!(decoded.device_name, "Work laptop");
+    assert_eq!(
+        decoded.synced_settings,
+        SettingsUpdate {
+            send_read_receipts: Some(false),
+            linked_devices: None,
+        }
+    );
+
+    let frame = new.send(LinkingPayloadType::LinkingComplete, Vec::new())?;
+    let payload = existing.receive(&group_message(frame))?;
+    assert_eq!(payload.payload_type, LinkingPayloadType::LinkingComplete);
+    assert!(payload.payload.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn a_wrong_code_fails_the_welcome() -> anyhow::Result<()> {
+    let new_code = LinkingCode::generate("417")?;
+    let mistyped = LinkingCode::generate("417")?;
+    let handshake = handshake(&new_code, &mistyped);
+
+    // The PSK ID comes from public values, so it matches even here. Only the
+    // secret differs, which is exactly why the welcome is the check.
+    assert_eq!(handshake.new_psk.id(), handshake.existing_psk.id());
+    assert_ne!(handshake.new_psk.secret(), handshake.existing_psk.secret());
+
+    let key_package = pairing::validate_key_package(&handshake.key_package)?;
+    let (_existing, welcome) = PairingGroup::create(&handshake.existing_psk, key_package)?;
+    let Err(error) = PairingGroup::join(handshake.new_device, &handshake.new_psk, &welcome) else {
+        panic!("a wrong code must not open the welcome");
+    };
+    assert!(
+        matches!(error, LinkingError::AuthenticationFailed),
+        "expected an authentication failure, got {error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_welcome_without_the_psk_is_rejected() -> anyhow::Result<()> {
+    let code = LinkingCode::generate("417")?;
+    let handshake = handshake(&code, &code);
+
+    let key_package = pairing::validate_key_package(&handshake.key_package)?;
+    let welcome = pairing::welcome_without_psk(key_package)?;
+
+    let Err(error) = PairingGroup::join(handshake.new_device, &handshake.new_psk, &welcome) else {
+        panic!("a welcome without the psk must be rejected");
+    };
+    assert!(
+        matches!(error, LinkingError::Validation(_)),
+        "expected a validation failure, got {error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_welcome_for_another_psk_is_a_validation_failure() -> anyhow::Result<()> {
+    let code = LinkingCode::generate("417")?;
+    let handshake = handshake(&code, &code);
+
+    let key_package = pairing::validate_key_package(&handshake.key_package)?;
+    let welcome = pairing::welcome_with_a_foreign_psk(key_package)?;
+
+    let Err(error) = PairingGroup::join(handshake.new_device, &handshake.new_psk, &welcome) else {
+        panic!("a welcome for another psk must be rejected");
+    };
+    assert!(
+        matches!(error, LinkingError::Validation(_)),
+        "expected a validation failure, got {error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn another_version_is_aborted_as_such() {
+    check_version(MDL_PROTOCOL_VERSION).unwrap();
+    let error = check_version(MDL_PROTOCOL_VERSION + 1).unwrap_err();
+    assert!(matches!(error, LinkingError::UnsupportedVersion(v) if v == MDL_PROTOCOL_VERSION + 1));
+    assert_eq!(error.abort_code(), Some(AbortCode::UnsupportedVersion));
+}
+
+#[test]
+fn garbage_in_place_of_a_key_package_is_rejected() -> anyhow::Result<()> {
+    let error =
+        pairing::validate_key_package(b"not a key package").expect_err("garbage must not validate");
+    assert!(matches!(error, LinkingError::Protocol(_)));
+    Ok(())
+}

--- a/protos/api/relay_service/v1/relay_service.proto
+++ b/protos/api/relay_service/v1/relay_service.proto
@@ -21,7 +21,7 @@ message QsUserId {
   common.v1.Uuid value = 1;
 }
 
-message LinkingSessionId {
+message RendezvousId {
   string value = 1;
 }
 
@@ -37,5 +37,5 @@ message LinkClientRequest {
 message LinkClientRequestPayload {
   common.v1.ClientMetadata client_metadata = 1;
   QsUserId sender = 2;
-  LinkingSessionId session_id = 3;
+  RendezvousId rendezvous_id = 3;
 }

--- a/protos/src/relay_service/mdl.rs
+++ b/protos/src/relay_service/mdl.rs
@@ -64,6 +64,18 @@ impl MdlMessage {
     pub fn from_frame(frame: &RelayFrame) -> Result<Self, tls_codec::Error> {
         Self::tls_deserialize_exact_bytes(frame.as_slice())
     }
+
+    /// The message type's name, for logs that must not print payloads.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::ProvisionRequest(_) => "provision_request",
+            Self::SessionAssigned(_) => "session_assigned",
+            Self::PakeShareA(_) => "pake_share_a",
+            Self::PakeShareB(_) => "pake_share_b",
+            Self::GroupMessage(_) => "group_message",
+            Self::Abort(_) => "abort",
+        }
+    }
 }
 
 /// Opens a rendezvous session. Carries no PAKE share: the CPace generator

--- a/protos/src/relay_service/mdl.rs
+++ b/protos/src/relay_service/mdl.rs
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2026 Phoenix R&D GmbH <hello@phnx.im>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Wire types of the multi-device linking protocol.
+//!
+//! Every `RelayFrame` payload of a linking session carries exactly one
+//! TLS-serialized [`MdlMessage`]. The relay parses only
+//! [`ProvisionRequest`] and produces [`SessionAssigned`]. Every other
+//! message is opaque to it.
+
+use tls_codec::{
+    DeserializeBytes, Serialize, TlsDeserializeBytes, TlsSerialize, TlsSize, VLByteSlice,
+};
+
+use super::v1::RelayFrame;
+
+/// The protocol version this implementation speaks.
+pub const MDL_PROTOCOL_VERSION: u16 = 1;
+
+/// CPace ciphersuite bound into [`MdlContext`]: CPACE-RISTR255-SHA512.
+pub const MDL_PAKE_CIPHER_SUITE: u16 = 1;
+
+/// MLS ciphersuite of the pairing group bound into [`MdlContext`]:
+/// `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519`.
+pub const MDL_MLS_CIPHER_SUITE: u16 = 0x0001;
+
+/// Domain separator of the protocol, bound into [`MdlContext`].
+pub const MDL_PROTOCOL_LABEL: &str = "air multi-device linking";
+
+/// The new device's role label, also its basic-credential identity in the
+/// pairing group.
+pub const MDL_INITIATOR_LABEL: &str = "new-device";
+
+/// The existing device's role label, also its basic-credential identity in
+/// the pairing group.
+pub const MDL_RESPONDER_LABEL: &str = "existing-device";
+
+/// One message of a linking session.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+#[repr(u8)]
+pub enum MdlMessage {
+    #[tls_codec(discriminant = 1)]
+    ProvisionRequest(ProvisionRequest),
+    #[tls_codec(discriminant = 2)]
+    SessionAssigned(SessionAssigned),
+    #[tls_codec(discriminant = 3)]
+    PakeShareA(PakeShareA),
+    #[tls_codec(discriminant = 4)]
+    PakeShareB(PakeShareB),
+    #[tls_codec(discriminant = 5)]
+    GroupMessage(GroupMessage),
+    #[tls_codec(discriminant = 6)]
+    Abort(Abort),
+}
+
+impl MdlMessage {
+    /// Wraps this message into a relay frame.
+    pub fn into_frame(self) -> Result<RelayFrame, tls_codec::Error> {
+        Ok(self.tls_serialize_detached()?.into())
+    }
+
+    /// Parses a relay frame's payload.
+    pub fn from_frame(frame: &RelayFrame) -> Result<Self, tls_codec::Error> {
+        Self::tls_deserialize_exact_bytes(frame.as_slice())
+    }
+}
+
+/// Opens a rendezvous session. Carries no PAKE share: the CPace generator
+/// depends on the rendezvous ID, which the new device does not know yet.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct ProvisionRequest {
+    pub version: u16,
+}
+
+/// The relay's answer to a [`ProvisionRequest`].
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct SessionAssigned {
+    pub rendezvous_id: String,
+}
+
+/// The initiator's CPace message, which carries the new device's KeyPackage
+/// as its associated data.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct PakeShareA {
+    /// The version the new device speaks. The relay checked it already, but
+    /// the existing device never sees that exchange, and without the field a
+    /// mismatch would surface as a wrong password.
+    pub version: u16,
+    pub sid: Vec<u8>,
+    pub msg_a: Vec<u8>,
+}
+
+/// The responder's CPace message together with the pairing group's Welcome.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct PakeShareB {
+    pub msg_b: Vec<u8>,
+    pub welcome: Vec<u8>,
+}
+
+/// An MLS message of the pairing group.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct GroupMessage {
+    pub mls_message: Vec<u8>,
+}
+
+/// Ends the session. Terminal for both peers.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct Abort {
+    pub code: AbortCode,
+}
+
+/// Why a linking session ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+#[repr(u8)]
+pub enum AbortCode {
+    /// Welcome decryption or key-schedule failure, meaning a wrong password.
+    AuthenticationFailed = 1,
+    /// Unexpected or malformed message, or an MLS processing error.
+    ProtocolError = 2,
+    /// A KeyPackage, Welcome or group check failed.
+    ValidationFailed = 3,
+    /// The user declined the confirmation dialog.
+    UserRejected = 4,
+    Timeout = 5,
+    /// The peer speaks a protocol version this device does not.
+    UnsupportedVersion = 6,
+}
+
+/// The CPace channel identifier, binding the exchange to the protocol
+/// version, both ciphersuites, both roles, the server and the session.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsSize)]
+pub struct MdlContext {
+    pub protocol_label: String,
+    pub protocol_version: u16,
+    pub pake_cipher_suite: u16,
+    pub mls_cipher_suite: u16,
+    pub initiator_label: String,
+    pub responder_label: String,
+    pub server_domain: String,
+    pub rendezvous_id: String,
+}
+
+impl MdlContext {
+    /// The context for a session on `server_domain` under `rendezvous_id`,
+    /// with every other field fixed by this implementation.
+    ///
+    /// `server_domain` must be the lowercase FQDN of the relay's server.
+    pub fn new(server_domain: String, rendezvous_id: String) -> Self {
+        Self {
+            protocol_label: MDL_PROTOCOL_LABEL.to_owned(),
+            protocol_version: MDL_PROTOCOL_VERSION,
+            pake_cipher_suite: MDL_PAKE_CIPHER_SUITE,
+            mls_cipher_suite: MDL_MLS_CIPHER_SUITE,
+            initiator_label: MDL_INITIATOR_LABEL.to_owned(),
+            responder_label: MDL_RESPONDER_LABEL.to_owned(),
+            server_domain,
+            rendezvous_id,
+        }
+    }
+}
+
+/// The transcript the pairing group's PSK is derived over.
+///
+/// The CPace messages enter as opaque byte strings, so the transcript is
+/// bound without re-deriving CPace's length-value encoding.
+#[derive(Debug, TlsSerialize, TlsSize)]
+pub struct MdlKdfContext<'a> {
+    /// The TLS-serialized [`MdlContext`].
+    pub ci: VLByteSlice<'a>,
+    pub sid: VLByteSlice<'a>,
+    /// `MSGa`, as sent respectively received.
+    pub msg_a: VLByteSlice<'a>,
+    /// `MSGb`, as sent respectively received.
+    pub msg_b: VLByteSlice<'a>,
+}
+
+/// The plaintext of a linking-payload application message.
+#[derive(Debug, Clone, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+pub struct LinkingPayload {
+    pub payload_type: LinkingPayloadType,
+    pub payload: Vec<u8>,
+}
+
+/// The provisional registry of linking-payload types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TlsSerialize, TlsDeserializeBytes, TlsSize)]
+#[repr(u16)]
+pub enum LinkingPayloadType {
+    /// The existing device's account material, a CBOR `ProvisioningPackage`.
+    ProvisioningPackage = 1,
+    /// The new device's self-group KeyPackage, a CBOR `SelfGroupJoinRequest`.
+    SelfGroupJoinRequest = 2,
+    /// The new device joined the self group. Empty payload, both sides tear
+    /// the session down afterwards.
+    LinkingComplete = 3,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(message: MdlMessage) {
+        let frame = message.clone().into_frame().unwrap();
+        assert_eq!(MdlMessage::from_frame(&frame).unwrap(), message);
+    }
+
+    #[test]
+    fn every_message_round_trips() {
+        round_trip(MdlMessage::ProvisionRequest(ProvisionRequest {
+            version: MDL_PROTOCOL_VERSION,
+        }));
+        round_trip(MdlMessage::SessionAssigned(SessionAssigned {
+            rendezvous_id: "417".to_owned(),
+        }));
+        round_trip(MdlMessage::PakeShareA(PakeShareA {
+            version: MDL_PROTOCOL_VERSION,
+            sid: vec![7; 16],
+            msg_a: vec![0xab; 70],
+        }));
+        round_trip(MdlMessage::PakeShareB(PakeShareB {
+            msg_b: vec![0xcd; 34],
+            welcome: vec![1, 2, 3],
+        }));
+        round_trip(MdlMessage::GroupMessage(GroupMessage {
+            mls_message: vec![4, 5, 6],
+        }));
+        round_trip(MdlMessage::Abort(Abort {
+            code: AbortCode::AuthenticationFailed,
+        }));
+    }
+
+    #[test]
+    fn message_types_use_the_fixed_discriminants() {
+        let types: Vec<u8> = [
+            MdlMessage::ProvisionRequest(ProvisionRequest { version: 1 }),
+            MdlMessage::SessionAssigned(SessionAssigned {
+                rendezvous_id: String::new(),
+            }),
+            MdlMessage::PakeShareA(PakeShareA {
+                version: 1,
+                sid: Vec::new(),
+                msg_a: Vec::new(),
+            }),
+            MdlMessage::PakeShareB(PakeShareB {
+                msg_b: Vec::new(),
+                welcome: Vec::new(),
+            }),
+            MdlMessage::GroupMessage(GroupMessage {
+                mls_message: Vec::new(),
+            }),
+            MdlMessage::Abort(Abort {
+                code: AbortCode::Timeout,
+            }),
+        ]
+        .into_iter()
+        .map(|message| message.tls_serialize_detached().unwrap()[0])
+        .collect();
+        assert_eq!(types, vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn unknown_message_type_is_rejected() {
+        assert!(MdlMessage::from_frame(&RelayFrame::from(vec![7, 0, 1])).is_err());
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let mut bytes = MdlMessage::Abort(Abort {
+            code: AbortCode::Timeout,
+        })
+        .tls_serialize_detached()
+        .unwrap();
+        bytes.push(0);
+        assert!(MdlMessage::from_frame(&RelayFrame::from(bytes)).is_err());
+    }
+
+    #[test]
+    fn unknown_abort_code_is_rejected() {
+        assert!(MdlMessage::from_frame(&RelayFrame::from(vec![6, 9])).is_err());
+    }
+
+    #[test]
+    fn unknown_linking_payload_type_is_rejected() {
+        assert!(LinkingPayload::tls_deserialize_exact_bytes(&[0, 9, 0]).is_err());
+    }
+
+    #[test]
+    fn linking_payload_round_trips() {
+        let payload = LinkingPayload {
+            payload_type: LinkingPayloadType::ProvisioningPackage,
+            payload: vec![9; 5],
+        };
+        let bytes = payload.tls_serialize_detached().unwrap();
+        assert_eq!(
+            LinkingPayload::tls_deserialize_exact_bytes(&bytes).unwrap(),
+            payload
+        );
+    }
+
+    /// The context is what both sides must derive identically, so its
+    /// serialization is fixed by the protocol rather than by this struct.
+    #[test]
+    fn context_serialization_is_stable() {
+        let ci = MdlContext::new("example.com".to_owned(), "417".to_owned())
+            .tls_serialize_detached()
+            .unwrap();
+        let mut expected = Vec::new();
+        expected.push(MDL_PROTOCOL_LABEL.len() as u8);
+        expected.extend_from_slice(MDL_PROTOCOL_LABEL.as_bytes());
+        expected.extend_from_slice(&MDL_PROTOCOL_VERSION.to_be_bytes());
+        expected.extend_from_slice(&MDL_PAKE_CIPHER_SUITE.to_be_bytes());
+        expected.extend_from_slice(&MDL_MLS_CIPHER_SUITE.to_be_bytes());
+        expected.push(MDL_INITIATOR_LABEL.len() as u8);
+        expected.extend_from_slice(MDL_INITIATOR_LABEL.as_bytes());
+        expected.push(MDL_RESPONDER_LABEL.len() as u8);
+        expected.extend_from_slice(MDL_RESPONDER_LABEL.as_bytes());
+        expected.push(11);
+        expected.extend_from_slice(b"example.com");
+        expected.push(3);
+        expected.extend_from_slice(b"417");
+        assert_eq!(ci, expected);
+    }
+
+    #[test]
+    fn kdf_context_serialization_is_stable() {
+        let kdf_ctx = MdlKdfContext {
+            ci: VLByteSlice(&[1, 2]),
+            sid: VLByteSlice(&[3]),
+            msg_a: VLByteSlice(&[4, 5, 6]),
+            msg_b: VLByteSlice(&[]),
+        }
+        .tls_serialize_detached()
+        .unwrap();
+        assert_eq!(kdf_ctx, vec![2, 1, 2, 1, 3, 3, 4, 5, 6, 0]);
+    }
+}

--- a/protos/src/relay_service/mod.rs
+++ b/protos/src/relay_service/mod.rs
@@ -4,5 +4,6 @@
 
 pub(crate) mod codec;
 mod convert;
+pub mod mdl;
 mod sign;
 pub mod v1;

--- a/protos/src/relay_service/v1.rs
+++ b/protos/src/relay_service/v1.rs
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::{fmt, ops::RangeInclusive};
+use std::fmt;
 
 use prost::bytes::Bytes;
-use sha2::{Digest, Sha256};
 
 tonic::include_proto!("relay_service.v1");
 
@@ -25,61 +24,25 @@ impl RelayFrame {
     pub fn as_slice(&self) -> &[u8] {
         self.payload.as_ref()
     }
+}
 
-    pub fn as_u32(&self) -> Option<u32> {
-        self.payload
-            .as_ref()
-            .try_into()
-            .ok()
-            .map(u32::from_be_bytes)
+impl RendezvousId {
+    pub fn new(value: String) -> Self {
+        Self { value }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+
+    /// Whether this is a well-formed rendezvous ID, that is a non-empty run
+    /// of ASCII digits.
+    pub fn is_well_formed(&self) -> bool {
+        !self.value.is_empty() && self.value.bytes().all(|b| b.is_ascii_digit())
     }
 }
 
-impl LinkingSessionId {
-    const DIGITS: RangeInclusive<u32> = 8..=16;
-
-    pub fn from_digest(sha256: &[u8; 32], digits: u32) -> Option<Self> {
-        if !Self::DIGITS.contains(&digits) {
-            return None;
-        }
-        sha256[..8]
-            .try_into()
-            .ok()
-            .map(u64::from_be_bytes)
-            .map(|n| Self {
-                value: format!("{:0width$}", n % 10u64.pow(digits), width = digits as usize),
-            })
-    }
-
-    pub fn generate(bytes: &[u8], mut has_collision: impl FnMut(&Self) -> bool) -> Option<Self> {
-        let digest: [u8; 32] = Sha256::digest(bytes).into();
-        for digits in Self::DIGITS {
-            let code = Self::from_digest(&digest, digits)?;
-            if !has_collision(&code) {
-                return Some(code);
-            }
-        }
-        None
-    }
-
-    pub fn validate(&self, bytes: &[u8]) -> bool {
-        let digest: [u8; 32] = Sha256::digest(bytes).into();
-        let digits = self.digits();
-        Self::from_digest(&digest, digits).is_some_and(|other| other == *self)
-    }
-
-    pub fn digits(&self) -> u32 {
-        self.value.len() as u32
-    }
-}
-
-impl AsRef<[u8]> for LinkingSessionId {
-    fn as_ref(&self) -> &[u8] {
-        self.value.as_bytes()
-    }
-}
-
-impl fmt::Display for LinkingSessionId {
+impl fmt::Display for RendezvousId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
     }
@@ -90,35 +53,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn returns_8_digit_code_when_no_collision() {
-        let code = LinkingSessionId::generate("hello-world".as_bytes(), |_| false).unwrap();
-        assert_eq!(code.digits(), 8);
-    }
-
-    #[test]
-    fn escalates_digits_on_collision() {
-        // collide on every 8-digit code; should escalate to 9 digits
-        let code =
-            LinkingSessionId::generate("hello-world".as_bytes(), |c| c.digits() == 8).unwrap();
-        assert_eq!(code.digits(), 9);
-    }
-
-    #[test]
-    fn escalates_multiple_times() {
-        // collide on 8 and 9 digit codes; should escalate to 10 digits
-        let code =
-            LinkingSessionId::generate("hello-world".as_bytes(), |c| c.digits() <= 9).unwrap();
-        assert_eq!(code.digits(), 10);
-    }
-
-    #[test]
-    fn all_lengths_collide() {
-        assert!(LinkingSessionId::generate("hello-world".as_bytes(), |_| true).is_none());
-    }
-
-    #[test]
-    fn code_contains_only_digits() {
-        let code = LinkingSessionId::generate("hello-world".as_bytes(), |_| false).unwrap();
-        assert!(code.value.chars().all(|c| c.is_ascii_digit()));
+    fn well_formed_ids_are_digit_runs() {
+        assert!(RendezvousId::new("000".to_owned()).is_well_formed());
+        assert!(RendezvousId::new("12345".to_owned()).is_well_formed());
+        assert!(!RendezvousId::new(String::new()).is_well_formed());
+        assert!(!RendezvousId::new("12a".to_owned()).is_well_formed());
+        assert!(!RendezvousId::new(" 12".to_owned()).is_well_formed());
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -128,7 +128,7 @@ async fn main() -> anyhow::Result<()> {
     .await
     .expect("Failed to connect to database.");
 
-    let rs = Rs::new(shutdown.clone());
+    let rs = Rs::new(shutdown.clone(), configuration.relay.clone());
 
     // New database name for the AS provider
     configuration.database.name = format!("{base_db_name}_as");

--- a/server/tests/tests/multi_device.rs
+++ b/server/tests/tests/multi_device.rs
@@ -14,7 +14,7 @@ use aircoreclient::{
     },
 };
 use airprotos::auth_service::v1::OperationType;
-use airserver_test_harness::utils::setup::TestBackend;
+use airserver_test_harness::utils::setup::{RelaySettings, TestBackend, TestBackendParams};
 use chrono::{DateTime, Utc};
 use mimi_content::{MessageStatus, MimiContent};
 use std::time::Duration;
@@ -2615,4 +2615,231 @@ async fn multi_device_both_devices_leave_before_the_commit() {
         charlie_user.mls_chat_participants(chat_id).await.unwrap(),
         remaining
     );
+}
+
+/// The digits of the rendezvous ID a code was issued for.
+fn rendezvous_id_of(code: &str) -> &str {
+    &code[..code.len() - PASSWORD_AND_CHECK_DIGITS]
+}
+
+/// A code for the same session with a different password, carrying a check
+/// digit that makes it pass the existing device's local check.
+///
+/// This is the typo the Damm digit cannot catch, and the only way to reach
+/// the protocol's authentication check.
+fn code_with_a_wrong_password(code: &str) -> String {
+    let mut digits = code.as_bytes().to_vec();
+    let password_start = digits.len() - PASSWORD_AND_CHECK_DIGITS;
+    digits[password_start] = if digits[password_start] == b'0' {
+        b'1'
+    } else {
+        b'0'
+    };
+
+    let check = digits.len() - 1;
+    for candidate in b'0'..=b'9' {
+        digits[check] = candidate;
+        let candidate = String::from_utf8(digits.clone()).unwrap();
+        if LinkingCode::parse(&candidate).is_ok() {
+            return candidate;
+        }
+    }
+    panic!("no check digit makes the altered code well formed");
+}
+
+/// Digits of the password plus the check digit, which is what the split from
+/// the end of a code has to skip.
+const PASSWORD_AND_CHECK_DIGITS: usize = 17;
+
+/// Spawns a provisioning device and hands back its linking code together
+/// with the task, so a test can drive the existing device's half itself.
+async fn provision_device(
+    setup: &TestBackend,
+) -> (
+    String,
+    tokio::task::JoinHandle<anyhow::Result<(CoreUser, TempDir)>>,
+    tokio::sync::mpsc::Receiver<MultiDeviceProvisionStep>,
+) {
+    let domain = setup.domain().clone();
+    let server_url = setup.server_url();
+    let (session_tx, mut session_rx) = tokio::sync::mpsc::channel(1);
+
+    let task = tokio::spawn(async move {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().to_str().unwrap();
+        let device =
+            CoreUser::multi_device_provision_client(db_path, domain, Some(server_url), session_tx)
+                .await?;
+        Ok((device, tmp))
+    });
+
+    let code = recv_linking_code(&mut session_rx).await;
+    (code, task, session_rx)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Test a wrong password fails the welcome", skip_all)]
+async fn multi_device_wrong_password_fails_authentication() {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+
+    let (code, new_device_task, _session_rx) = provision_device(&setup).await;
+    let wrong_code = code_with_a_wrong_password(&code);
+    assert_eq!(rendezvous_id_of(&wrong_code), rendezvous_id_of(&code));
+
+    let existing = setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(wrong_code, ignore_connected(), auto_confirm())
+        .await;
+
+    let error = existing
+        .expect_err("the existing device must learn about the failure")
+        .to_string();
+    assert!(
+        error.contains("AuthenticationFailed"),
+        "expected a forwarded authentication failure, got {error}"
+    );
+
+    let error = new_device_task
+        .await
+        .unwrap()
+        .expect_err("the new device must reject the welcome")
+        .to_string();
+    assert!(
+        error.contains("authentication failed"),
+        "expected an authentication failure, got {error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Test a mistyped code is caught locally", skip_all)]
+async fn multi_device_mistyped_code_does_not_burn_the_session() {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+
+    let (code, new_device_task, _session_rx) = provision_device(&setup).await;
+
+    // Swapping two adjacent digits is exactly what the Damm digit catches.
+    let mut typo = code.as_bytes().to_vec();
+    let position = typo
+        .windows(2)
+        .position(|pair| pair[0] != pair[1])
+        .expect("the code cannot consist of one repeated digit");
+    typo.swap(position, position + 1);
+    let typo = String::from_utf8(typo).unwrap();
+
+    let rejected = setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(typo, ignore_connected(), auto_confirm())
+        .await;
+    assert!(matches!(
+        rejected,
+        Ok(Err(MultiDeviceLinkClientError::InvalidCode))
+    ));
+
+    // The session was never touched, so the correct code still links.
+    setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(code, ignore_connected(), auto_confirm())
+        .await
+        .unwrap()
+        .unwrap();
+    new_device_task.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Test a linking session expires", skip_all)]
+async fn multi_device_session_expires() {
+    let mut setup = TestBackend::single_with_params(TestBackendParams {
+        relay: RelaySettings {
+            sessionttl: Duration::from_millis(300),
+            ..RelaySettings::default()
+        },
+        ..Default::default()
+    })
+    .await;
+    let alice = setup.add_user().await;
+
+    let (code, new_device_task, _session_rx) = provision_device(&setup).await;
+
+    assert!(
+        new_device_task.await.unwrap().is_err(),
+        "the new device's session must end when the relay reaps it"
+    );
+
+    let result = setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(code, ignore_connected(), auto_confirm())
+        .await;
+    assert!(matches!(
+        result,
+        Ok(Err(MultiDeviceLinkClientError::SessionNotFound))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Test a rendezvous id is quarantined", skip_all)]
+async fn multi_device_rendezvous_id_is_not_reused() {
+    let mut setup = TestBackend::single().await;
+    let alice = setup.add_user().await;
+
+    let (first_code, first_task, _first_rx) = provision_device(&setup).await;
+    setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(first_code.clone(), ignore_connected(), auto_confirm())
+        .await
+        .unwrap()
+        .unwrap();
+    let (_first_device, _first_tmp) = first_task.await.unwrap().unwrap();
+
+    let (second_code, second_task, _second_rx) = provision_device(&setup).await;
+    assert_ne!(
+        rendezvous_id_of(&second_code),
+        rendezvous_id_of(&first_code),
+        "an ended rendezvous id must stay in quarantine"
+    );
+    second_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tracing::instrument(name = "Test link attempts are rate limited per user", skip_all)]
+async fn multi_device_link_attempts_are_rate_limited() {
+    let mut setup = TestBackend::single_with_params(TestBackendParams {
+        relay: RelaySettings {
+            peruser: 1,
+            ..RelaySettings::default()
+        },
+        ..Default::default()
+    })
+    .await;
+    let alice = setup.add_user().await;
+
+    let (first_code, first_task, _first_rx) = provision_device(&setup).await;
+    setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(first_code, ignore_connected(), auto_confirm())
+        .await
+        .unwrap()
+        .unwrap();
+    let (_first_device, _first_tmp) = first_task.await.unwrap().unwrap();
+
+    let (second_code, second_task, _second_rx) = provision_device(&setup).await;
+    let error = setup
+        .get_user(&alice)
+        .user()
+        .multi_device_link_client(second_code, ignore_connected(), auto_confirm())
+        .await
+        .expect_err("the second attempt must be rate limited")
+        .to_string();
+    assert!(
+        error.contains("Too many requests"),
+        "expected a rate-limit error, got {error}"
+    );
+    second_task.abort();
 }

--- a/server/tests/tests/multi_device.rs
+++ b/server/tests/tests/multi_device.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashSet;
 
-use aircommon::{credentials::LeafCredential, identifiers::UserId};
+use aircommon::{credentials::LeafCredential, crypto::mdl::code::LinkingCode, identifiers::UserId};
 use aircoreclient::{
     ChatId, ChatStatus, ChatType, EventMessage, Message, ReadReceiptsSetting, SystemMessage,
     UserProfile,
@@ -13,7 +13,7 @@ use aircoreclient::{
         multi_device::{MultiDeviceLinkClientError, MultiDeviceProvisionStep},
     },
 };
-use airprotos::{auth_service::v1::OperationType, relay_service::v1::LinkingSessionId};
+use airprotos::auth_service::v1::OperationType;
 use airserver_test_harness::utils::setup::TestBackend;
 use chrono::{DateTime, Utc};
 use mimi_content::{MessageStatus, MimiContent};
@@ -107,19 +107,20 @@ fn ignore_connected() -> tokio::sync::oneshot::Sender<()> {
     tokio::sync::oneshot::channel().0
 }
 
-/// Receives the session ID from the first provisioning step. The receiver must
-/// stay alive afterwards: the new device later sends a `Linking` step, and
-/// dropping the receiver would make that send fail and abort provisioning.
-async fn recv_session_id(
+/// Receives the linking code from the first provisioning step. The receiver
+/// must stay alive afterwards: the new device later sends a `Linking` step,
+/// and dropping the receiver would make that send fail and abort
+/// provisioning.
+async fn recv_linking_code(
     rx: &mut tokio::sync::mpsc::Receiver<MultiDeviceProvisionStep>,
-) -> LinkingSessionId {
+) -> String {
     match rx
         .recv()
         .await
-        .expect("provision channel closed before session id")
+        .expect("provision channel closed before the linking code")
     {
-        MultiDeviceProvisionStep::SessionId(session_id) => session_id,
-        MultiDeviceProvisionStep::Linking => panic!("unexpected Linking step before session id"),
+        MultiDeviceProvisionStep::Code(code) => code,
+        MultiDeviceProvisionStep::Linking => panic!("unexpected Linking step before the code"),
     }
 }
 
@@ -152,7 +153,7 @@ async fn link_new_device_named(
         (new_device, tmp)
     });
 
-    let session_id = recv_session_id(&mut session_rx).await;
+    let session_id = recv_linking_code(&mut session_rx).await;
 
     setup
         .get_user(user_id)
@@ -509,16 +510,13 @@ async fn multi_device_link_with_nonexistent_session_id() {
     let mut setup = TestBackend::single().await;
     let alice = setup.add_user().await;
 
-    let fake_digest =
-        hex::decode("68924f1f6f60d5fdb8463881a5945e58c3f1402c65681b1270f5aeccbed17bd1")
-            .unwrap()
-            .try_into()
-            .unwrap();
-    let fake_session_id = LinkingSessionId::from_digest(&fake_digest, 8).unwrap();
+    // A well-formed code, check digit and all, for a session that was never
+    // opened.
+    let fake_code = LinkingCode::generate("999").unwrap().to_digits();
     let result = setup
         .get_user(&alice)
         .user()
-        .multi_device_link_client(fake_session_id, ignore_connected(), auto_confirm())
+        .multi_device_link_client(fake_code, ignore_connected(), auto_confirm())
         .await;
 
     assert!(matches!(
@@ -549,7 +547,7 @@ async fn multi_device_second_link_attempt_returns_error() {
         (new_device, tmp)
     });
 
-    let session_id = recv_session_id(&mut session_rx).await;
+    let session_id = recv_linking_code(&mut session_rx).await;
 
     setup
         .get_user(&alice)
@@ -620,10 +618,11 @@ async fn multi_device_concurrent_linking_sessions_dont_interfere() {
         (new_device, tmp)
     });
 
-    let alice_session_id = recv_session_id(&mut alice_session_rx).await;
-    let bob_session_id = recv_session_id(&mut bob_session_rx).await;
+    let alice_session_id = recv_linking_code(&mut alice_session_rx).await;
+    let bob_session_id = recv_linking_code(&mut bob_session_rx).await;
 
-    // Session IDs derived from different key packages must be distinct.
+    // Concurrent sessions must get distinct rendezvous ids, and therefore
+    // distinct codes.
     assert_ne!(alice_session_id, bob_session_id);
 
     setup

--- a/test_harness/src/utils/mod.rs
+++ b/test_harness/src/utils/mod.rs
@@ -172,6 +172,7 @@ pub(crate) async fn spawn_app(
 
     let TestBackendParams {
         rate_limits,
+        relay,
         version_policy,
         registration,
         unredeemable_code,
@@ -290,7 +291,7 @@ pub(crate) async fn spawn_app(
         network: network_provider.clone(),
     };
 
-    let rs = Rs::new(stop.clone());
+    let rs = Rs::new(stop.clone(), relay);
 
     // Start the server
     let server = run(

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use airbackend::{
-    settings::{RateLimitsSettings, RegistrationPolicy, RegistrationSettings},
+    settings::{RateLimitsSettings, RegistrationPolicy, RegistrationSettings, RelaySettings},
     version::VersionPolicy,
 };
 use aircommon::{
@@ -192,6 +192,7 @@ enum ServerUrl {
 #[derive(Debug)]
 pub struct TestBackendParams {
     pub rate_limits: Option<RateLimitsSettings>,
+    pub relay: RelaySettings,
     pub version_policy: VersionPolicy,
     pub registration: RegistrationSettings,
     pub unredeemable_code: Option<String>,
@@ -214,6 +215,7 @@ impl Default for TestBackendParams {
     fn default() -> Self {
         Self {
             rate_limits: None,
+            relay: RelaySettings::default(),
             version_policy: Default::default(),
             registration: RegistrationSettings {
                 policy: RegistrationPolicy::Open,

--- a/test_harness/src/utils/setup.rs
+++ b/test_harness/src/utils/setup.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use airbackend::{
-    settings::{RateLimitsSettings, RegistrationPolicy, RegistrationSettings, RelaySettings},
+    settings::{RateLimitsSettings, RegistrationPolicy, RegistrationSettings},
     version::VersionPolicy,
 };
 use aircommon::{
@@ -188,6 +188,8 @@ enum ServerUrl {
     External(Url),
     Local(SocketAddr),
 }
+
+pub use airbackend::settings::RelaySettings;
 
 #[derive(Debug)]
 pub struct TestBackendParams {


### PR DESCRIPTION
This PR does the following:

- Integrate a PAKE into the multi-device linking protocol with the PAKE key injected as a PSK into the MLS group
- Change the way the linking code is composed: It's now a three-digit rendez-vous code (that can grow with the number of active linking processes on the relay service) plus a random 16 digit security code ("password") plus a Damm check digit that catches typos to some degree
- The linking protocol is now versioned (a version number is included in the first message)
- Introduces a multi-pronged rate limiting scheme for the relay service (session creation per address, link attempts per address and link attempts per user)