### PR TITLE
feat(app): add a toggle to limit the loops of animated images

### DIFF
--- a/app/lib/core/api/user_settings_cubit.dart
+++ b/app/lib/core/api/user_settings_cubit.dart
@@ -15,8 +15,8 @@ import 'user.dart';
 part 'user_settings_cubit.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `f64_decode`, `f64_encode`, `reload_read_receipts`, `settings_listener`, `subscribe`
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DefaultEmojiSkinToneSetting`, `DismissedVersionExpirySetting`, `InterfaceScaleSetting`, `LocaleSetting`, `SendOnEnterSetting`, `SidebarWidthSetting`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `decode`, `decode`, `decode`, `decode`, `decode`, `decode`, `encode`, `encode`, `encode`, `encode`, `encode`, `encode`, `fmt`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DefaultEmojiSkinToneSetting`, `DismissedVersionExpirySetting`, `InterfaceScaleSetting`, `LimitAnimatedImagesLoopsSetting`, `LocaleSetting`, `SendOnEnterSetting`, `SidebarWidthSetting`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `decode`, `decode`, `decode`, `decode`, `decode`, `decode`, `decode`, `encode`, `encode`, `encode`, `encode`, `encode`, `encode`, `encode`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `default`
 
 /// Loads the persisted user settings. Missing rows keep the defaults.
@@ -51,6 +51,8 @@ abstract class UserSettingsCubitBase implements RustOpaqueInterface {
 
   Future<void> setInterfaceScale({required double value});
 
+  Future<void> setLimitAnimatedImagesLoops({required bool value});
+
   Future<void> setLocale({required String value});
 
   Future<void> setReadReceipts({required bool value});
@@ -71,6 +73,7 @@ sealed class UserSettings with _$UserSettings {
     double? interfaceScale,
     @Default(240.0) double sidebarWidth,
     @Default(false) bool sendOnEnter,
+    @Default(false) bool limitAnimatedImagesLoops,
     @Default(true) bool readReceipts,
     @Default(false) bool developerMode,
     @Default(false) bool experimentalFeatures,

--- a/app/lib/core/api/user_settings_cubit.freezed.dart
+++ b/app/lib/core/api/user_settings_cubit.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserSettings {
 
- String? get locale; double? get interfaceScale; double get sidebarWidth; bool get sendOnEnter; bool get readReceipts; bool get developerMode; bool get experimentalFeatures; int get defaultEmojiSkinTone; DateTime? get dismissedVersionExpiry;
+ String? get locale; double? get interfaceScale; double get sidebarWidth; bool get sendOnEnter; bool get limitAnimatedImagesLoops; bool get readReceipts; bool get developerMode; bool get experimentalFeatures; int get defaultEmojiSkinTone; DateTime? get dismissedVersionExpiry;
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,20 +27,20 @@ $UserSettingsCopyWith<UserSettings> get copyWith => _$UserSettingsCopyWithImpl<U
 @override
 bool operator ==(Object other) {
   final _this = this as UserSettings;
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserSettings&&(identical(other.locale, _this.locale) || other.locale == _this.locale)&&(identical(other.interfaceScale, _this.interfaceScale) || other.interfaceScale == _this.interfaceScale)&&(identical(other.sidebarWidth, _this.sidebarWidth) || other.sidebarWidth == _this.sidebarWidth)&&(identical(other.sendOnEnter, _this.sendOnEnter) || other.sendOnEnter == _this.sendOnEnter)&&(identical(other.readReceipts, _this.readReceipts) || other.readReceipts == _this.readReceipts)&&(identical(other.developerMode, _this.developerMode) || other.developerMode == _this.developerMode)&&(identical(other.experimentalFeatures, _this.experimentalFeatures) || other.experimentalFeatures == _this.experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, _this.defaultEmojiSkinTone) || other.defaultEmojiSkinTone == _this.defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, _this.dismissedVersionExpiry) || other.dismissedVersionExpiry == _this.dismissedVersionExpiry));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserSettings&&(identical(other.locale, _this.locale) || other.locale == _this.locale)&&(identical(other.interfaceScale, _this.interfaceScale) || other.interfaceScale == _this.interfaceScale)&&(identical(other.sidebarWidth, _this.sidebarWidth) || other.sidebarWidth == _this.sidebarWidth)&&(identical(other.sendOnEnter, _this.sendOnEnter) || other.sendOnEnter == _this.sendOnEnter)&&(identical(other.limitAnimatedImagesLoops, _this.limitAnimatedImagesLoops) || other.limitAnimatedImagesLoops == _this.limitAnimatedImagesLoops)&&(identical(other.readReceipts, _this.readReceipts) || other.readReceipts == _this.readReceipts)&&(identical(other.developerMode, _this.developerMode) || other.developerMode == _this.developerMode)&&(identical(other.experimentalFeatures, _this.experimentalFeatures) || other.experimentalFeatures == _this.experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, _this.defaultEmojiSkinTone) || other.defaultEmojiSkinTone == _this.defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, _this.dismissedVersionExpiry) || other.dismissedVersionExpiry == _this.dismissedVersionExpiry));
 }
 
 
 @override
 int get hashCode {
   final _this = this as UserSettings;
-  return Object.hash(runtimeType,_this.locale,_this.interfaceScale,_this.sidebarWidth,_this.sendOnEnter,_this.readReceipts,_this.developerMode,_this.experimentalFeatures,_this.defaultEmojiSkinTone,_this.dismissedVersionExpiry);
+  return Object.hash(runtimeType,_this.locale,_this.interfaceScale,_this.sidebarWidth,_this.sendOnEnter,_this.limitAnimatedImagesLoops,_this.readReceipts,_this.developerMode,_this.experimentalFeatures,_this.defaultEmojiSkinTone,_this.dismissedVersionExpiry);
 }
 
 @override
 String toString() {
   final _this = this as UserSettings;
-  return 'UserSettings(locale: ${_this.locale}, interfaceScale: ${_this.interfaceScale}, sidebarWidth: ${_this.sidebarWidth}, sendOnEnter: ${_this.sendOnEnter}, readReceipts: ${_this.readReceipts}, developerMode: ${_this.developerMode}, experimentalFeatures: ${_this.experimentalFeatures}, defaultEmojiSkinTone: ${_this.defaultEmojiSkinTone}, dismissedVersionExpiry: ${_this.dismissedVersionExpiry})';
+  return 'UserSettings(locale: ${_this.locale}, interfaceScale: ${_this.interfaceScale}, sidebarWidth: ${_this.sidebarWidth}, sendOnEnter: ${_this.sendOnEnter}, limitAnimatedImagesLoops: ${_this.limitAnimatedImagesLoops}, readReceipts: ${_this.readReceipts}, developerMode: ${_this.developerMode}, experimentalFeatures: ${_this.experimentalFeatures}, defaultEmojiSkinTone: ${_this.defaultEmojiSkinTone}, dismissedVersionExpiry: ${_this.dismissedVersionExpiry})';
 }
 
 
@@ -51,7 +51,7 @@ abstract mixin class $UserSettingsCopyWith<$Res>  {
   factory $UserSettingsCopyWith(UserSettings value, $Res Function(UserSettings) _then) = _$UserSettingsCopyWithImpl;
 @useResult
 $Res call({
- String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
+ String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool limitAnimatedImagesLoops, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
 });
 
 
@@ -68,12 +68,13 @@ class _$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? limitAnimatedImagesLoops = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
   return _then(UserSettings(
 locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as String?,interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
 as double?,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
 as double,sendOnEnter: null == sendOnEnter ? _self.sendOnEnter : sendOnEnter // ignore: cast_nullable_to_non_nullable
+as bool,limitAnimatedImagesLoops: null == limitAnimatedImagesLoops ? _self.limitAnimatedImagesLoops : limitAnimatedImagesLoops // ignore: cast_nullable_to_non_nullable
 as bool,readReceipts: null == readReceipts ? _self.readReceipts : readReceipts // ignore: cast_nullable_to_non_nullable
 as bool,developerMode: null == developerMode ? _self.developerMode : developerMode // ignore: cast_nullable_to_non_nullable
 as bool,experimentalFeatures: null == experimentalFeatures ? _self.experimentalFeatures : experimentalFeatures // ignore: cast_nullable_to_non_nullable
@@ -91,13 +92,14 @@ as DateTime?,
 
 
 class _UserSettings implements UserSettings {
-  const _UserSettings({this.locale, this.interfaceScale, this.sidebarWidth = 240.0, this.sendOnEnter = false, this.readReceipts = true, this.developerMode = false, this.experimentalFeatures = false, this.defaultEmojiSkinTone = 0, this.dismissedVersionExpiry});
+  const _UserSettings({this.locale, this.interfaceScale, this.sidebarWidth = 240.0, this.sendOnEnter = false, this.limitAnimatedImagesLoops = false, this.readReceipts = true, this.developerMode = false, this.experimentalFeatures = false, this.defaultEmojiSkinTone = 0, this.dismissedVersionExpiry});
   
 
 @override final  String? locale;
 @override final  double? interfaceScale;
 @override@JsonKey() final  double sidebarWidth;
 @override@JsonKey() final  bool sendOnEnter;
+@override@JsonKey() final  bool limitAnimatedImagesLoops;
 @override@JsonKey() final  bool readReceipts;
 @override@JsonKey() final  bool developerMode;
 @override@JsonKey() final  bool experimentalFeatures;
@@ -114,18 +116,18 @@ _$UserSettingsCopyWith<_UserSettings> get copyWith => __$UserSettingsCopyWithImp
 
 @override
 bool operator ==(Object other) {
-    return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, dismissedVersionExpiry) || other.dismissedVersionExpiry == dismissedVersionExpiry));
+    return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserSettings&&(identical(other.locale, locale) || other.locale == locale)&&(identical(other.interfaceScale, interfaceScale) || other.interfaceScale == interfaceScale)&&(identical(other.sidebarWidth, sidebarWidth) || other.sidebarWidth == sidebarWidth)&&(identical(other.sendOnEnter, sendOnEnter) || other.sendOnEnter == sendOnEnter)&&(identical(other.limitAnimatedImagesLoops, limitAnimatedImagesLoops) || other.limitAnimatedImagesLoops == limitAnimatedImagesLoops)&&(identical(other.readReceipts, readReceipts) || other.readReceipts == readReceipts)&&(identical(other.developerMode, developerMode) || other.developerMode == developerMode)&&(identical(other.experimentalFeatures, experimentalFeatures) || other.experimentalFeatures == experimentalFeatures)&&(identical(other.defaultEmojiSkinTone, defaultEmojiSkinTone) || other.defaultEmojiSkinTone == defaultEmojiSkinTone)&&(identical(other.dismissedVersionExpiry, dismissedVersionExpiry) || other.dismissedVersionExpiry == dismissedVersionExpiry));
 }
 
 
 @override
 int get hashCode {
-    return Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone,dismissedVersionExpiry);
+    return Object.hash(runtimeType,locale,interfaceScale,sidebarWidth,sendOnEnter,limitAnimatedImagesLoops,readReceipts,developerMode,experimentalFeatures,defaultEmojiSkinTone,dismissedVersionExpiry);
 }
 
 @override
 String toString() {
-    return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone, dismissedVersionExpiry: $dismissedVersionExpiry)';
+    return 'UserSettings(locale: $locale, interfaceScale: $interfaceScale, sidebarWidth: $sidebarWidth, sendOnEnter: $sendOnEnter, limitAnimatedImagesLoops: $limitAnimatedImagesLoops, readReceipts: $readReceipts, developerMode: $developerMode, experimentalFeatures: $experimentalFeatures, defaultEmojiSkinTone: $defaultEmojiSkinTone, dismissedVersionExpiry: $dismissedVersionExpiry)';
 }
 
 
@@ -136,7 +138,7 @@ abstract mixin class _$UserSettingsCopyWith<$Res> implements $UserSettingsCopyWi
   factory _$UserSettingsCopyWith(_UserSettings value, $Res Function(_UserSettings) _then) = __$UserSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
+ String? locale, double? interfaceScale, double sidebarWidth, bool sendOnEnter, bool limitAnimatedImagesLoops, bool readReceipts, bool developerMode, bool experimentalFeatures, int defaultEmojiSkinTone, DateTime? dismissedVersionExpiry
 });
 
 
@@ -153,12 +155,13 @@ class __$UserSettingsCopyWithImpl<$Res>
 
 /// Create a copy of UserSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? locale = freezed,Object? interfaceScale = freezed,Object? sidebarWidth = null,Object? sendOnEnter = null,Object? limitAnimatedImagesLoops = null,Object? readReceipts = null,Object? developerMode = null,Object? experimentalFeatures = null,Object? defaultEmojiSkinTone = null,Object? dismissedVersionExpiry = freezed,}) {
   return _then(_UserSettings(
 locale: freezed == locale ? _self.locale : locale // ignore: cast_nullable_to_non_nullable
 as String?,interfaceScale: freezed == interfaceScale ? _self.interfaceScale : interfaceScale // ignore: cast_nullable_to_non_nullable
 as double?,sidebarWidth: null == sidebarWidth ? _self.sidebarWidth : sidebarWidth // ignore: cast_nullable_to_non_nullable
 as double,sendOnEnter: null == sendOnEnter ? _self.sendOnEnter : sendOnEnter // ignore: cast_nullable_to_non_nullable
+as bool,limitAnimatedImagesLoops: null == limitAnimatedImagesLoops ? _self.limitAnimatedImagesLoops : limitAnimatedImagesLoops // ignore: cast_nullable_to_non_nullable
 as bool,readReceipts: null == readReceipts ? _self.readReceipts : readReceipts // ignore: cast_nullable_to_non_nullable
 as bool,developerMode: null == developerMode ? _self.developerMode : developerMode // ignore: cast_nullable_to_non_nullable
 as bool,experimentalFeatures: null == experimentalFeatures ? _self.experimentalFeatures : experimentalFeatures // ignore: cast_nullable_to_non_nullable

--- a/app/lib/core/frb_generated.dart
+++ b/app/lib/core/frb_generated.dart
@@ -96,7 +96,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.13.0';
 
   @override
-  int get rustContentHash => -500933161;
+  int get rustContentHash => -864116904;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -724,6 +724,12 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiUserSettingsCubitUserSettingsCubitBaseSetInterfaceScale({
     required UserSettingsCubitBase that,
     required double value,
+  });
+
+  Future<void>
+  crateApiUserSettingsCubitUserSettingsCubitBaseSetLimitAnimatedImagesLoops({
+    required UserSettingsCubitBase that,
+    required bool value,
   });
 
   Future<void> crateApiUserSettingsCubitUserSettingsCubitBaseSetLocale({
@@ -6056,6 +6062,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void>
+  crateApiUserSettingsCubitUserSettingsCubitBaseSetLimitAnimatedImagesLoops({
+    required UserSettingsCubitBase that,
+    required bool value,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerUserSettingsCubitBase(
+            that,
+            serializer,
+          );
+          sse_encode_bool(value, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 131,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta:
+            kCrateApiUserSettingsCubitUserSettingsCubitBaseSetLimitAnimatedImagesLoopsConstMeta,
+        argValues: [that, value],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiUserSettingsCubitUserSettingsCubitBaseSetLimitAnimatedImagesLoopsConstMeta =>
+      const TaskConstMeta(
+        debugName: "UserSettingsCubitBase_set_limit_animated_images_loops",
+        argNames: ["that", "value"],
+      );
+
+  @override
   Future<void> crateApiUserSettingsCubitUserSettingsCubitBaseSetLocale({
     required UserSettingsCubitBase that,
     required String value,
@@ -6072,7 +6119,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6112,7 +6159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6152,7 +6199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6192,7 +6239,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6230,7 +6277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 136,
           )!;
         },
         codec: SseCodec(
@@ -6270,7 +6317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 136,
+              funcId: 137,
               port: port_,
             );
           },
@@ -6308,7 +6355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 138,
           )!;
         },
         codec: SseCodec(
@@ -6341,7 +6388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 139,
             port: port_,
           );
         },
@@ -6376,7 +6423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 140,
             port: port_,
           );
         },
@@ -6409,7 +6456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 141,
             port: port_,
           );
         },
@@ -6440,7 +6487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 142,
             port: port_,
           );
         },
@@ -6484,7 +6531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 143,
             port: port_,
           );
         },
@@ -6532,7 +6579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 144,
             port: port_,
           );
         },
@@ -6566,7 +6613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 145,
           )!;
         },
         codec: SseCodec(
@@ -6603,7 +6650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 146,
             port: port_,
           );
         },
@@ -6641,7 +6688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 147,
             port: port_,
           );
         },
@@ -6675,7 +6722,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 148,
             port: port_,
           );
         },
@@ -6709,7 +6756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 149,
           )!;
         },
         codec: SseCodec(
@@ -6741,7 +6788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 150,
             port: port_,
           );
         },
@@ -6777,7 +6824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 151,
           )!;
         },
         codec: SseCodec(
@@ -6812,7 +6859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 152,
           )!;
         },
         codec: SseCodec(
@@ -6848,7 +6895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 153,
           )!;
         },
         codec: SseCodec(
@@ -6890,7 +6937,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 153,
+              funcId: 154,
               port: port_,
             );
           },
@@ -6930,7 +6977,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 155,
           )!;
         },
         codec: SseCodec(
@@ -6967,7 +7014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 156,
           )!;
         },
         codec: SseCodec(
@@ -7004,7 +7051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 157,
           )!;
         },
         codec: SseCodec(
@@ -7033,7 +7080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 158,
           )!;
         },
         codec: SseCodec(
@@ -7059,7 +7106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7094,7 +7141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7124,7 +7171,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7152,7 +7199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7187,7 +7234,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 163,
             port: port_,
           );
         },
@@ -7220,7 +7267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 163,
+              funcId: 164,
               port: port_,
             );
           },
@@ -7259,7 +7306,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 165,
             port: port_,
           );
         },
@@ -7290,7 +7337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 165,
+            funcId: 166,
             port: port_,
           );
         },
@@ -7320,7 +7367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 166,
+            funcId: 167,
             port: port_,
           );
         },
@@ -7351,7 +7398,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 167,
+            funcId: 168,
           )!;
         },
         codec: SseCodec(
@@ -7381,7 +7428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 169,
           )!;
         },
         codec: SseCodec(
@@ -7412,7 +7459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 170,
             port: port_,
           );
         },
@@ -7445,7 +7492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 171,
             port: port_,
           );
         },
@@ -7473,7 +7520,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 172,
             port: port_,
           );
         },
@@ -7511,7 +7558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 173,
             port: port_,
           );
         },
@@ -7539,7 +7586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 173,
+            funcId: 174,
             port: port_,
           );
         },
@@ -7574,7 +7621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 174,
+            funcId: 175,
             port: port_,
           );
         },
@@ -7607,7 +7654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 175,
+            funcId: 176,
             port: port_,
           );
         },
@@ -7640,7 +7687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 176,
+            funcId: 177,
           )!;
         },
         codec: SseCodec(
@@ -7669,7 +7716,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 177,
+            funcId: 178,
             port: port_,
           );
         },
@@ -7715,7 +7762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 178,
+              funcId: 179,
               port: port_,
             );
           },
@@ -7764,7 +7811,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 179,
+              funcId: 180,
               port: port_,
             );
           },
@@ -7797,7 +7844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 180,
+            funcId: 181,
             port: port_,
           );
         },
@@ -7829,7 +7876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 181,
+            funcId: 182,
             port: port_,
           );
         },
@@ -7857,7 +7904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 182,
+            funcId: 183,
             port: port_,
           );
         },
@@ -7887,7 +7934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 183,
+            funcId: 184,
             port: port_,
           );
         },
@@ -7914,7 +7961,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 184,
+            funcId: 185,
             port: port_,
           );
         },
@@ -7941,7 +7988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 185,
+            funcId: 186,
             port: port_,
           );
         },
@@ -7969,7 +8016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 186,
+            funcId: 187,
             port: port_,
           );
         },
@@ -7996,7 +8043,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 187,
+            funcId: 188,
             port: port_,
           );
         },
@@ -8029,7 +8076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 188,
+            funcId: 189,
           )!;
         },
         codec: SseCodec(
@@ -8062,7 +8109,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 189,
+            funcId: 190,
           )!;
         },
         codec: SseCodec(
@@ -11640,18 +11687,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   UserSettings dco_decode_user_settings(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return UserSettings(
       locale: dco_decode_opt_String(arr[0]),
       interfaceScale: dco_decode_opt_box_autoadd_f_64(arr[1]),
       sidebarWidth: dco_decode_f_64(arr[2]),
       sendOnEnter: dco_decode_bool(arr[3]),
-      readReceipts: dco_decode_bool(arr[4]),
-      developerMode: dco_decode_bool(arr[5]),
-      experimentalFeatures: dco_decode_bool(arr[6]),
-      defaultEmojiSkinTone: dco_decode_u_8(arr[7]),
-      dismissedVersionExpiry: dco_decode_opt_box_autoadd_Chrono_Utc(arr[8]),
+      limitAnimatedImagesLoops: dco_decode_bool(arr[4]),
+      readReceipts: dco_decode_bool(arr[5]),
+      developerMode: dco_decode_bool(arr[6]),
+      experimentalFeatures: dco_decode_bool(arr[7]),
+      defaultEmojiSkinTone: dco_decode_u_8(arr[8]),
+      dismissedVersionExpiry: dco_decode_opt_box_autoadd_Chrono_Utc(arr[9]),
     );
   }
 
@@ -15737,6 +15785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_interfaceScale = sse_decode_opt_box_autoadd_f_64(deserializer);
     var var_sidebarWidth = sse_decode_f_64(deserializer);
     var var_sendOnEnter = sse_decode_bool(deserializer);
+    var var_limitAnimatedImagesLoops = sse_decode_bool(deserializer);
     var var_readReceipts = sse_decode_bool(deserializer);
     var var_developerMode = sse_decode_bool(deserializer);
     var var_experimentalFeatures = sse_decode_bool(deserializer);
@@ -15749,6 +15798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       interfaceScale: var_interfaceScale,
       sidebarWidth: var_sidebarWidth,
       sendOnEnter: var_sendOnEnter,
+      limitAnimatedImagesLoops: var_limitAnimatedImagesLoops,
       readReceipts: var_readReceipts,
       developerMode: var_developerMode,
       experimentalFeatures: var_experimentalFeatures,
@@ -19881,6 +19931,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_f_64(self.interfaceScale, serializer);
     sse_encode_f_64(self.sidebarWidth, serializer);
     sse_encode_bool(self.sendOnEnter, serializer);
+    sse_encode_bool(self.limitAnimatedImagesLoops, serializer);
     sse_encode_bool(self.readReceipts, serializer);
     sse_encode_bool(self.developerMode, serializer);
     sse_encode_bool(self.experimentalFeatures, serializer);
@@ -21108,6 +21159,14 @@ class UserSettingsCubitBaseImpl extends RustOpaque
       .instance
       .api
       .crateApiUserSettingsCubitUserSettingsCubitBaseSetInterfaceScale(
+        that: this,
+        value: value,
+      );
+
+  Future<void> setLimitAnimatedImagesLoops({required bool value}) => RustLib
+      .instance
+      .api
+      .crateApiUserSettingsCubitUserSettingsCubitBaseSetLimitAnimatedImagesLoops(
         that: this,
         value: value,
       );

--- a/app/lib/features/attachments/animated_attachment_image.dart
+++ b/app/lib/features/attachments/animated_attachment_image.dart
@@ -7,6 +7,7 @@ import 'dart:ui' as ui;
 
 import 'package:air/core/core.dart';
 import 'package:air/features/attachments/attachment_image_overlay.dart';
+import 'package:air/features/user/user_settings_cubit.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
@@ -20,10 +21,12 @@ const int _maxAutoLoops = 3;
 ///
 /// The original bytes are read from the database and a fresh codec is
 /// instantiated per mount (and per replay); frames are driven by a [Timer].
-/// Autoplays on mount up to [_maxAutoLoops] then freezes on the last frame.
-/// Tapping toggles playback (running → freeze on current frame; stopped →
-/// replay from the start). Neither bytes nor frames are held in widget state
-/// beyond the current frame; each mount drives its own animation.
+/// Autoplays on mount. With [UserSettings.limitAnimatedImagesLoops]
+/// on, playback stops after [_maxAutoLoops] and freezes on the last frame;
+/// otherwise it loops forever. Tapping toggles playback (running → freeze on
+/// current frame; stopped → replay from the start). Neither bytes nor frames
+/// are held in widget state beyond the current frame; each mount drives its
+/// own animation.
 ///
 /// Renders nothing until the first frame is decoded, so the caller's
 /// placeholder shows through.
@@ -153,7 +156,11 @@ class _AnimatedAttachmentImageState extends State<AnimatedAttachmentImage> {
     _nextFrameIndex = (_nextFrameIndex + 1) % codec.frameCount;
     if (_nextFrameIndex == 0) {
       _completedLoops++;
-      if (_completedLoops >= _maxAutoLoops) {
+      final limitLoops = context
+          .read<UserSettingsCubit>()
+          .state
+          .limitAnimatedImagesLoops;
+      if (limitLoops && _completedLoops >= _maxAutoLoops) {
         setState(() => _stopped = true);
         return;
       }

--- a/app/lib/features/user/user_settings_cubit.dart
+++ b/app/lib/features/user/user_settings_cubit.dart
@@ -127,6 +127,9 @@ class UserSettingsCubit implements StateStreamableSource<UserSettings> {
   Future<void> setSendOnEnter({required bool value}) =>
       _impl!.setSendOnEnter(value: value);
 
+  Future<void> setLimitAnimatedImagesLoops({required bool value}) =>
+      _impl!.setLimitAnimatedImagesLoops(value: value);
+
   Future<void> setReadReceipts({required bool value}) =>
       _impl!.setReadReceipts(value: value);
 

--- a/app/lib/features/you/you_sections.dart
+++ b/app/lib/features/you/you_sections.dart
@@ -341,9 +341,6 @@ class PreferencesSection extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Captured here rather than read inside the submit callback: a debounced
-    // submit can fire while the widget is being disposed, when context
-    // lookups are no longer allowed.
     final settingsCubit = context.read<UserSettingsCubit>();
     final readReceiptsSetting = context.select(
       (UserSettingsCubit cubit) => cubit.state.readReceipts,
@@ -389,6 +386,8 @@ class PreferencesSection extends HookWidget {
         FieldLabel(loc.userSettingsScreen_readReceiptsDescription),
 
         if (DeviceType.isPhone) const _SendOnEnterSetting(),
+
+        const _LimitAnimatedImagesLoopsSetting(),
       ],
     );
   }
@@ -433,9 +432,6 @@ class _SendOnEnterSetting extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Captured here rather than read inside the submit callback: a debounced
-    // submit can fire while the widget is being disposed, when context
-    // lookups are no longer allowed.
     final settingsCubit = context.read<UserSettingsCubit>();
     final sendOnEnter = useState(
       useMemoized(() => settingsCubit.state.sendOnEnter),
@@ -457,6 +453,37 @@ class _SendOnEnterSetting extends HookWidget {
         const SizedBox(height: S.s12),
 
         FieldLabel(loc.userSettingsScreen_sendWithEnterDescription),
+      ],
+    );
+  }
+}
+
+class _LimitAnimatedImagesLoopsSetting extends HookWidget {
+  const _LimitAnimatedImagesLoopsSetting();
+
+  @override
+  Widget build(BuildContext context) {
+    final settingsCubit = context.read<UserSettingsCubit>();
+    final limitAnimatedImagesLoops = useState(
+      useMemoized(() => settingsCubit.state.limitAnimatedImagesLoops),
+    );
+
+    final loc = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: .start,
+      children: [
+        SwitchField(
+          label: loc.userSettingsScreen_limitAnimatedImagesLoops,
+          value: limitAnimatedImagesLoops,
+          onSubmit: (value) {
+            settingsCubit.setLimitAnimatedImagesLoops(value: value);
+          },
+        ),
+
+        const SizedBox(height: S.s12),
+
+        FieldLabel(loc.userSettingsScreen_limitAnimatedImagesLoopsDescription),
       ],
     );
   }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Air-Konto löschen",
   "userSettingsScreen_sendWithEnter": "Mit Eingabetaste senden",
   "userSettingsScreen_sendWithEnterDescription": "Wenn aktiviert, sendet die \"Enter\"-Taste die Nachricht.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "GIF-Autoplay begrenzen",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Wenn aktiviert, werden GIFs beim Anzeigen 3-mal wiederholt und können danach manuell erneut abgespielt werden.",
   "userSettingsScreen_readReceipts": "Lesebestätigungen",
   "userSettingsScreen_readReceiptsDescription": "Wenn aktiviert, sehen andere, ob du ihre Nachrichten gelesen hast, und du siehst, ob sie deine gelesen haben.",
   "userSettingsScreen_displayNameLabel": "Anzeigename",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -36,6 +36,14 @@
   "@userSettingsScreen_sendWithEnterDescription": {
     "description": "Explains the Send with Enter toggle. The quoted word is the name of the keyboard key."
   },
+  "userSettingsScreen_limitAnimatedImagesLoops": "Limit GIF autoplay",
+  "@userSettingsScreen_limitAnimatedImagesLoops": {
+    "description": "Label of the preference toggle that limits how many times a GIF autoplays."
+  },
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "If turned on, GIFs loop 3 times when viewed, then can be manually replayed.",
+  "@userSettingsScreen_limitAnimatedImagesLoopsDescription": {
+    "description": "Explains the Limit GIF autoplay toggle."
+  },
   "userSettingsScreen_readReceipts": "Read receipts",
   "@userSettingsScreen_readReceipts": {
     "description": "Label of the preference toggle that enables read receipts."

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Eliminar cuenta de Air",
   "userSettingsScreen_sendWithEnter": "Enviar con Enter",
   "userSettingsScreen_sendWithEnterDescription": "Si se activa, la tecla \"Enter\" del teclado envía el mensaje.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "Limitar la reproducción automática de GIF",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Si se activa, los GIF se reproducen 3 veces al verlos y luego se pueden reproducir de nuevo manualmente.",
   "userSettingsScreen_readReceipts": "Confirmaciones de lectura",
   "userSettingsScreen_readReceiptsDescription": "Si se activa, los demás verán si has leído sus mensajes y tú verás si han leído los tuyos.",
   "userSettingsScreen_displayNameLabel": "Nombre visible",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Supprimer le compte Air",
   "userSettingsScreen_sendWithEnter": "Envoyer avec Entrée",
   "userSettingsScreen_sendWithEnterDescription": "Si activée, la touche « Entrée » du clavier envoie le message.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "Limiter la lecture automatique des GIF",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Si activée, les GIF sont lus en boucle 3 fois à l'affichage, puis peuvent être relancés manuellement.",
   "userSettingsScreen_readReceipts": "Accusés de lecture",
   "userSettingsScreen_readReceiptsDescription": "Si activés, les autres verront si vous avez lu leurs messages et vous verrez s'ils ont lu les vôtres.",
   "userSettingsScreen_displayNameLabel": "Nom d'affichage",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -167,6 +167,18 @@ abstract class AppLocalizations {
   /// **'If turned on, the keyboard\'s \"Enter\" key sends the message.'**
   String get userSettingsScreen_sendWithEnterDescription;
 
+  /// Label of the preference toggle that limits how many times a GIF autoplays.
+  ///
+  /// In en, this message translates to:
+  /// **'Limit GIF autoplay'**
+  String get userSettingsScreen_limitAnimatedImagesLoops;
+
+  /// Explains the Limit GIF autoplay toggle.
+  ///
+  /// In en, this message translates to:
+  /// **'If turned on, GIFs loop 3 times when viewed, then can be manually replayed.'**
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription;
+
   /// Label of the preference toggle that enables read receipts.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -46,6 +46,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wenn aktiviert, sendet die \"Enter\"-Taste die Nachricht.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'GIF-Autoplay begrenzen';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Wenn aktiviert, werden GIFs beim Anzeigen 3-mal wiederholt und können danach manuell erneut abgespielt werden.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Lesebestätigungen';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -46,6 +46,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'If turned on, the keyboard\'s \"Enter\" key sends the message.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Limit GIF autoplay';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'If turned on, GIFs loop 3 times when viewed, then can be manually replayed.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Read receipts';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -46,6 +46,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Si se activa, la tecla \"Enter\" del teclado envía el mensaje.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Limitar la reproducción automática de GIF';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Si se activa, los GIF se reproducen 3 veces al verlos y luego se pueden reproducir de nuevo manualmente.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Confirmaciones de lectura';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -46,6 +46,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Si activée, la touche « Entrée » du clavier envoie le message.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Limiter la lecture automatique des GIF';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Si activée, les GIF sont lus en boucle 3 fois à l\'affichage, puis peuvent être relancés manuellement.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Accusés de lecture';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -46,6 +46,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Se estiver ativado, a tecla \"Enter\" do teclado envia a mensagem.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Limitar a reprodução automática de GIFs';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Se estiver ativado, os GIFs são reproduzidos 3 vezes ao serem visualizados e depois podem ser reproduzidos novamente manualmente.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Confirmações de leitura';
 
   @override
@@ -1543,6 +1551,14 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get userSettingsScreen_sendWithEnterDescription =>
       'Se estiver ativado, a tecla \"Enter\" do teclado envia a mensagem.';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Limitar a reprodução automática de GIFs';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Se estiver ativado, os GIFs são reproduzidos 3 vezes ao serem visualizados e depois podem ser reproduzidos novamente manualmente.';
 
   @override
   String get userSettingsScreen_readReceipts => 'Confirmações de leitura';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -46,6 +46,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Om detta är aktiverat skickar tangentbordets \"Enter\"-tangent meddelandet.';
 
   @override
+  String get userSettingsScreen_limitAnimatedImagesLoops =>
+      'Begränsa automatisk uppspelning av GIF';
+
+  @override
+  String get userSettingsScreen_limitAnimatedImagesLoopsDescription =>
+      'Om detta är aktiverat loopas GIF-bilder 3 gånger när de visas och kan sedan spelas upp igen manuellt.';
+
+  @override
   String get userSettingsScreen_readReceipts => 'Läskvitton';
 
   @override

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Excluir conta do Air",
   "userSettingsScreen_sendWithEnter": "Enviar com Enter",
   "userSettingsScreen_sendWithEnterDescription": "Se estiver ativado, a tecla \"Enter\" do teclado envia a mensagem.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "Limitar a reprodução automática de GIFs",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Se estiver ativado, os GIFs são reproduzidos 3 vezes ao serem visualizados e depois podem ser reproduzidos novamente manualmente.",
   "userSettingsScreen_readReceipts": "Confirmações de leitura",
   "userSettingsScreen_readReceiptsDescription": "Se estiver ativado, os outros veem se você leu as mensagens deles e você vê se eles leram as suas.",
   "userSettingsScreen_displayNameLabel": "Nome de exibição",

--- a/app/lib/l10n/app_pt_PT.arb
+++ b/app/lib/l10n/app_pt_PT.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Eliminar conta do Air",
   "userSettingsScreen_sendWithEnter": "Enviar com Enter",
   "userSettingsScreen_sendWithEnterDescription": "Se estiver ativado, a tecla \"Enter\" do teclado envia a mensagem.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "Limitar a reprodução automática de GIFs",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Se estiver ativado, os GIFs são reproduzidos 3 vezes ao serem visualizados e depois podem ser reproduzidos novamente manualmente.",
   "userSettingsScreen_readReceipts": "Confirmações de leitura",
   "userSettingsScreen_readReceiptsDescription": "Se estiver ativado, os outros veem se leste as mensagens deles e tu vês se eles leram as tuas.",
   "userSettingsScreen_displayNameLabel": "Nome a apresentar",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -8,6 +8,8 @@
   "userSettingsScreen_deleteAccount": "Radera Air-konto",
   "userSettingsScreen_sendWithEnter": "Skicka med Enter",
   "userSettingsScreen_sendWithEnterDescription": "Om detta är aktiverat skickar tangentbordets \"Enter\"-tangent meddelandet.",
+  "userSettingsScreen_limitAnimatedImagesLoops": "Begränsa automatisk uppspelning av GIF",
+  "userSettingsScreen_limitAnimatedImagesLoopsDescription": "Om detta är aktiverat loopas GIF-bilder 3 gånger när de visas och kan sedan spelas upp igen manuellt.",
   "userSettingsScreen_readReceipts": "Läskvitton",
   "userSettingsScreen_readReceiptsDescription": "Om detta är aktiverat kan andra se om du har läst deras meddelanden och du kan se om de har läst dina.",
   "userSettingsScreen_displayNameLabel": "Visningsnamn",

--- a/applogic/src/api/user_settings_cubit.rs
+++ b/applogic/src/api/user_settings_cubit.rs
@@ -32,6 +32,8 @@ pub struct UserSettings {
     pub sidebar_width: f64,
     #[frb(default = false)]
     pub send_on_enter: bool,
+    #[frb(default = false)]
+    pub limit_animated_images_loops: bool,
     #[frb(default = true)]
     pub read_receipts: bool,
     /// Whether the developer surface is unlocked on this device.
@@ -57,6 +59,7 @@ impl Default for UserSettings {
             interface_scale: None,
             sidebar_width: 240.0,
             send_on_enter: false,
+            limit_animated_images_loops: false,
             read_receipts: true,
             developer_mode: false,
             experimental_features: false,
@@ -74,6 +77,7 @@ pub async fn load_user_settings(user: &User) -> UserSettings {
     let interface_scale = core_user.user_setting().await;
     let sidebar_width = core_user.user_setting().await;
     let send_on_enter = core_user.user_setting().await;
+    let limit_animated_images_loops = core_user.user_setting().await;
     let read_receipts = core_user.user_setting().await;
     let developer_mode = core_user.user_setting().await;
     let experimental_features = core_user.user_setting().await;
@@ -88,6 +92,10 @@ pub async fn load_user_settings(user: &User) -> UserSettings {
             .map_or(defaults.sidebar_width, |SidebarWidthSetting(value)| value),
         send_on_enter: send_on_enter
             .map_or(defaults.send_on_enter, |SendOnEnterSetting(value)| value),
+        limit_animated_images_loops: limit_animated_images_loops.map_or(
+            defaults.limit_animated_images_loops,
+            |LimitAnimatedImagesLoopsSetting(value)| value,
+        ),
         read_receipts: read_receipts
             .map_or(defaults.read_receipts, |ReadReceiptsSetting(value)| value),
         developer_mode: developer_mode
@@ -209,6 +217,19 @@ impl UserSettingsCubitBase {
         self.core
             .state_tx()
             .send_modify(|state| state.send_on_enter = value);
+        Ok(())
+    }
+
+    pub async fn set_limit_animated_images_loops(&self, value: bool) -> anyhow::Result<()> {
+        if self.core.state_tx().borrow().limit_animated_images_loops == value {
+            return Ok(());
+        }
+        self.core_user
+            .set_user_setting(&LimitAnimatedImagesLoopsSetting(value))
+            .await?;
+        self.core
+            .state_tx()
+            .send_modify(|state| state.limit_animated_images_loops = value);
         Ok(())
     }
 
@@ -445,6 +466,23 @@ impl UserSetting for SendOnEnterSetting {
         match bytes.as_slice() {
             [byte] => Ok(Self(*byte != 0)),
             _ => bail!("invalid send_on_enter bytes"),
+        }
+    }
+}
+
+struct LimitAnimatedImagesLoopsSetting(bool);
+
+impl UserSetting for LimitAnimatedImagesLoopsSetting {
+    const KEY: &'static str = "limit_animated_images_loops";
+
+    fn encode(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(vec![self.0 as u8])
+    }
+
+    fn decode(bytes: Vec<u8>) -> anyhow::Result<Self> {
+        match bytes.as_slice() {
+            [byte] => Ok(Self(*byte != 0)),
+            _ => bail!("invalid limit_animated_images_loops bytes"),
         }
     }
 }

--- a/applogic/src/frb_generated.rs
+++ b/applogic/src/frb_generated.rs
@@ -56,7 +56,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.13.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -500933161;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -864116904;
 
 // Section: executor
 
@@ -6675,6 +6675,31 @@ let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decod
                     })().await)
                 } })
 }
+fn wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_limit_animated_images_loops_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "UserSettingsCubitBase_set_limit_animated_images_loops", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || {
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<UserSettingsCubitBase>>>::sse_decode(&mut deserializer);
+let api_value = <bool>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>((move || async move {
+                        let mut api_that_guard = None;
+let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(&api_that, 0, false)]);
+        for i in decode_indices_ {
+            match i {
+                0 => api_that_guard = Some(api_that.lockable_decode_async_ref().await),
+                _ => unreachable!(),
+            }
+        }
+        let api_that_guard = api_that_guard.unwrap();
+ let output_ok = crate::api::user_settings_cubit::UserSettingsCubitBase::set_limit_animated_images_loops(&*api_that_guard, api_value).await?;   std::result::Result::Ok(output_ok)
+                    })().await)
+                } })
+}
 fn wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -13149,6 +13174,7 @@ impl SseDecode for crate::api::user_settings_cubit::UserSettings {
         let mut var_interfaceScale = <Option<f64>>::sse_decode(deserializer);
         let mut var_sidebarWidth = <f64>::sse_decode(deserializer);
         let mut var_sendOnEnter = <bool>::sse_decode(deserializer);
+        let mut var_limitAnimatedImagesLoops = <bool>::sse_decode(deserializer);
         let mut var_readReceipts = <bool>::sse_decode(deserializer);
         let mut var_developerMode = <bool>::sse_decode(deserializer);
         let mut var_experimentalFeatures = <bool>::sse_decode(deserializer);
@@ -13160,6 +13186,7 @@ impl SseDecode for crate::api::user_settings_cubit::UserSettings {
             interface_scale: var_interfaceScale,
             sidebar_width: var_sidebarWidth,
             send_on_enter: var_sendOnEnter,
+            limit_animated_images_loops: var_limitAnimatedImagesLoops,
             read_receipts: var_readReceipts,
             developer_mode: var_developerMode,
             experimental_features: var_experimentalFeatures,
@@ -13309,49 +13336,50 @@ fn pde_ffi_dispatcher_primary_impl(
 128 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_dismissed_version_expiry_impl(port, ptr, rust_vec_len, data_len),
 129 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_experimental_features_impl(port, ptr, rust_vec_len, data_len),
 130 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_interface_scale_impl(port, ptr, rust_vec_len, data_len),
-131 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
-132 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-138 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
-139 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
-140 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
-141 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
-142 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
-143 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
-145 => wire__crate__api__user__User_trigger_timed_task_impl(port, ptr, rust_vec_len, data_len),
-146 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
-147 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
-149 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
-153 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
-158 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-159 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
-160 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
-161 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
-162 => wire__crate__api__registration__create_admission_session_impl(port, ptr, rust_vec_len, data_len),
-163 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
-164 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
-165 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
-166 => wire__crate__api__registration__get_registration_info_impl(port, ptr, rust_vec_len, data_len),
-169 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
-170 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
-171 => wire__crate__api__linked_devices_cubit__linked_devices_state_default_impl(port, ptr, rust_vec_len, data_len),
-172 => wire__crate__api__user_settings_cubit__load_user_settings_impl(port, ptr, rust_vec_len, data_len),
-173 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
-174 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
-175 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
-177 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
-178 => wire__crate__api__multi_device__multi_device_link_client_impl(port, ptr, rust_vec_len, data_len),
-179 => wire__crate__api__multi_device__multi_device_provision_client_impl(port, ptr, rust_vec_len, data_len),
-180 => wire__crate__api__notification_context__notification_policy_default_impl(port, ptr, rust_vec_len, data_len),
-181 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
-182 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
-183 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
-184 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
-185 => wire__crate__api__share_cubit__share_state_default_impl(port, ptr, rust_vec_len, data_len),
-186 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
-187 => wire__crate__api__share_cubit__ui_share_send_status_default_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_limit_animated_images_loops_impl(port, ptr, rust_vec_len, data_len),
+132 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_locale_impl(port, ptr, rust_vec_len, data_len),
+133 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_read_receipts_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_send_on_enter_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_set_sidebar_width_impl(port, ptr, rust_vec_len, data_len),
+137 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__user__User_global_unread_messages_count_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__user__User_load_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__user__User_load_client_records_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__user__User_load_default_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__user__User_new_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__user__User_prepare_for_background_impl(port, ptr, rust_vec_len, data_len),
+146 => wire__crate__api__user__User_trigger_timed_task_impl(port, ptr, rust_vec_len, data_len),
+147 => wire__crate__api__user__User_update_push_token_impl(port, ptr, rust_vec_len, data_len),
+148 => wire__crate__api__user__User_user_debug_info_impl(port, ptr, rust_vec_len, data_len),
+150 => wire__crate__api__users_cubit__UsersCubitBase_close_impl(port, ptr, rust_vec_len, data_len),
+154 => wire__crate__api__users_cubit__UsersCubitBase_stream_impl(port, ptr, rust_vec_len, data_len),
+159 => wire__crate__api__chat_details_cubit__chat_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+160 => wire__crate__api__invitation_code__check_invitation_code_impl(port, ptr, rust_vec_len, data_len),
+161 => wire__crate__api__logging__clear_app_logs_impl(port, ptr, rust_vec_len, data_len),
+162 => wire__crate__api__logging__clear_background_logs_impl(port, ptr, rust_vec_len, data_len),
+163 => wire__crate__api__registration__create_admission_session_impl(port, ptr, rust_vec_len, data_len),
+164 => wire__crate__api__logging__create_log_stream_impl(port, ptr, rust_vec_len, data_len),
+165 => wire__crate__api__utils__delete_client_database_impl(port, ptr, rust_vec_len, data_len),
+166 => wire__crate__api__utils__delete_databases_impl(port, ptr, rust_vec_len, data_len),
+167 => wire__crate__api__registration__get_registration_info_impl(port, ptr, rust_vec_len, data_len),
+170 => wire__crate__api__invitation_codes_cubit__invitation_codes_state_default_impl(port, ptr, rust_vec_len, data_len),
+171 => wire__crate__api__utils__is_image_file_impl(port, ptr, rust_vec_len, data_len),
+172 => wire__crate__api__linked_devices_cubit__linked_devices_state_default_impl(port, ptr, rust_vec_len, data_len),
+173 => wire__crate__api__user_settings_cubit__load_user_settings_impl(port, ptr, rust_vec_len, data_len),
+174 => wire__crate__api__member_details_cubit__member_details_state_default_impl(port, ptr, rust_vec_len, data_len),
+175 => wire__crate__api__markdown__message_content_error_impl(port, ptr, rust_vec_len, data_len),
+176 => wire__crate__api__markdown__message_content_parse_markdown_impl(port, ptr, rust_vec_len, data_len),
+178 => wire__crate__api__message_list_cubit__message_list_state_default_impl(port, ptr, rust_vec_len, data_len),
+179 => wire__crate__api__multi_device__multi_device_link_client_impl(port, ptr, rust_vec_len, data_len),
+180 => wire__crate__api__multi_device__multi_device_provision_client_impl(port, ptr, rust_vec_len, data_len),
+181 => wire__crate__api__notification_context__notification_policy_default_impl(port, ptr, rust_vec_len, data_len),
+182 => wire__crate__api__logging__read_app_logs_impl(port, ptr, rust_vec_len, data_len),
+183 => wire__crate__api__logging__read_background_logs_impl(port, ptr, rust_vec_len, data_len),
+184 => wire__crate__api__utils__read_clipboard_file_paths_impl(port, ptr, rust_vec_len, data_len),
+185 => wire__crate__api__utils__read_clipboard_image_impl(port, ptr, rust_vec_len, data_len),
+186 => wire__crate__api__share_cubit__share_state_default_impl(port, ptr, rust_vec_len, data_len),
+187 => wire__crate__api__logging__tar_logs_impl(port, ptr, rust_vec_len, data_len),
+188 => wire__crate__api__share_cubit__ui_share_send_status_default_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -13545,48 +13573,48 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        135 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
+        136 => wire__crate__api__user_settings_cubit__UserSettingsCubitBase_state_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        137 => wire__crate__api__user__User_client_record_id_impl(ptr, rust_vec_len, data_len),
-        144 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
+        138 => wire__crate__api__user__User_client_record_id_impl(ptr, rust_vec_len, data_len),
+        145 => wire__crate__api__user__User_signal_pending_store_notifications_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        148 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
-        150 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
+        149 => wire__crate__api__user__User_user_id_impl(ptr, rust_vec_len, data_len),
+        151 => wire__crate__api__users_cubit__UsersCubitBase_is_closed_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        151 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
-        152 => {
+        152 => wire__crate__api__users_cubit__UsersCubitBase_new_impl(ptr, rust_vec_len, data_len),
+        153 => {
             wire__crate__api__users_cubit__UsersCubitBase_state_impl(ptr, rust_vec_len, data_len)
         }
-        154 => {
+        155 => {
             wire__crate__api__users_cubit__UsersState_display_name_impl(ptr, rust_vec_len, data_len)
         }
-        155 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
-        156 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
+        156 => wire__crate__api__users_cubit__UsersState_profile_impl(ptr, rust_vec_len, data_len),
+        157 => wire__crate__api__users_cubit__UsersState_profile_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        157 => wire__crate__api__utils__app_version_impl(ptr, rust_vec_len, data_len),
-        167 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
-        168 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
-        176 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
+        158 => wire__crate__api__utils__app_version_impl(ptr, rust_vec_len, data_len),
+        168 => wire__crate__api__types__image_data_compute_hash_impl(ptr, rust_vec_len, data_len),
+        169 => wire__crate__api__logging__init_rust_logging_impl(ptr, rust_vec_len, data_len),
+        177 => wire__crate__api__markdown__message_content_parse_markdown_raw_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        188 => {
+        189 => {
             wire__crate__api__types__ui_username_validation_error_impl(ptr, rust_vec_len, data_len)
         }
-        189 => wire__crate__api__username_suggestions__username_from_display_impl(
+        190 => wire__crate__api__username_suggestions__username_from_display_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -16396,6 +16424,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::user_settings_cubit::UserSett
             self.interface_scale.into_into_dart().into_dart(),
             self.sidebar_width.into_into_dart().into_dart(),
             self.send_on_enter.into_into_dart().into_dart(),
+            self.limit_animated_images_loops
+                .into_into_dart()
+                .into_dart(),
             self.read_receipts.into_into_dart().into_dart(),
             self.developer_mode.into_into_dart().into_dart(),
             self.experimental_features.into_into_dart().into_dart(),
@@ -19548,6 +19579,7 @@ impl SseEncode for crate::api::user_settings_cubit::UserSettings {
         <Option<f64>>::sse_encode(self.interface_scale, serializer);
         <f64>::sse_encode(self.sidebar_width, serializer);
         <bool>::sse_encode(self.send_on_enter, serializer);
+        <bool>::sse_encode(self.limit_animated_images_loops, serializer);
         <bool>::sse_encode(self.read_receipts, serializer);
         <bool>::sse_encode(self.developer_mode, serializer);
         <bool>::sse_encode(self.experimental_features, serializer);


### PR DESCRIPTION
- The toggle can be found in the You > Preferences screen
- When off, animated images can be paused by tapping on the picture
- When on, animated images stop after 3 loops