### PR TITLE
fix(CI): pass enviroment variables in CI to build.dart

### DIFF
--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -52,9 +52,6 @@ outputs:
   build-number:
     description: "Build number derived from the workflow run number"
     value: ${{ steps.build-number.outputs.value }}
-  build-name:
-    description: "App version, as committed in app/pubspec.yaml"
-    value: ${{ steps.build-name.outputs.value }}
 runs:
   using: composite
   steps:
@@ -71,11 +68,6 @@ runs:
       id: build-number
       shell: bash
       run: echo "value=$(bash scripts/build-number.sh)" >> $GITHUB_OUTPUT
-
-    - name: Compute build name
-      id: build-name
-      shell: bash
-      run: echo "value=$(bash scripts/build-name.sh)" >> $GITHUB_OUTPUT
 
     # Forces apiclient's build script to collect fresh git metadata for this
     # commit and bakes the store build number into it (see apiclient/build.rs)
@@ -223,3 +215,23 @@ runs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -yqq lld ninja-build libgtk-3-dev
+
+    # The Flutter native-assets hook runs with an allowlisted environment, so
+    # the variables set above never reach `cargo build` for the app. Forward
+    # them through the hook config instead (see app/hook/build.dart).
+    - if: inputs.flutter == 'true'
+      name: Configure the Rust build hook
+      shell: bash
+      run: |
+        mkdir -p app/.dart_tool
+        jq -n \
+          --arg build_number "$AIR_BUILD_NUMBER" \
+          --arg refresh "$AIR_REFRESH_BUILD_METADATA" \
+          --arg rustc_wrapper "${RUSTC_WRAPPER:-}" \
+          '{cargo_env: ({
+              AIR_BUILD_NUMBER: $build_number,
+              AIR_REFRESH_BUILD_METADATA: $refresh,
+              RUSTC_WRAPPER: $rustc_wrapper
+            } | with_entries(select(.value != "")))}' \
+          > app/.dart_tool/air_hook_config.json
+        cat app/.dart_tool/air_hook_config.json

--- a/.github/workflows/app-pr-android.yml
+++ b/.github/workflows/app-pr-android.yml
@@ -22,7 +22,6 @@ on:
       - "app/pubspec.lock"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - "scripts/build-name.sh"
       - "scripts/build-number.sh"
       - ".github/workflows/android.yml"
       - ".github/workflows/app-pr-android.yml"

--- a/.github/workflows/app-pr-ios.yml
+++ b/.github/workflows/app-pr-ios.yml
@@ -23,7 +23,6 @@ on:
       - "app/pubspec.lock"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - "scripts/build-name.sh"
       - "scripts/build-number.sh"
       - ".github/workflows/ios.yml"
       - ".github/workflows/app-pr-ios.yml"

--- a/.github/workflows/app-pr-macos.yml
+++ b/.github/workflows/app-pr-macos.yml
@@ -23,7 +23,6 @@ on:
       - "app/pubspec.lock"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - "scripts/build-name.sh"
       - "scripts/build-number.sh"
       - ".github/workflows/macos.yml"
       - ".github/workflows/app-pr-macos.yml"

--- a/.github/workflows/app-pr-windows.yml
+++ b/.github/workflows/app-pr-windows.yml
@@ -21,7 +21,6 @@ on:
       - "app/pubspec.lock"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - "scripts/build-name.sh"
       - "scripts/build-number.sh"
       - ".github/workflows/windows.yml"
       - ".github/workflows/app-pr-windows.yml"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build app
         working-directory: app
-        run: flutter build linux -v --flavor ${{ env.APP_FLAVOR }} --build-number=${{ steps.setup-buildenv.outputs.build-number }} --build-name=${{ steps.setup-buildenv.outputs.build-name }}
+        run: flutter build linux -v --flavor ${{ env.APP_FLAVOR }} --build-number=${{ steps.setup-buildenv.outputs.build-number }}
 
       - name: Upload app bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Windows app
         working-directory: app
-        run: flutter build windows -v --build-number=${{ steps.setup-buildenv.outputs.build-number }} --build-name=${{ steps.setup-buildenv.outputs.build-name }}
+        run: flutter build windows -v --build-number=${{ steps.setup-buildenv.outputs.build-number }}
 
       # Show sccache stats manually (because it fails in the post setup-buildenv step)
       - name: Show sccache stats

--- a/app/fastlane/.gitignore
+++ b/app/fastlane/.gitignore
@@ -1,3 +1,6 @@
 build
 report.xml
 README.md
+# Secrets decoded by the android lane at build time
+release-key.jks
+playstorekey.json

--- a/app/hook/build.dart
+++ b/app/hook/build.dart
@@ -10,18 +10,38 @@ import 'package:code_assets/code_assets.dart';
 // ignore: depend_on_referenced_packages
 import 'package:flutter_rust_bridge_hooks/flutter_rust_bridge_hooks.dart';
 
-// Written by `just test-flutter` to skip rust build.
-// See <https://github.com/dart-lang/native/issues/3237>
+// Optional build configuration, written by `just test-flutter` and by CI
+// (see .github/actions/setup-buildenv). Keys:
+//
+// - `skip_rust_build`: skip the Rust build, which the Flutter tests don't
+//   need. See <https://github.com/dart-lang/native/issues/3237>.
+// - `cargo_env`: extra environment variables for `cargo build`. The hook runs
+//   with an allowlisted environment, so CI variables such as the build number
+//   only reach cargo when forwarded here.
 const _hookConfigPath = '.dart_tool/air_hook_config.json';
 
-bool _skipRustBuild(BuildInput input, BuildOutputBuilder output) {
-  final file = File.fromUri(input.packageRoot.resolve(_hookConfigPath));
-  if (!file.existsSync()) {
-    return false;
+class _HookConfig {
+  const _HookConfig({this.skipRustBuild = false, this.cargoEnv = const {}});
+
+  final bool skipRustBuild;
+  final Map<String, String> cargoEnv;
+
+  static _HookConfig load(BuildInput input, BuildOutputBuilder output) {
+    final file = File.fromUri(input.packageRoot.resolve(_hookConfigPath));
+    if (!file.existsSync()) {
+      return const _HookConfig();
+    }
+    output.dependencies.add(file.uri);
+    final config = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    final cargoEnv = config['cargo_env'] as Map<String, Object?>? ?? const {};
+    return _HookConfig(
+      skipRustBuild: config['skip_rust_build'] == true,
+      cargoEnv: {
+        for (final MapEntry(:key, :value) in cargoEnv.entries)
+          key: value as String,
+      },
+    );
   }
-  output.dependencies.add(file.uri);
-  final config = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
-  return config['skip_rust_build'] == true;
 }
 
 // The native-assets hook protocol does not carry the Flutter build mode
@@ -35,7 +55,8 @@ FlutterRustBridgeBuildMode _rustBuildMode({required bool linkingEnabled}) =>
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
-    if (_skipRustBuild(input, output)) {
+    final config = _HookConfig.load(input, output);
+    if (config.skipRustBuild) {
       return;
     }
     await FlutterRustBridgeNativeAssetsBuilder(
@@ -58,6 +79,7 @@ void main(List<String> args) async {
             input.config.code.targetOS == OS.iOS)
           'IPHONEOS_DEPLOYMENT_TARGET':
               '${input.config.code.iOS.targetVersion}.0',
+        ...config.cargoEnv,
       },
     ).run(input: input, output: output);
   });


### PR DESCRIPTION
Dart's native assets build runs in allowlisted environment, and variables as RUSTC_WRAPPER, AIR_BUILD_NUMBER, AIR_REFRESH_BUILD_METADATA were not passed to it. As consequence, builds had "-dev" suffix in their version, and sccache was not used.

Additionally, remove invocations of build-name.sh which was deleted.