### PR TITLE
fix(app): dismiss keyboard on Android on pause

### DIFF
--- a/app/lib/platform/app_lifecycle_handler.dart
+++ b/app/lib/platform/app_lifecycle_handler.dart
@@ -57,6 +57,14 @@ class AppLifecycleHandler with WidgetsBindingObserver {
       // is closed. In that case, we want to treat it as background state.
       _appStateController.sink.add(AppState.mobileBackground);
 
+      if (Platform.isAndroid) {
+        // Drop the keyboard focus. Otherwise Android tries to restore the
+        // keyboard on resume and immediately cancels it again, and the Flutter
+        // engine then reports a stale keyboard inset (bug), leaving the layout
+        // as if the keyboard were still up.
+        FocusManager.instance.primaryFocus?.unfocus();
+      }
+
       // iOS only
       if (Platform.isIOS) {
         // Request additional background time until the outbound service is


### PR DESCRIPTION
This is consistent with how other applications behave. There's a bug in the Flutter engine about keyboard insets which I might file a ticket for, but ultimately we don't want this behaviour on Android because it leads to flickering animations (the app first renders without the keyboard, and the keyboard _then_ opens/loads, which looks shady).